### PR TITLE
enhancement to urlize:  support target attribute for links

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -403,19 +403,24 @@ def do_pprint(value, verbose=False):
 
 
 @evalcontextfilter
-def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False):
+def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False, target=None):
     """Converts URLs in plain text into clickable links.
 
     If you pass the filter an additional integer it will shorten the urls
     to that number. Also a third argument exists that makes the urls
-    "nofollow":
+    "nofollow".  The 4th argument, target, may be used to specify the target for
+    the clickable links:
 
     .. sourcecode:: jinja
 
         {{ mytext|urlize(40, true) }}
             links are shortened to 40 chars and defined with rel="nofollow"
+
+        {{ mytext|urlize(40, true, '_blank') }}
+            links are shortened to 40 chars and defined with rel="nofollow" and target="_blank"
+
     """
-    rv = urlize(value, trim_url_limit, nofollow)
+    rv = urlize(value, trim_url_limit, nofollow, target)
     if eval_ctx.autoescape:
         rv = Markup(rv)
     return rv

--- a/jinja2/testsuite/filters.py
+++ b/jinja2/testsuite/filters.py
@@ -223,6 +223,16 @@ class FilterTestCase(JinjaTestCase):
         assert tmpl.render() == 'foo <a href="http://www.example.com/">'\
                                 'http://www.example.com/</a> bar'
 
+    def test_urlize_with_target(self):
+        tmpl = env.from_string('{{ "foo http://www.example.com/ bar"|urlize(target="_blank") }}')
+        assert tmpl.render() == 'foo <a href="http://www.example.com/" target="_blank">'\
+                                'http://www.example.com/</a> bar'
+
+    def test_urlize_with_nofollow_and_target(self):
+        tmpl = env.from_string('{{ "foo http://www.example.com/ bar"|urlize(nofollow=True, target="_blank") }}')
+        assert tmpl.render() == 'foo <a href="http://www.example.com/" rel="nofollow" target="_blank">'\
+                                'http://www.example.com/</a> bar'
+
     def test_wordcount(self):
         tmpl = env.from_string('{{ "foo bar baz"|wordcount }}')
         assert tmpl.render() == '3'

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -260,7 +260,7 @@ def pformat(obj, verbose=False):
         return pformat(obj)
 
 
-def urlize(text, trim_url_limit=None, nofollow=False):
+def urlize(text, trim_url_limit=None, nofollow=False, target=None):
     """Converts any URLs in text into clickable links. Works on http://,
     https:// and www. links. Links can have trailing punctuation (periods,
     commas, close-parens) and leading punctuation (opening parens) and
@@ -271,12 +271,16 @@ def urlize(text, trim_url_limit=None, nofollow=False):
 
     If nofollow is True, the URLs in link text will get a rel="nofollow"
     attribute.
+
+    If target is not None, the URLs in link text will get a
+    target attribute with a value equal to target.
     """
     trim_url = lambda x, limit=trim_url_limit: limit is not None \
                          and (x[:limit] + (len(x) >=limit and '...'
                          or '')) or x
     words = _word_split_re.split(unicode(escape(text)))
     nofollow_attr = nofollow and ' rel="nofollow"' or ''
+    target_attr = target and ' target="%s"' % target or ''
     for i, word in enumerate(words):
         match = _punctuation_re.match(word)
         if match:
@@ -288,14 +292,15 @@ def urlize(text, trim_url_limit=None, nofollow=False):
                 middle[0] in _letters + _digits and (
                     middle.endswith('.org') or
                     middle.endswith('.net') or
-                    middle.endswith('.com')
+                    middle.endswith('.com') or
+                    middle.endswith('.edu')
                 )):
-                middle = '<a href="http://%s"%s>%s</a>' % (middle,
-                    nofollow_attr, trim_url(middle))
+                middle = '<a href="http://%s"%s%s>%s</a>' % (middle,
+                    nofollow_attr, target_attr, trim_url(middle))
             if middle.startswith('http://') or \
                middle.startswith('https://'):
-                middle = '<a href="%s"%s>%s</a>' % (middle,
-                    nofollow_attr, trim_url(middle))
+                middle = '<a href="%s"%s%s>%s</a>' % (middle,
+                    nofollow_attr, target_attr, trim_url(middle))
             if '@' in middle and not middle.startswith('www.') and \
                not ':' in middle and _simple_email_re.match(middle):
                 middle = '<a href="mailto:%s">%s</a>' % (middle, middle)


### PR DESCRIPTION
I recently needed to include the target attribute on links produced by the urlize filter.
Thought I'd send these changes back in case others need links to open in a new window/tab.
