### PR TITLE
Add a Template.render_blocks method

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -893,6 +893,22 @@ class Template(object):
             exc_info = sys.exc_info()
         return self.environment.handle_exception(exc_info, True)
 
+    def render_blocks(self, *args, **kwargs):
+        """
+        This method renders each block of the template, and returns a dict where
+        the keys are the block names, and the values are the corresponding
+        rendered content.
+        """
+        context = self.new_context(dict(*args, **kwargs))
+        try:
+            blocks = {}
+            for name, func in self.blocks.iteritems():
+                blocks[name] = concat(func(context))
+            return blocks
+        except Exception:
+            exc_info = sys.exc_info()
+        return self.environment.handle_exception(exc_info, True)
+
     def stream(self, *args, **kwargs):
         """Works exactly like :meth:`generate` but returns a
         :class:`TemplateStream`.


### PR DESCRIPTION
I wrote a method to render each block of a template, and return them all in a dict. Would you consider merging this in if it had proper tests/docs?
