### PR TITLE
Support included blocks override

### DIFF
--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -950,9 +950,16 @@ class CodeGenerator(NodeVisitor):
             self.indent()
 
         if node.with_context:
+            self.writeline('include_context = template.new_context('
+                           'context.parent, True, locals())')
+            self.writeline('for name, context_blocks in context.'
+                           'blocks.%s():' % dict_item_iter)
+            self.indent()
+            self.writeline('include_context.blocks.setdefault('
+                           'name, [])[0:0] = context_blocks')
+            self.outdent()
             self.writeline('for event in template.root_render_func('
-                           'template.new_context(context.parent, True, '
-                           'locals())):')
+                           'include_context):')
         else:
             self.writeline('for event in template.module._body_stream:')
 

--- a/jinja2/testsuite/imports.py
+++ b/jinja2/testsuite/imports.py
@@ -121,6 +121,22 @@ class IncludesTestCase(JinjaTestCase):
         )))
         assert env.get_template("main").render() == "123"
 
+    def test_included_block_override(self):
+        env = Environment(loader=DictLoader(dict(
+            main="{% extends 'base' %}{% block b %}1337{% endblock %}",
+            base="{% include 'inc' %}",
+            inc="{% block b %}42{% endblock %}"
+        )))
+        assert env.get_template("main").render() == "1337"
+
+    def test_included_block_override_with_super(self):
+        env = Environment(loader=DictLoader(dict(
+            main="{% extends 'base' %}{% block b %}1337|{{ super() }}{% endblock %}",
+            base="{% include 'inc' %}",
+            inc="{% block b %}42{% endblock %}"
+        )))
+        assert env.get_template("main").render() == "1337|42"
+
     def test_unoptimized_scopes(self):
         t = test_env.from_string("""
             {% macro outer(o) %}


### PR DESCRIPTION
This commit fix inheritance with included blocks.
Consider these templates:

**A.jinja2**

```
I am A
{% include 'I.jinja2' %}
```

**I.jinja2**

```
Who are you ?
{% block whoami %}
    I am I
{% endblock %}
```

**B.jinja2**

```
{% extends 'A.jinja2' %}
{% block whoami %}
    I am B
{% endblock %}
```

As of now, rendering **B.jinja2** would output:

```
I am A
Who are you ?
I am I
```

This patch allow B to override I block, the output will be instead:

```
I am A
Who are you ?
I am B
```
