### PR TITLE
Update to jinja2/runtime.py to handle IronPython unicode strings issue.

### DIFF
--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -15,8 +15,6 @@ from jinja2.utils import Markup, partial, soft_unicode, escape, missing, \
 from jinja2.exceptions import UndefinedError, TemplateRuntimeError, \
      TemplateNotFound
 
-import os
-
 # these variables are exported to the template runtime
 __all__ = ['LoopContext', 'TemplateReference', 'Macro', 'Markup',
            'TemplateRuntimeError', 'missing', 'concat', 'escape',
@@ -26,11 +24,7 @@ __all__ = ['LoopContext', 'TemplateReference', 'Macro', 'Markup',
 #: the name of the function that is used to convert something into
 #: a string.  2to3 will adopt that automatically and the generated
 #: code can take advantage of it.
-to_string = None
-if not 'IronPython' in sys.version:  
-    to_string = unicode 
-else:    
-    to_string = to_string = lambda x: unicode(x)
+to_string = unicode if sys.platform != 'cli' else lambda x: unicode(x)
 
 #: the identity function.  Useful for certain things in the environment
 identity = lambda x: x


### PR DESCRIPTION
IronPython fails to correctly reference unicode strings containing non-ASCII characters.  This covers issue #146.

Please dismiss the earlier request.  Committed a test copy instead of the working copy earlier.
