### PR TITLE
Use abs path for cache key

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -759,7 +759,7 @@ class Environment(object):
             raise TypeError('no loader for this environment specified')
         try:
             # use abs path for cache key
-            _, cache_key, _ = self.loader.get_source(self, name)
+            cache_key = self.loader.get_source(self, name)[1]
         except RuntimeError:
             # if loader does not implement get_source()
             cache_key = None


### PR DESCRIPTION
If we have 2 loaders and using 1 environment, and we have 2 templates of same name in different folder (I am using Flask, that's all Blueprint using the same env, so I need this patch)

```
/templates
    /loader1
        /index.html
    /loader2
        /index.html
```

then the cache will return the first rendered template, for example:

``` python
env.loader = loader1
env.get_template('index.html') # return loader1/index.html
env.loader = loader2
env.get_template('index.html') # also return loader1/index.html because of cache
```

and if we use abs path, we can cache different relative filename (e.g. `./index.html` and `index.html`).
