### PR TITLE
Fixed optimization of filters and misoptimizations with changed eval context

### DIFF
--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -563,8 +563,7 @@ class Filter(Expr):
         filter_ = self.environment.filters.get(self.name)
         if filter_ is None or getattr(filter_, 'contextfilter', False):
             raise Impossible()
-        obj = self.node.as_const(eval_ctx)
-        args = [x.as_const(eval_ctx) for x in self.args]
+        args = [x.as_const(eval_ctx) for x in [self.node] + self.args]
         if getattr(filter_, 'evalcontextfilter', False):
             args.insert(0, eval_ctx)
         elif getattr(filter_, 'environmentfilter', False):


### PR DESCRIPTION
I realized that some filters aren't inlined during optimizations. It turned out that this effects all environment and eval context filters. That is because the environment or eval context isn't passed as first but second argument. Therefore the filter function raises an exception and the optimizer skips the node. This one was easy to fix, see the first commit in this PR.

However, now things get funny. With that fix, the tests for the `{% autoescape %}` tag suddenly start to fail. As it turned out the optimizer were agnostic to the eval context, and the `as_const()` method created implicitly a new eval context for every node, ignoring `{% autoescape %}` tags up the tree. So I fixed this as well, see the second commit in this PR. Therefore optimizer now keeps track of the eval context, and updates it when visiting `ScopedEvalContextModifier` nodes. To avoid future issues like that and to get rid of dead code, I also made the eval context passed to `as_const()` mandatory.
