### PR TITLE
Allow choice of newline in wordwrap filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.so
 docs/_build
 *.pyc
+*~
 *.pyo
 *.egg-info
 build


### PR DESCRIPTION
I had a situation where I needed to escape the backslash in my newline using wordwrap, so I just added in the general ability to use any string to represent the newline. I thought others might benefit from this being available. I've changed the docstring accordingly, so everything should be ready to go.
