### PR TITLE
Bugfix for list_templates in PackageLoader

### DIFF
--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -251,8 +251,7 @@ class PackageLoader(BaseLoader):
             for filename in self.provider.resource_listdir(path):
                 fullname = path + '/' + filename
                 if self.provider.resource_isdir(fullname):
-                    for item in _walk(fullname):
-                        results.append(item)
+                    _walk(fullname)
                 else:
                     results.append(fullname[offset:].lstrip('/'))
         _walk(path)


### PR DESCRIPTION
Hi,

First, thanks for Jinja2!

I was investigating pre-compiling my templates in an app that makes use of PackageLoader.  It looks like _walk may have returned a list at some point, but that's no longer the case, so I changed it to just be called recursively.

Let me know if you'd like me to write a test or anything.

-Bryan
