### PR TITLE
Prevent default filter from throwing UndefinedError

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -276,7 +276,7 @@ def do_default(value, default_value=u'', boolean=False):
 
         {{ ''|default('the string was empty', true) }}
     """
-    if (boolean and not value) or isinstance(value, Undefined):
+    if isinstance(value, Undefined) or (boolean and not value):
         return default_value
     return value
 

--- a/jinja2/testsuite/api.py
+++ b/jinja2/testsuite/api.py
@@ -214,6 +214,7 @@ class UndefinedTestCase(JinjaTestCase):
         self.assert_equal(env.from_string('{{ missing is not defined }}').render(), 'True')
         self.assert_raises(UndefinedError, env.from_string('{{ foo.missing }}').render, foo=42)
         self.assert_raises(UndefinedError, env.from_string('{{ not missing }}').render)
+        self.assert_equal(env.from_string('{{ missing|default("default", true) }}').render(), 'default')
 
     def test_indexing_gives_undefined(self):
         t = Template("{{ var[42].foo }}")


### PR DESCRIPTION
The default filter currently throws an UndefinedError when environment is using StrictUndefined mode and using the boolean flag for default filter. example:
    `{{ something|default(somethingelse, true) }}`
Will throw an UndefinedError when `something` is undefined.
This pull request fixes that and adds a unit test exemplifying the problem.
