### PR TITLE
Fix to #93, this time respecting whitespace

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -176,7 +176,12 @@ def do_title(s):
     """Return a titlecased version of the value. I.e. words will start with
     uppercase letters, all remaining characters are lowercase.
     """
-    return soft_unicode(s).title()
+    rv = []
+    for item in re.compile(r'([-\s]+)(?u)').split(s):
+        if not item:
+            continue
+        rv.append(item[0].upper() + item[1:])
+    return ''.join(rv)
 
 
 def do_dictsort(value, case_sensitive=False, by='key'):

--- a/jinja2/testsuite/filters.py
+++ b/jinja2/testsuite/filters.py
@@ -193,6 +193,16 @@ class FilterTestCase(JinjaTestCase):
     def test_title(self):
         tmpl = env.from_string('''{{ "foo bar"|title }}''')
         assert tmpl.render() == "Foo Bar"
+        tmpl = env.from_string('''{{ "foo's bar"|title }}''')
+        assert tmpl.render() == "Foo's Bar"
+        tmpl = env.from_string('''{{ "foo   bar"|title }}''')
+        assert tmpl.render() == "Foo   Bar"
+        tmpl = env.from_string('''{{ "f bar f"|title }}''')
+        assert tmpl.render() == "F Bar F"
+        tmpl = env.from_string('''{{ "foo-bar"|title }}''')
+        assert tmpl.render() == "Foo-Bar"
+        tmpl = env.from_string('''{{ "foo\tbar"|title }}''')
+        assert tmpl.render() == "Foo\tBar"
 
     def test_truncate(self):
         tmpl = env.from_string(


### PR DESCRIPTION
Rejigger of title split to respect whitespace, also capitalize follow-on
hyphenated words.
