### PR TITLE
Added testcase for bug #196

### DIFF
--- a/jinja2/testsuite/regression.py
+++ b/jinja2/testsuite/regression.py
@@ -255,6 +255,13 @@ class BugTestCase(JinjaTestCase):
         output = tpl1.render(g = dict(a = 'TEST'))
         
         self.assert_equal(expected, output)
+        
+        tpl2 = Template("""
+        {{g.a}}
+        """)
+        expected = '\n        TEST\n        '
+        output = tpl2.render(g = dict(a = 'TEST'))
+        self.assert_equal(expected, output)
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
This adds a regression testcase for bug #196 where it is claimed that `{{-g.a}}` will ignore the whitespace stripping if 'g' is a dictionary.
