### PR TITLE
ByteCodeCache to support Python 3

### DIFF
--- a/jinja2/bccache.py
+++ b/jinja2/bccache.py
@@ -158,7 +158,7 @@ class BytecodeCache(object):
         if filename is not None:
             filename = '|' + filename
             if isinstance(filename, unicode):
-                key = filename.encode('utf-8')
+                filename = filename.encode('utf-8')
             hash.update(filename)
         return hash.hexdigest()
 


### PR DESCRIPTION
Few things changed for following differences in Python 3:
- Unicode string / byte string problem.
- io.BytesIO should be used instead of StringIO to handle buffered byte stream.
- The 'file' type is gone, but marshal has begun to support arbitrary streams ([from 3.0](http://hg.python.org/cpython/file/4cd9f5e89061/Python/marshal.c#l1135)).
