### PR TITLE
Simplify and correct include validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 dist
 .DS_Store
 .tox
+.cache

--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -10,6 +10,7 @@
 """
 import os
 import sys
+import re
 import weakref
 from types import ModuleType
 from os import path
@@ -20,19 +21,13 @@ from jinja2._compat import string_types, iteritems
 
 
 def split_template_path(template):
-    """Split a path into segments and perform a sanity check.  If it detects
-    '..' in the path it will raise a `TemplateNotFound` error.
-    """
-    pieces = []
-    for piece in template.split('/'):
-        if path.sep in piece \
-           or (path.altsep and path.altsep in piece) or \
-           piece == path.pardir:
-            raise TemplateNotFound(template)
-        elif piece and piece != '.':
-            pieces.append(piece)
+    """Split a path into segments and perform a sanity check.  If it detects 
+    an absolute path it will raise a `TemplateNotFound` error."""
+    template = os.path.normpath(template)
+    altsep = os.altsep if os.altsep else ''
+    pieces = re.split(r'[%s%s]' % (os.sep, altsep), template)
+    if pieces[0] == '': raise TemplateNotFound(template)    
     return pieces
-
 
 class BaseLoader(object):
     """Baseclass for all loaders.  Subclass this and override `get_source` to

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -33,6 +33,10 @@ class TestLoaders():
         env = Environment(loader=package_loader)
         tmpl = env.get_template('test.html')
         assert tmpl.render().strip() == 'BAR'
+        tmpl = env.get_template('foo/test.html')
+        assert tmpl.render().strip() == 'FOO'
+        tmpl = env.get_template('foo/../foo/test.html')
+        assert tmpl.render().strip() == 'FOO'
         pytest.raises(TemplateNotFound, env.get_template, 'missing.html')
 
     def test_filesystem_loader(self, filesystem_loader):
@@ -40,6 +44,8 @@ class TestLoaders():
         tmpl = env.get_template('test.html')
         assert tmpl.render().strip() == 'BAR'
         tmpl = env.get_template('foo/test.html')
+        assert tmpl.render().strip() == 'FOO'
+        tmpl = env.get_template('foo/../foo/test.html')
         assert tmpl.render().strip() == 'FOO'
         pytest.raises(TemplateNotFound, env.get_template, 'missing.html')
 
@@ -102,8 +108,11 @@ class TestLoaders():
     def test_split_template_path(self):
         assert split_template_path('foo/bar') == ['foo', 'bar']
         assert split_template_path('./foo/bar') == ['foo', 'bar']
-        pytest.raises(TemplateNotFound, split_template_path, '../foo')
+        assert split_template_path('foo//bar') == ['foo', 'bar']
+        assert split_template_path('foo/../bar') == ['bar']
+        assert split_template_path('../foo') == ['..', 'foo']
 
+        pytest.raises(TemplateNotFound, split_template_path, '/foo/bar')
 
 @pytest.mark.loaders
 @pytest.mark.moduleloader


### PR DESCRIPTION
* Allow for parent directories to be included
* Disallow absolute paths as includes (these were being misinterpreted)
* Expanded unit tests to match