### PR TITLE
Use relative import for compiler module in nodes.py (Python 2.5 support)

### DIFF
--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -431,7 +431,7 @@ class Const(Literal):
         constant value in the generated code, otherwise it will raise
         an `Impossible` exception.
         """
-        from compiler import has_safe_repr
+        from .compiler import has_safe_repr
         if not has_safe_repr(value):
             raise Impossible()
         return cls(value, lineno=lineno, environment=environment)


### PR DESCRIPTION
This is necessary to avoid a name collision with the deprecated(as of Python 2.6) builtin compiler module in Python 2.5.

This should also be ported to Jinja2 2.6, but I didn't see an appropriate branch for that.

Tested with Python 2.5 on Windows XP
