### PR TITLE
Simple regexp-substitution filter, using re.sub

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -125,6 +125,16 @@ def do_replace(eval_ctx, s, old, new, count=None):
     return s.replace(soft_unicode(old), soft_unicode(new), count)
 
 
+@evalcontextfilter
+def do_sub(eval_ctx, string, pattern, repl, count=0, flags=0):
+    """Return the string obtained by replacing the leftmost non-overlapping
+    occurrences of pattern in string by the replacement repl. Like Python's
+    ``re.sub``, except that the source string is the filter input (so the
+    first argument is the pattern) and the flag UNICODE is forced on."""
+    return re.sub(unicode(pattern), unicode(repl), unicode(string),
+                  count, flags | re.UNICODE)
+
+
 def do_upper(s):
     """Convert a value to uppercase."""
     return soft_unicode(s).upper()
@@ -936,6 +946,7 @@ def _select_or_reject(args, kwargs, modfunc, lookup_attr):
 FILTERS = {
     'attr':                 do_attr,
     'replace':              do_replace,
+    'sub':                  do_sub,
     'upper':                do_upper,
     'lower':                do_lower,
     'escape':               escape,

--- a/jinja2/testsuite/filters.py
+++ b/jinja2/testsuite/filters.py
@@ -384,6 +384,16 @@ class FilterTestCase(JinjaTestCase):
         tmpl = env.from_string('{{ string|replace("o", ">x<") }}')
         assert tmpl.render(string=Markup('foo')) == 'f&gt;x&lt;&gt;x&lt;'
 
+    def test_sub(self):
+        env = Environment()
+        tmpl = env.from_string('{{ string|sub("(?<!f)o", 42) }}')
+        assert tmpl.render(string='<foo>') == '<fo42>'
+        env = Environment(autoescape=True)
+        tmpl = env.from_string('{{ string|sub("(?<!f)o", 42) }}')
+        assert tmpl.render(string='<foo>') == '&lt;fo42&gt;'
+        tmpl = env.from_string('{{ string|sub("^.", 42) }}')
+        assert tmpl.render(string='<foo>') == '42foo&gt;'
+
     def test_forceescape(self):
         tmpl = env.from_string('{{ x|forceescape }}')
         assert tmpl.render(x=Markup('<div />')) == u'&lt;div /&gt;'


### PR DESCRIPTION
Gives a bit more in-template logic leeway, useful e.g. in salt templates
where "just put it in the view function" is not convenient.
