### PR TITLE
Fix for #204 - line_comment_prefix

### DIFF
--- a/jinja2/lexer.py
+++ b/jinja2/lexer.py
@@ -530,7 +530,7 @@ class Lexer(object):
             ] + tag_rules,
             # line comments
             TOKEN_LINECOMMENT_BEGIN: [
-                (c(r'(.*?)()(?=\n|$)'), (TOKEN_LINECOMMENT,
+                (c(r'(.*?)()(\n|$)'), (TOKEN_LINECOMMENT,
                  TOKEN_LINECOMMENT_END), '#pop')
             ]
         }


### PR DESCRIPTION
Fix for this issue: https://github.com/mitsuhiko/jinja2/issues/204

This fix cascaded into a few other tests when it comes to whitespace. 

For `test_line_syntax_priority`, since this line was in the code:

```
# XXX: why is the whitespace there in front of the newline?
```

I feel that it is alright for me to change that test.

I'm not sure about `test_lstrip_angle_bracket` and `test_lstrip_angle_bracket_compact`. On line 505:

```
${item} ## the rest of the stuff
```

It seems like there could be a whitespace before the comment, but I'm not sure.

Let me know if I should change anything!
