### PR TITLE
Update jinja2/runtime.py to handle IronPython unicode strings issue.

### DIFF
--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -15,6 +15,7 @@ from jinja2.utils import Markup, partial, soft_unicode, escape, missing, \
 from jinja2.exceptions import UndefinedError, TemplateRuntimeError, \
      TemplateNotFound
 
+import os
 
 # these variables are exported to the template runtime
 __all__ = ['LoopContext', 'TemplateReference', 'Macro', 'Markup',
@@ -25,7 +26,11 @@ __all__ = ['LoopContext', 'TemplateReference', 'Macro', 'Markup',
 #: the name of the function that is used to convert something into
 #: a string.  2to3 will adopt that automatically and the generated
 #: code can take advantage of it.
-to_string = unicode
+to_string = None
+if not 'IronPython' in py_version:  
+    to_string = unicode 
+else:    
+    to_string = to_string = lambda x: unicode(x)
 
 #: the identity function.  Useful for certain things in the environment
 identity = lambda x: x


### PR DESCRIPTION
IronPython fails to correctly reference unicode strings containing non-ASCII characters.

This covers [issue #146]( https://github.com/mitsuhiko/jinja2/issues/146)
