### PR TITLE
Fix for CVE-2014-0012 (Insecure temp folder creation)

### DIFF
--- a/jinja2/bccache.py
+++ b/jinja2/bccache.py
@@ -15,9 +15,7 @@
     :license: BSD.
 """
 from os import path, listdir
-import os
 import sys
-import errno
 import marshal
 import tempfile
 import fnmatch
@@ -206,31 +204,9 @@ class FileSystemBytecodeCache(BytecodeCache):
 
     def __init__(self, directory=None, pattern='__jinja2_%s.cache'):
         if directory is None:
-            directory = self._get_default_cache_dir()
+            directory = tempfile.mkdtemp(prefix="jinja2-cache-")
         self.directory = directory
         self.pattern = pattern
-
-    def _get_default_cache_dir(self):
-        tmpdir = tempfile.gettempdir()
-
-        # On windows the temporary directory is used specific unless
-        # explicitly forced otherwise.  We can just use that.
-        if os.name == 'n':
-            return tmpdir
-        if not hasattr(os, 'getuid'):
-            raise RuntimeError('Cannot determine safe temp directory.  You '
-                               'need to explicitly provide one.')
-
-        dirname = '_jinja2-cache-%d' % os.getuid()
-        actual_dir = os.path.join(tmpdir, dirname)
-        try:
-            # 448 == 0700
-            os.mkdir(actual_dir, 448)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
-
-        return actual_dir
 
     def _get_cache_filename(self, bucket):
         return path.join(self.directory, self.pattern % bucket.key)


### PR DESCRIPTION
I think this one slipped through the cracks somehow, but the fix for [CVE-2014-1402](https://github.com/mitsuhiko/jinja2/commit/acb672b6a179567632e032f547582f30fa2f4aa7) introduced another security issue, which was assigned CVE-2014-0012.

This PR simply delegates temporary directory creation to `tempfile.mkdtemp()` in FileSystemBytecodeCache, which does the right thing.

The tests pass, but the only question I have is in regard to the intended behavior of the FilesystemBytecodeCache.  Should multiple instances of a FileSystemBytecodeCache initialized without the directory argument point to the same directory?  If so, I would need to modify my PR to stash the directory as a class variable (or something) to work around the issue.

Please see the following links for discussion of the issue:

http://seclists.org/oss-sec/2014/q1/73

http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734956

Note that it looks like this was fixed via a similar patch in Debian, but it would be nice to have this upstream.
