### PR TITLE
Inline template tests during optimization

### DIFF
--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -542,6 +542,22 @@ class CondExpr(Expr):
         return self.expr2.as_const(eval_ctx)
 
 
+def args_as_const(node, eval_ctx):
+    args = [x.as_const(eval_ctx) for x in node.args]
+    kwargs = dict(x.as_const(eval_ctx) for x in node.kwargs)
+    if node.dyn_args is not None:
+        try:
+            args.extend(node.dyn_args.as_const(eval_ctx))
+        except Exception:
+            raise Impossible()
+    if node.dyn_kwargs is not None:
+        try:
+            kwargs.update(node.dyn_kwargs.as_const(eval_ctx))
+        except Exception:
+            raise Impossible()
+    return args, kwargs
+
+
 class Filter(Expr):
     """This node applies a filter on an expression.  `name` is the name of
     the filter, the rest of the fields are the same as for :class:`Call`.
@@ -564,22 +580,11 @@ class Filter(Expr):
         if filter_ is None or getattr(filter_, 'contextfilter', False):
             raise Impossible()
         obj = self.node.as_const(eval_ctx)
-        args = [x.as_const(eval_ctx) for x in self.args]
+        args, kwargs = args_as_const(self, eval_ctx)
         if getattr(filter_, 'evalcontextfilter', False):
             args.insert(0, eval_ctx)
         elif getattr(filter_, 'environmentfilter', False):
             args.insert(0, self.environment)
-        kwargs = dict(x.as_const(eval_ctx) for x in self.kwargs)
-        if self.dyn_args is not None:
-            try:
-                args.extend(self.dyn_args.as_const(eval_ctx))
-            except Exception:
-                raise Impossible()
-        if self.dyn_kwargs is not None:
-            try:
-                kwargs.update(self.dyn_kwargs.as_const(eval_ctx))
-            except Exception:
-                raise Impossible()
         try:
             return filter_(obj, *args, **kwargs)
         except Exception:
@@ -591,6 +596,18 @@ class Test(Expr):
     rest of the fields are the same as for :class:`Call`.
     """
     fields = ('node', 'name', 'args', 'kwargs', 'dyn_args', 'dyn_kwargs')
+
+    def as_const(self, eval_ctx=None):
+        test = self.environment.tests.get(self.name)
+        if test is None:
+            raise Impossible()
+        eval_ctx = get_eval_context(self, eval_ctx)
+        obj = self.node.as_const(eval_ctx)
+        args, kwargs = args_as_const(self, eval_ctx)
+        try:
+            return test(obj, *args, **kwargs)
+        except Exception:
+            raise Impossible()
 
 
 class Call(Expr):
@@ -607,9 +624,9 @@ class Call(Expr):
         if eval_ctx.volatile:
             raise Impossible()
         obj = self.node.as_const(eval_ctx)
+        args, kwargs = args_as_const(self, eval_ctx)
 
         # don't evaluate context functions
-        args = [x.as_const(eval_ctx) for x in self.args]
         if isinstance(obj, _context_function_types):
             if getattr(obj, 'contextfunction', False):
                 raise Impossible()
@@ -618,17 +635,6 @@ class Call(Expr):
             elif getattr(obj, 'environmentfunction', False):
                 args.insert(0, self.environment)
 
-        kwargs = dict(x.as_const(eval_ctx) for x in self.kwargs)
-        if self.dyn_args is not None:
-            try:
-                args.extend(self.dyn_args.as_const(eval_ctx))
-            except Exception:
-                raise Impossible()
-        if self.dyn_kwargs is not None:
-            try:
-                kwargs.update(self.dyn_kwargs.as_const(eval_ctx))
-            except Exception:
-                raise Impossible()
         try:
             return obj(*args, **kwargs)
         except Exception:


### PR DESCRIPTION
This pull requests implements the `as_const()` method for `Test` nodes. That way tests get inlined along with filters and function calls by the optimizer. To avoid/remove code duplication, I moved the common code, parsing the arguments, into a helper function.
