### PR TITLE
Fixed an issue about urlize function

### DIFF
--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -284,6 +284,7 @@ def urlize(text, trim_url_limit=None, nofollow=False):
             if middle.startswith('www.') or (
                 '@' not in middle and
                 not middle.startswith('http://') and
+                not middle.startswith('https://') and
                 len(middle) > 0 and
                 middle[0] in _letters + _digits and (
                     middle.endswith('.org') or


### PR DESCRIPTION
When URL startswith 'https://', the return is wrong.
Before:

```
>>> urlize('https://github.com/')
u'<a href="http://https://github.com/">https://github.com/</a>'
```

After:

```
>>> urlize('https://github.com/')
u'<a href="https://github.com/">https://github.com/</a>'
```
