### PR TITLE
Prevent line statements eating newlines (fixes #52)

### DIFF
--- a/jinja2/lexer.py
+++ b/jinja2/lexer.py
@@ -197,7 +197,7 @@ def compile_rules(environment):
 
     if environment.line_statement_prefix is not None:
         rules.append((len(environment.line_statement_prefix), 'linestatement',
-                      r'^\s*' + e(environment.line_statement_prefix)))
+                      r'^[ \t\v]*' + e(environment.line_statement_prefix)))
     if environment.line_comment_prefix is not None:
         rules.append((len(environment.line_comment_prefix), 'linecomment',
                       r'(?:^|(?<=\S))[^\S\r\n]*' +


### PR DESCRIPTION
This is just a copy of @gavento's fix in #52.
