### PR TITLE
Implemented  flag to extract_babel method to properly handle the behavior

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@ Version 2.7
   separately in order to work in combination with module loaders as
   advertised.
 - Fixed filesizeformat.
+- Implemented `fail_silently` flag to extract_babel method
+  to properly handle the behavior if errors occur during extracting
+  translations.
 
 Version 2.6
 -----------

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -552,6 +552,10 @@ def babel_extract(fileobj, keywords, comment_tags, options):
        The `newstyle_gettext` flag can be set to `True` to enable newstyle
        gettext calls.
 
+    .. versionchanged:: 2.7
+       You can provide a `fail_silently` flag to define the behavior if
+       errors occur during the parsing process.  Defaults to `True`
+
     :param fileobj: the file-like object the messages should be extracted from
     :param keywords: a list of keywords (i.e. function names) that should be
                      recognized as translation functions
@@ -595,9 +599,12 @@ def babel_extract(fileobj, keywords, comment_tags, options):
     try:
         node = environment.parse(source)
         tokens = list(environment.lex(environment.preprocess(source)))
-    except TemplateSyntaxError, e:
+    except TemplateSyntaxError, exc:
         # skip templates with syntax errors
-        return
+        if options.get('fail_silently', True):
+            return
+        else:
+            raise exc
 
     finder = _CommentFinder(tokens, comment_tags)
     for lineno, func, message in extract_from_ast(node, keywords):


### PR DESCRIPTION
Implemented  flag to extract_babel method to properly handle the behavior if errors occur during extracting translations.

This really bugged me when I tried to debug some weird behavior of the extractor to find why it was not working as expected.
