### PR TITLE
Support a split filter, counterpart to join filter

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -337,6 +337,25 @@ def do_join(eval_ctx, value, d=u'', attribute=None):
     return soft_unicode(d).join(imap(soft_unicode, value))
 
 
+@evalcontextfilter
+def do_split(eval_ctx, value, d=None, maxsplit=-1):
+    """Return a list resulting from splitting a string on a delimiter, exactly
+    like Python ``split()``.
+
+    .. sourcecode:: jinja
+
+        {{ '1  2  \t\n 3'|split }}
+            -> ['1', '2', '3']
+
+        {{ '1 and 2 and 3'|split(' and  ') }}
+            -> ['1', '2', '3']
+
+        {{ '1 and 2 and 3'|split(' and  ', 1) }}
+            -> [1, '2 and 3']
+    """
+    return value.split(d, maxsplit)
+
+
 def do_center(value, width=80):
     """Centers the value in a field of a given width."""
     return text_type(value).center(width)
@@ -946,6 +965,7 @@ FILTERS = {
     'default':              do_default,
     'd':                    do_default,
     'join':                 do_join,
+    'split':                do_split,
     'count':                len,
     'dictsort':             do_dictsort,
     'sort':                 do_sort,

--- a/jinja2/testsuite/filters.py
+++ b/jinja2/testsuite/filters.py
@@ -154,6 +154,19 @@ class FilterTestCase(JinjaTestCase):
         tmpl = env.from_string('''{{ users|join(', ', 'username') }}''')
         assert tmpl.render(users=map(User, ['foo', 'bar'])) == 'foo, bar'
 
+    def test_split(self):
+        tmpl = env.from_string('{{ "1  2  \t\n 3"|split }}')
+        out = tmpl.render()
+        self.assertEqual(out, u"['1', '2', '3']")
+
+        tmpl = env.from_string('{{ "1 and 2 and 3"|split(" and ") }}')
+        out = tmpl.render()
+        self.assertEqual(out, u"['1', '2', '3']")
+
+        tmpl = env.from_string('{{ "1 and 2 and 3"|split(" and ", 1) }}')
+        out = tmpl.render()
+        self.assertEqual(out, u"['1', '2 and 3']")
+
     def test_last(self):
         tmpl = env.from_string('''{{ foo|last }}''')
         out = tmpl.render(foo=list(range(10)))


### PR DESCRIPTION
Like previous pull request, this gives a bit more in-template logic leeway, my use case being salt templates, where "just put it in the view function" is not convenient.
