### PR TITLE
`title` filter should accept objects.

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -183,7 +183,7 @@ def do_title(s):
     uppercase letters, all remaining characters are lowercase.
     """
     rv = []
-    for item in re.compile(r'([-\s]+)(?u)').split(s):
+    for item in re.compile(r'([-\s]+)(?u)').split(soft_unicode(s)):
         if not item:
             continue
         rv.append(item[0].upper() + item[1:])

--- a/jinja2/testsuite/filters.py
+++ b/jinja2/testsuite/filters.py
@@ -205,6 +205,14 @@ class FilterTestCase(JinjaTestCase):
         tmpl = env.from_string('''{{ "foo\tbar"|title }}''')
         assert tmpl.render() == "Foo\tBar"
 
+        class Foo:
+            def __str__(self):
+                return 'foo-bar'
+
+        tmpl = env.from_string('''{{ data|title }}''')
+        out = tmpl.render(data=Foo())
+        assert out == 'Foo-Bar'
+
     def test_truncate(self):
         tmpl = env.from_string(
             '{{ data|truncate(15, true, ">>>") }}|'


### PR DESCRIPTION
In Jinja 2.6 it was possible to pass objects to the `title` filter and have them correctly resolved.

This behaviour regressed in 2.7.

This change restores the 2.6 behaviour of casting the passed value to a string using `soft_unicode`.
