### PR TITLE
Add NPR to organizations who use Jinja2

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -61,6 +61,7 @@ Who uses it?
 -   `Mozilla <http://www.mozilla.org/>`_
 -   `SourceForge <http://www.sourceforge.net/>`_
 -   `Instagram <http://instagr.am/>`_
+-   `NPR <http://www.npr.org/>`_
 -   … and many more
 
 


### PR DESCRIPTION
The NPR News Apps team recently blogged about their tools for app development and said they use Jinja2 in their app template.

Links: 
- http://github.com/nprapps/app-template
- http://blog.apps.npr.org/2013/02/14/app-template-redux.html
