### PR TITLE
firstof function

### DIFF
--- a/jinja2/defaults.py
+++ b/jinja2/defaults.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from jinja2._compat import range_type
-from jinja2.utils import generate_lorem_ipsum, Cycler, Joiner
+from jinja2.utils import generate_lorem_ipsum, Cycler, Joiner, firstof
 
 
 # defaults for the parser / lexer
@@ -35,7 +35,8 @@ DEFAULT_NAMESPACE = {
     'dict':         dict,
     'lipsum':       generate_lorem_ipsum,
     'cycler':       Cycler,
-    'joiner':       Joiner
+    'joiner':       Joiner,
+    'firstof':      firstof,
 }
 
 

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -666,8 +666,10 @@ def do_round(value, precision=0, method='common'):
 
 
 @environmentfilter
-def do_groupby(environment, value, attribute):
+def do_groupby(environment, value, attribute, sort=True):
     """Group a sequence of objects by a common attribute.
+
+    Use `sort=False` if the objects are already sorted accordingly.
 
     If you for example have a list of dicts or objects that represent persons
     with `gender`, `first_name` and `last_name` attributes and you want to
@@ -705,7 +707,11 @@ def do_groupby(environment, value, attribute):
        attribute of another attribute.
     """
     expr = make_attrgetter(environment, attribute)
-    return sorted(map(_GroupTuple, groupby(sorted(value, key=expr), expr)))
+    if sort:
+        return sorted(map(_GroupTuple, groupby(sorted(value, key=expr), expr)))
+    else:
+        return map(_GroupTuple, groupby(value, expr))
+
 
 
 class _GroupTuple(tuple):

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -13,7 +13,7 @@ import errno
 from collections import deque
 from threading import Lock
 from jinja2._compat import text_type, string_types, implements_iterator, \
-     url_quote
+     url_quote, ifilter, get_next
 
 
 _word_split_re = re.compile(r'(\s+)')
@@ -522,6 +522,9 @@ class Joiner(object):
             return u''
         return self.sep
 
+
+def firstof(*items):
+    return get_next(ifilter(None, items))()
 
 # Imported here because that's where it was in the past
 from markupsafe import Markup, escape, soft_unicode


### PR DESCRIPTION
To simplify transition of django templates to jinja2:

{% firstof obj1 obj2 obj3 %} -> {{ firstof(obj1, obj2, obj3) }}

instead of currently working

{{ [obj1, obj2, obj3]|select|first }}

Or at least maybe mention this in the documentation somewhere for it doesn't look obvious at first glance.

PS Yes, I've seen https://github.com/mitsuhiko/jinja2/pull/42