### PR TITLE
Got rid of redundant sorting in groupby filter

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -12,8 +12,8 @@ import re
 import math
 
 from random import choice
-from operator import itemgetter
 from itertools import groupby
+from collections import namedtuple
 from jinja2.utils import Markup, escape, pformat, urlize, soft_unicode, \
      unicode_urlencode
 from jinja2.runtime import Undefined
@@ -669,6 +669,8 @@ def do_round(value, precision=0, method='common'):
     return func(value * (10 ** precision)) / (10 ** precision)
 
 
+_GroupTuple = namedtuple('_GroupTuple', ['grouper', 'list'])
+
 @environmentfilter
 def do_groupby(environment, value, attribute):
     """Group a sequence of objects by a common attribute.
@@ -709,17 +711,7 @@ def do_groupby(environment, value, attribute):
        attribute of another attribute.
     """
     expr = make_attrgetter(environment, attribute)
-    return sorted(map(_GroupTuple, groupby(sorted(value, key=expr), expr)))
-
-
-class _GroupTuple(tuple):
-    __slots__ = ()
-    grouper = property(itemgetter(0))
-    list = property(itemgetter(1))
-
-    def __new__(cls, xxx_todo_changeme):
-        (key, value) = xxx_todo_changeme
-        return tuple.__new__(cls, (key, list(value)))
+    return [_GroupTuple(key, list(values)) for key, values in groupby(sorted(value, key=expr), expr)]
 
 
 @environmentfilter


### PR DESCRIPTION
I realized that the `groupby` filter applies sorting on the grouped result. This however is unnecessary, since we already sort the input using the same expression we group by and `itertools.groupby` doesn't change the order (which is the reason you have to manually sort the input for in the first place).

So sorting the the result again doesn't have any effect, beside hurting performance and increasing memory usage, since it will effectively sort for the expression it has been sorted by before, as it's computed value is stored in the first item of the tuples in the sequence.

Note that I also had to replace `map` with a list comprehension to make sure that we still return a list in Python 3, where `map` returns a lazy-evaluated iterable. And since `_GroupTuple` doesn't have to take a single argument then anymore (and since we don't support Python versions older than 2.6 anymore), we can simply use `collections.namedtuple()` to define `_GroupTuple` now.