### PR TITLE
Add more information to preprocessor, parser and lexer in babel extraction

### DIFF
--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -614,9 +614,11 @@ def babel_extract(fileobj, keywords, comment_tags, options):
         environment.newstyle_gettext = True
 
     source = fileobj.read().decode(options.get('encoding', 'utf-8'))
+    filename = getattr(fileobj, 'name', None)
     try:
-        node = environment.parse(source)
-        tokens = list(environment.lex(environment.preprocess(source)))
+        node = environment.parse(source, name=filename, filename=filename)
+        processed_source = environment.preprocess(source, name=filename, filename=filename)
+        tokens = list(environment.lex(processed_source, name=filename, filename=filename))
     except TemplateSyntaxError as e:
         if not silent:
             raise


### PR DESCRIPTION
The babel extractor don't pass the filename information to the preprocessor, parser and lexer, this is an error because some extensions use the filename to decide to preprocess or not the code (like pyjade).

This change (IMHO) doesn't break anything, and allow to integrate babel with jinja + extensions easily.
