### PR TITLE
Added better support to template loader for paths that don't use slash

### DIFF
--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -24,7 +24,7 @@ def split_template_path(template):
     '..' in the path it will raise a `TemplateNotFound` error.
     """
     pieces = []
-    for piece in template.split('/'):
+    for piece in template.replace(os.sep, '/').replace(os.altsep, '/').split('/'):
         if path.sep in piece \
            or (path.altsep and path.altsep in piece) or \
            piece == path.pardir:


### PR DESCRIPTION
Very simple change to make a path canonical (use '/' as separator) before splitting.
