### PR TITLE
Typo fixes in documentation

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1295,7 +1295,7 @@ Loop Controls
 
 If the application enables the :ref:`loopcontrols-extension` it's possible to
 use `break` and `continue` in loops.  When `break` is reached, the loop is
-terminated;  if `continue` is reached the processing is stopped and continues
+terminated;  if `continue` is reached, the processing is stopped and continues
 with the next iteration.
 
 Here a loop that skips every second item::


### PR DESCRIPTION
I've fixed a couple of typos in templates.rst in the docs.
