### PR TITLE
use getattr in jinja2.filters.make_attrgetter instead of getitem

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -54,11 +54,11 @@ def make_attrgetter(environment, attribute):
     to access attributes of attributes.
     """
     if not isinstance(attribute, basestring) or '.' not in attribute:
-        return lambda x: environment.getitem(x, attribute)
+        return lambda x: environment.getattr(x, attribute)
     attribute = attribute.split('.')
     def attrgetter(item):
         for part in attribute:
-            item = environment.getitem(item, part)
+            item = environment.getattr(item, part)
         return item
     return attrgetter
 


### PR DESCRIPTION
IMO, jinja2.filters.make_attrgetter should use environment.getattr instead of environment.getitem, which tries Python's getattr first and then falls back to attempting to treat the object as a dict/list.

For context, we ran into an issue when trying to use the sort filter's attribute argument on a list of security-proxied objects; trying to use index notation on them raises an exception that is not caught in environment.getitem.

I've tested this change minor change locally and all of the tests pass.
