### PR TITLE
Fix for CVE-2014-0012

### DIFF
--- a/jinja2/bccache.py
+++ b/jinja2/bccache.py
@@ -16,6 +16,7 @@
 """
 from os import path, listdir
 import os
+import stat
 import sys
 import errno
 import marshal
@@ -215,7 +216,7 @@ class FileSystemBytecodeCache(BytecodeCache):
 
         # On windows the temporary directory is used specific unless
         # explicitly forced otherwise.  We can just use that.
-        if os.name == 'n':
+        if os.name == 'nt':
             return tmpdir
         if not hasattr(os, 'getuid'):
             raise RuntimeError('Cannot determine safe temp directory.  You '
@@ -224,11 +225,17 @@ class FileSystemBytecodeCache(BytecodeCache):
         dirname = '_jinja2-cache-%d' % os.getuid()
         actual_dir = os.path.join(tmpdir, dirname)
         try:
-            # 448 == 0700
-            os.mkdir(actual_dir, 448)
+            os.mkdir(actual_dir, stat.S_IRWXU) # 0o700
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
+
+        actual_dir_stat = os.lstat(actual_dir)
+        if actual_dir_stat.st_uid != os.getuid() \
+                or not stat.S_ISDIR(actual_dir_stat.st_mode) \
+                or stat.S_IMODE(actual_dir_stat.st_mode) != stat.S_IRWXU:
+            raise RuntimeError('Temporary directory \'%s\' has an incorrect '
+	                       'owner, permissions, or type.' % actual_dir)
 
         return actual_dir
 


### PR DESCRIPTION
Commit acb672b attempted to fix insecure temporary file use in FileSystemBytecodeCache by introducing per-user temporary directory.  However, if directory already exists, it is used without checking its ownership and permissions.  Local attacker able to create temporary directory with victim's uid before victim does so can achieve the same impact as with the original issue.

This attempts to address the issue by introducing ownership, permission and type check and makes jinja2 raise an exception if existing directory has unexpected attributes.

Further discussion can be found in:
https://bugzilla.redhat.com/show_bug.cgi?id=1051421
