### PR TITLE
Fix for groupby on tuple lists

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -10,6 +10,7 @@
 """
 import re
 import math
+import collections
 from random import choice
 from operator import itemgetter
 from itertools import imap, groupby
@@ -53,7 +54,7 @@ def make_attrgetter(environment, attribute):
     passed object with the rules of the environment.  Dots are allowed
     to access attributes of attributes.
     """
-    if '.' not in attribute:
+    if not (isinstance(attribute, collections.Iterable) and '.'  in attribute):
         return lambda x: environment.getitem(x, attribute)
     attribute = attribute.split('.')
     def attrgetter(item):


### PR DESCRIPTION
Before this commit: https://github.com/mitsuhiko/jinja2/commit/9573b663d5327bcb644f6776082c832ec0f49b44#jinja2/filters.py
groupby worked on tuple list by specifying tuple index in groupby :

```
[("a", "foo"), ("b", "bar"), ("a", "baz")] | groupby(0)
```

Not trying to check '.' presence in non iterable fixes this problem
