### PR TITLE
Specify what whitespace is.

### DIFF
--- a/jinja2/defaults.py
+++ b/jinja2/defaults.py
@@ -22,6 +22,7 @@ LINE_STATEMENT_PREFIX = None
 LINE_COMMENT_PREFIX = None
 TRIM_BLOCKS = False
 NEWLINE_SEQUENCE = '\n'
+WHITESPACE_RE = r'\s'
 
 
 # default filters, tests and namespace

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -10,6 +10,7 @@
 """
 import os
 import sys
+import re
 from jinja2 import nodes
 from jinja2.defaults import *
 from jinja2.lexer import get_lexer, TokenStream
@@ -87,6 +88,8 @@ def _environment_sanity_check(environment):
            'start strings must be different'
     assert environment.newline_sequence in ('\r', '\r\n', '\n'), \
            'newline_sequence set to unknown line ending string.'
+    assert re.compile(environment.whitespace_re, re.U) is not None, \
+           'whitespace_re is not a valid regular expression.'
     return environment
 
 
@@ -139,6 +142,11 @@ class Environment(object):
             ``'\n'`` or ``'\r\n'``.  The default is ``'\n'`` which is a
             useful default for Linux and OS X systems as well as web
             applications.
+
+        `whitespace_re`
+            An regular expression to match whitespace. Defaults to ``'\s'``.
+            Because the python ``'\s'`` matches also ``'\n'``, you may choose a
+            different set of whitespace characters.
 
         `extensions`
             List of Jinja extensions to use.  This can either be import paths
@@ -225,6 +233,7 @@ class Environment(object):
                  line_comment_prefix=LINE_COMMENT_PREFIX,
                  trim_blocks=TRIM_BLOCKS,
                  newline_sequence=NEWLINE_SEQUENCE,
+                 whitespace_re=WHITESPACE_RE,
                  extensions=(),
                  optimized=True,
                  undefined=Undefined,
@@ -256,6 +265,7 @@ class Environment(object):
         self.line_comment_prefix = line_comment_prefix
         self.trim_blocks = trim_blocks
         self.newline_sequence = newline_sequence
+        self.whitespace_re = whitespace_re
 
         # runtime information
         self.undefined = undefined
@@ -817,6 +827,7 @@ class Template(object):
                 line_comment_prefix=LINE_COMMENT_PREFIX,
                 trim_blocks=TRIM_BLOCKS,
                 newline_sequence=NEWLINE_SEQUENCE,
+                whitespace_re=WHITESPACE_RE,
                 extensions=(),
                 optimized=True,
                 undefined=Undefined,
@@ -826,8 +837,8 @@ class Template(object):
             block_start_string, block_end_string, variable_start_string,
             variable_end_string, comment_start_string, comment_end_string,
             line_statement_prefix, line_comment_prefix, trim_blocks,
-            newline_sequence, frozenset(extensions), optimized, undefined,
-            finalize, autoescape, None, 0, False, None)
+            newline_sequence, whitespace_re, frozenset(extensions), optimized,
+            undefined, finalize, autoescape, None, 0, False, None)
         return env.from_string(source, template_class=cls)
 
     @classmethod

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -583,7 +583,8 @@ def babel_extract(fileobj, keywords, comment_tags, options):
         line_statement_prefix=options.get('line_statement_prefix') or LINE_STATEMENT_PREFIX,
         line_comment_prefix=options.get('line_comment_prefix') or LINE_COMMENT_PREFIX,
         trim_blocks=getbool(options, 'trim_blocks', TRIM_BLOCKS),
-        newline_sequence=NEWLINE_SEQUENCE, extensions=frozenset(extensions),
+        newline_sequence=NEWLINE_SEQUENCE, whitespace_re=WHITESPACE_RE,
+        extensions=frozenset(extensions),
         cache_size=0,
         auto_reload=False
     )


### PR DESCRIPTION
I had a hard time to get the desired result out of my template into a form which fits our codingstyle. I use jinja to generate C code. But in C empty lines should be preserved as much as possible to increase readebility. And while I'm not only generate C code but C header files which will be installed, these empty lines are of high value for our project. Unfortunately, the \s in pythons re engine also matches \n, thus any jinja token also eats up its leading empty lines.

This pull request includes my current solution to this problem. It lets the user specify what whitespace is. In my project I just use [ \t].
