### PR TITLE
Changed three to four in nodes.py at line no 107

### DIFF
--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -104,7 +104,7 @@ def get_eval_context(node, ctx):
 
 class Node(object):
     """Baseclass for all Jinja2 nodes.  There are a number of nodes available
-    of different types.  There are three major types:
+    of different types.  There are four major types:
 
     -   :class:`Stmt`: statements
     -   :class:`Expr`: expressions


### PR DESCRIPTION
Since four major types were listed  
    -   :class:`Stmt`: statements
    -   :class:`Expr`: expressions
    -   :class:`Helper`: helper nodes
    -   :class:`Template`: the outermost wrapper node

but it was mentioned as three. 
