### PR TITLE
unsorted groupby

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -666,8 +666,10 @@ def do_round(value, precision=0, method='common'):
 
 
 @environmentfilter
-def do_groupby(environment, value, attribute):
+def do_groupby(environment, value, attribute, sort=True):
     """Group a sequence of objects by a common attribute.
+
+    Use `sort=False` if the objects are already sorted accordingly.
 
     If you for example have a list of dicts or objects that represent persons
     with `gender`, `first_name` and `last_name` attributes and you want to
@@ -705,7 +707,11 @@ def do_groupby(environment, value, attribute):
        attribute of another attribute.
     """
     expr = make_attrgetter(environment, attribute)
-    return sorted(map(_GroupTuple, groupby(sorted(value, key=expr), expr)))
+    if sort:
+        return sorted(map(_GroupTuple, groupby(sorted(value, key=expr), expr)))
+    else:
+        return map(_GroupTuple, groupby(value, expr))
+
 
 
 class _GroupTuple(tuple):


### PR DESCRIPTION
Django groupby tag cannot currently be translated to jinja2.

This commit makes it possible without breaking backwards compatilibity.

In Django ordering is done by `group._meta.ordering` field(s). Currently performed `sorting` by `group` does no sorting at all since `django.db.Model` doesn't have `__lt__` method.

```python
class Group(object):
    def __init__(self, v):
        self.v = v

#    def __lt__(self, other):
#        return self.v < other.v

class A(object):
    def __init__(self, n, v):
        self.name = n
        self.group = Group(v)
    
    def __repr__(self):
        return 'A(%s, %d)' % (self.name, self.group.v)


q = (
    A('a', 5),
    A('b', 2),
    A('c', 5),
    A('d', 1),
    A('e', 2)
)

print q
print sorted(q, key=lambda x:x.group)
```

before uncommenting `__lt__()`:
(A(a, 5), A(b, 2), A(c, 5), A(d, 1), A(e, 2))
[A(a, 5), A(b, 2), A(c, 5), A(d, 1), A(e, 2)]

after uncommenting `__lt__()`:
(A(a, 5), A(b, 2), A(c, 5), A(d, 1), A(e, 2))
[A(d, 1), A(b, 2), A(e, 2), A(a, 5), A(c, 5)]

`{{ q|groupby('group') }}` wont sort at all
`{{ q|groupby('group.v') }}` will sort but returns senseless group.v as a grouper
`{{ q|sort('group.v')|groupby('group', sort=False) }}` works as expected