### PR TITLE
Support filters in set block

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,10 +33,12 @@ Version 2.10
 - Add ``reverse`` argument for ``dictsort`` filter. (`#692`_)
 - Add a ``NativeEnvironment`` that renders templates to native Python types
   instead of strings. (`#708`_)
+- Added filter support to the block ``set`` tag. (`#489`_)
 
 .. _#469: https://github.com/pallets/jinja/pull/469
 .. _#475: https://github.com/pallets/jinja/pull/475
 .. _#478: https://github.com/pallets/jinja/pull/478
+.. _#489: https://github.com/pallets/jinja/pull/489
 .. _#617: https://github.com/pallets/jinja/pull/617
 .. _#618: https://github.com/pallets/jinja/pull/618
 .. _#665: https://github.com/pallets/jinja/pull/665

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -947,6 +947,17 @@ Example::
 
 The `navigation` variable then contains the navigation HTML source.
 
+.. versionchanged:: 2.10
+
+Starting with Jinja 2.10, the block assignment supports filters.
+
+Example::
+
+    {% set reply | wordwrap %}
+        You wrote:
+        {{ message }}
+    {% endset %}
+
 
 .. _extends:
 

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1385,7 +1385,12 @@ class CodeGenerator(NodeVisitor):
         self.newline(node)
         self.visit(node.target, frame)
         self.write(' = (Markup if context.eval_ctx.autoescape '
-                   'else identity)(concat(%s))' % block_frame.buffer)
+                   'else identity)(')
+        if node.filter is not None:
+            self.visit_Filter(node.filter, block_frame)
+        else:
+            self.write('concat(%s)' % block_frame.buffer)
+        self.write(')')
         self.pop_assign_tracking(frame)
         self.leave_frame(block_frame)
 

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -387,7 +387,7 @@ class Assign(Stmt):
 
 class AssignBlock(Stmt):
     """Assigns a block to a target."""
-    fields = ('target', 'body')
+    fields = ('target', 'filter', 'body')
 
 
 class Expr(Node):

--- a/jinja2/parser.py
+++ b/jinja2/parser.py
@@ -180,9 +180,10 @@ class Parser(object):
         if self.stream.skip_if('assign'):
             expr = self.parse_tuple()
             return nodes.Assign(target, expr, lineno=lineno)
+        filter_node = self.parse_filter(None)
         body = self.parse_statements(('name:endset',),
                                      drop_needle=True)
-        return nodes.AssignBlock(target, body, lineno=lineno)
+        return nodes.AssignBlock(target, filter_node, body, lineno=lineno)
 
     def parse_for(self):
         """Parse a for loop."""


### PR DESCRIPTION
As suggested in #486, this adds support for filters in `set` blocks:

```
{% set foo | somefilter %}
    this is a test
{% endset %}
```
