### PR TITLE
There is no need to initialize Environment#bytecode_cache twice

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -270,7 +270,6 @@ class Environment(object):
 
         # set the loader provided
         self.loader = loader
-        self.bytecode_cache = None
         self.cache = create_cache(cache_size)
         self.bytecode_cache = bytecode_cache
         self.auto_reload = auto_reload


### PR DESCRIPTION
In the **init** method of Environment class, self.bytecode is initialized twice. The first initialization does nothing.

```
self.bytecode_cache = None
self.cache = create_cache(cache_size)
self.bytecode_cache = bytecode_cache
```
