### PR TITLE
Changed naked except statements to catch only subclasses of Exception

### DIFF
--- a/jinja2/__init__.py
+++ b/jinja2/__init__.py
@@ -30,7 +30,7 @@ __docformat__ = 'restructuredtext en'
 try:
     __version__ = __import__('pkg_resources') \
         .get_distribution('Jinja2').version
-except:
+except Exception:
     __version__ = 'unknown'
 
 # high level interface

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1249,7 +1249,7 @@ class CodeGenerator(NodeVisitor):
                     else:
                         const = escape(const)
                 const = finalize(const)
-            except:
+            except Exception:
                 # if something goes wrong here we evaluate the node
                 # at runtime for easier debugging
                 body.append(child)

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -354,7 +354,7 @@ class Environment(object):
             if isinstance(argument, basestring):
                 try:
                     attr = str(argument)
-                except:
+                except Exception:
                     pass
                 else:
                     try:
@@ -886,7 +886,7 @@ class Template(object):
         vars = dict(*args, **kwargs)
         try:
             return concat(self.root_render_func(self.new_context(vars)))
-        except:
+        except Exception:
             exc_info = sys.exc_info()
         return self.environment.handle_exception(exc_info, True)
 
@@ -908,7 +908,7 @@ class Template(object):
         try:
             for event in self.root_render_func(self.new_context(vars)):
                 yield event
-        except:
+        except Exception:
             exc_info = sys.exc_info()
         else:
             return

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -375,7 +375,7 @@ class BinExpr(Expr):
         f = _binop_to_func[self.operator]
         try:
             return f(self.left.as_const(eval_ctx), self.right.as_const(eval_ctx))
-        except:
+        except Exception:
             raise Impossible()
 
 
@@ -390,7 +390,7 @@ class UnaryExpr(Expr):
         f = _uaop_to_func[self.operator]
         try:
             return f(self.node.as_const(eval_ctx))
-        except:
+        except Exception:
             raise Impossible()
 
 
@@ -555,16 +555,16 @@ class Filter(Expr):
         if self.dyn_args is not None:
             try:
                 args.extend(self.dyn_args.as_const(eval_ctx))
-            except:
+            except Exception:
                 raise Impossible()
         if self.dyn_kwargs is not None:
             try:
                 kwargs.update(self.dyn_kwargs.as_const(eval_ctx))
-            except:
+            except Exception:
                 raise Impossible()
         try:
             return filter_(obj, *args, **kwargs)
-        except:
+        except Exception:
             raise Impossible()
 
 
@@ -604,16 +604,16 @@ class Call(Expr):
         if self.dyn_args is not None:
             try:
                 args.extend(self.dyn_args.as_const(eval_ctx))
-            except:
+            except Exception:
                 raise Impossible()
         if self.dyn_kwargs is not None:
             try:
                 kwargs.update(self.dyn_kwargs.as_const(eval_ctx))
-            except:
+            except Exception:
                 raise Impossible()
         try:
             return obj(*args, **kwargs)
-        except:
+        except Exception:
             raise Impossible()
 
 
@@ -628,7 +628,7 @@ class Getitem(Expr):
         try:
             return self.environment.getitem(self.node.as_const(eval_ctx),
                                             self.arg.as_const(eval_ctx))
-        except:
+        except Exception:
             raise Impossible()
 
     def can_assign(self):
@@ -648,7 +648,7 @@ class Getattr(Expr):
             eval_ctx = get_eval_context(self, eval_ctx)
             return self.environment.getattr(self.node.as_const(eval_ctx),
                                             self.attr)
-        except:
+        except Exception:
             raise Impossible()
 
     def can_assign(self):
@@ -695,7 +695,7 @@ class Compare(Expr):
                 new_value = op.expr.as_const(eval_ctx)
                 result = _cmpop_to_func[op.op](value, new_value)
                 value = new_value
-        except:
+        except Exception:
             raise Impossible()
         return result
 

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -212,7 +212,7 @@ class SandboxedEnvironment(Environment):
             if isinstance(argument, basestring):
                 try:
                     attr = str(argument)
-                except:
+                except Exception:
                     pass
                 else:
                     try:

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -53,7 +53,7 @@ except TypeError, _error:
         def concat(gen):
             try:
                 return _concat(list(gen))
-            except:
+            except Exception:
                 # this hack is needed so that the current frame
                 # does not show up in the traceback.
                 exc_type, exc_value, tb = sys.exc_info()


### PR DESCRIPTION
Naked except statements catch subclasses of BaseException which
can occur anywhere (i.e. KeyboardInterrupt).

Unexpected issues can occur when the exception happens during the
loading of a module. The python interpreter doesn't know about a
module's failed load and does not remove it from sys.modules. This
is particularly a problem on AppEngine where DeadlineExceededErrors
can occur anywhere and modules that catch the error cause python to
think the module is loaded but in fact the module load has failed.

See: http://code.google.com/p/googleappengine/issues/detail?id=1409

If any of the changed imports look like they might be problematic please comment.
