### PR TITLE
Issue #126: Add `target` keyword argument to urlize.

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -409,7 +409,8 @@ def do_pprint(value, verbose=False):
 
 
 @evalcontextfilter
-def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False):
+def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False,
+              target=None):
     """Converts URLs in plain text into clickable links.
 
     If you pass the filter an additional integer it will shorten the urls
@@ -420,8 +421,18 @@ def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False):
 
         {{ mytext|urlize(40, true) }}
             links are shortened to 40 chars and defined with rel="nofollow"
+
+    If *target* is specified, the ``target`` attribute will be added to the
+    ``<a>`` tag:
+
+    .. sourcecode:: jinja
+
+       {{ mytext|urlize(40, target='_blank') }}
+
+    .. versionchanged:: 2.8+
+       The *target* parameter was added.
     """
-    rv = urlize(value, trim_url_limit, nofollow)
+    rv = urlize(value, trim_url_limit, nofollow, target)
     if eval_ctx.autoescape:
         rv = Markup(rv)
     return rv

--- a/jinja2/testsuite/filters.py
+++ b/jinja2/testsuite/filters.py
@@ -238,6 +238,14 @@ class FilterTestCase(JinjaTestCase):
         assert tmpl.render() == 'foo <a href="http://www.example.com/">'\
                                 'http://www.example.com/</a> bar'
 
+    def test_urlize_target_parameter(self):
+        tmpl = env.from_string('{{ "foo http://www.example.com/ bar"|urlize(target="_blank") }}')
+        assert tmpl.render() == 'foo <a href="http://www.example.com/" target="_blank">'\
+                                'http://www.example.com/</a> bar'
+        tmpl = env.from_string('{{ "foo http://www.example.com/ bar"|urlize(target=42) }}')
+        assert tmpl.render() == 'foo <a href="http://www.example.com/">'\
+                                'http://www.example.com/</a> bar'
+
     def test_wordcount(self):
         tmpl = env.from_string('{{ "foo bar baz"|wordcount }}')
         assert tmpl.render() == '3'

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -183,7 +183,7 @@ def pformat(obj, verbose=False):
         return pformat(obj)
 
 
-def urlize(text, trim_url_limit=None, nofollow=False):
+def urlize(text, trim_url_limit=None, nofollow=False, target=None):
     """Converts any URLs in text into clickable links. Works on http://,
     https:// and www. links. Links can have trailing punctuation (periods,
     commas, close-parens) and leading punctuation (opening parens) and
@@ -194,12 +194,18 @@ def urlize(text, trim_url_limit=None, nofollow=False):
 
     If nofollow is True, the URLs in link text will get a rel="nofollow"
     attribute.
+
+    If target is not None, a target attribute will be added to the link.
     """
     trim_url = lambda x, limit=trim_url_limit: limit is not None \
                          and (x[:limit] + (len(x) >=limit and '...'
                          or '')) or x
     words = _word_split_re.split(text_type(escape(text)))
     nofollow_attr = nofollow and ' rel="nofollow"' or ''
+    if target is not None and isinstance(target, string_types):
+        target_attr = ' target="%s"' % target
+    else:
+        target_attr = ''
     for i, word in enumerate(words):
         match = _punctuation_re.match(word)
         if match:
@@ -214,12 +220,12 @@ def urlize(text, trim_url_limit=None, nofollow=False):
                     middle.endswith('.net') or
                     middle.endswith('.com')
                 )):
-                middle = '<a href="http://%s"%s>%s</a>' % (middle,
-                    nofollow_attr, trim_url(middle))
+                middle = '<a href="http://%s"%s%s>%s</a>' % (middle,
+                    nofollow_attr, target_attr, trim_url(middle))
             if middle.startswith('http://') or \
                middle.startswith('https://'):
-                middle = '<a href="%s"%s>%s</a>' % (middle,
-                    nofollow_attr, trim_url(middle))
+                middle = '<a href="%s"%s%s>%s</a>' % (middle,
+                    nofollow_attr, target_attr, trim_url(middle))
             if '@' in middle and not middle.startswith('www.') and \
                not ':' in middle and _simple_email_re.match(middle):
                 middle = '<a href="mailto:%s">%s</a>' % (middle, middle)


### PR DESCRIPTION
In #128, @mitsuhiko says:

> Accepting a patch for making the target a keyword argument however.

This pull request adds `target` keyword argument to the urlize filter, including tests and documentation updates.
