### PR TITLE
Use partial(next, ...) instead get_next()

### DIFF
--- a/jinja2/_compat.py
+++ b/jinja2/_compat.py
@@ -45,7 +45,6 @@ if not PY2:
     implements_iterator = _identity
     implements_to_string = _identity
     encode_filename = _identity
-    get_next = lambda x: x.__next__
 
 else:
     unichr = unichr
@@ -76,8 +75,6 @@ else:
         cls.__unicode__ = cls.__str__
         cls.__str__ = lambda x: x.__unicode__().encode('utf-8')
         return cls
-
-    get_next = lambda x: x.next
 
     def encode_filename(filename):
         if isinstance(filename, unicode):


### PR DESCRIPTION
Since jinja2 doesn't support any version older than Python 2.6 anymore, we can simply use the `next` built-in function rather than abstracting `it.__next__` (Python 3) and `it.next` (Python 2) ourselves.