### PR TITLE
wordwrap filter should use the newline_sequence defined in current Environment

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -443,8 +443,8 @@ def do_truncate(s, length=255, killwords=False, end='...'):
     result.append(end)
     return u' '.join(result)
 
-
-def do_wordwrap(s, width=79, break_long_words=True):
+@environmentfilter
+def do_wordwrap(environment, s, width=79, break_long_words=True):
     """
     Return a copy of the string passed to the filter wrapped after
     ``79`` characters.  You can override this default using the first
@@ -452,7 +452,7 @@ def do_wordwrap(s, width=79, break_long_words=True):
     split words apart if they are longer than `width`.
     """
     import textwrap
-    return u'\n'.join(textwrap.wrap(s, width=width, expand_tabs=False,
+    return environment.newline_sequence.join(textwrap.wrap(s, width=width, expand_tabs=False,
                                    replace_whitespace=False,
                                    break_long_words=break_long_words))
 


### PR DESCRIPTION
wordwrap filter should use the newline_sequence defined in current Environment object 

(see mitsuhiko/jinja2#29)
