### PR TITLE
Use container-based travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
This should result in faster Travis builds and also gets rid of the warning currently shown on builds.