### PR TITLE
Fix the UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)

### DIFF
--- a/jinja2/_markupsafe/_native.py
+++ b/jinja2/_markupsafe/_native.py
@@ -40,6 +40,8 @@ def soft_unicode(s):
     """Make a string unicode if it isn't already.  That way a markup
     string is not converted back to unicode.
     """
+    if isinstance(s, str):
+        s = s.decode('utf-8')
     if not isinstance(s, unicode):
         s = unicode(s)
     return s


### PR DESCRIPTION
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)

when rendering template within non-ASCII strings (non-unicodes)
