### PR TITLE
"NameError: global name 'code' is not defined" if using byte code cache on Python 2.7.1.

### DIFF
--- a/jinja2/bccache.py
+++ b/jinja2/bccache.py
@@ -98,7 +98,7 @@ class Bucket(object):
             raise TypeError('can\'t write empty bucket')
         f.write(bc_magic)
         pickle.dump(self.checksum, f, 2)
-        marshal_dump(code, f)
+        marshal_dump(self.code, f)
 
     def bytecode_from_string(self, string):
         """Load bytecode from a string."""


### PR DESCRIPTION
A typo in recent commit is causing this bug. Patch attached.
