### PR TITLE
Adding tojson to the built-in filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,3 +47,4 @@ Builds
 | ``2.7-maintenance`` | .. image:: https://travis-ci.org/mitsuhiko/jinja2.svg?branch=2.7-maintenance |
 |                     |     :target: https://travis-ci.org/mitsuhiko/jinja2                          |
 +---------------------+------------------------------------------------------------------------------+
+ 

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -635,6 +635,12 @@ def do_batch(value, linecount, fill_with=None):
         yield tmp
 
 
+def do_json(value):
+    """A filter that outputs Python objects as JSON"""
+    import json
+    return json.dumps(value)
+
+
 def do_round(value, precision=0, method='common'):
     """Round the number to a given precision. The first
     parameter specifies the precision (default is ``0``), the
@@ -993,4 +999,5 @@ FILTERS = {
     'wordcount':            do_wordcount,
     'wordwrap':             do_wordwrap,
     'xmlattr':              do_xmlattr,
+    'to_json':              do_json,
 }

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -999,5 +999,5 @@ FILTERS = {
     'wordcount':            do_wordcount,
     'wordwrap':             do_wordwrap,
     'xmlattr':              do_xmlattr,
-    'to_json':              do_json,
+    'tojson':              do_json,
 }

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -560,5 +560,5 @@ class TestFilter():
     def test_json(self, env):
         env = Environment()
         obj = ['foo', {'bar': ('baz', None, 1.0, 2)}]
-        tmpl = env.from_string('{{ obj|to_json }}')
+        tmpl = env.from_string('{{ obj|tojson }}')
         assert tmpl.render(obj=obj) == '["foo", {"bar": ["baz", null, 1.0, 2]}]'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -556,3 +556,9 @@ class TestFilter():
         tmpl = env.from_string('{{ users|rejectattr("id", "odd")|'
                                'map(attribute="name")|join("|") }}')
         assert tmpl.render(users=users) == 'jane'
+
+    def test_json(self, env):
+        env = Environment()
+        obj = ['foo', {'bar': ('baz', None, 1.0, 2)}]
+        tmpl = env.from_string('{{ obj|to_json }}')
+        assert tmpl.render(obj=obj) == '["foo", {"bar": ["baz", null, 1.0, 2]}]'


### PR DESCRIPTION
Test included. Sorry about the newline in README.rst.

There was a concern that this might not be appropriate for the built-ins. Obviously, I'd argue that it is. Many major projects outside Pocoo (Ansible and Django for example) have written their own filters to do the same job. In my case, our company uses Jinja as a standalone library for our automation tooling and don't get the extras included with applications/frameworks that build on top of Jinja. Since so many devs are doing the same work in their downstream projects to make up for the lack in Jinja, it seems appropriate to simply provide that functionality here.
