### PR TITLE
Simplified tox invocation from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ python:
 install:
     - pip install tox
 script:
-    - tox -e \
-      $(echo $TRAVIS_PYTHON_VERSION | sed 's/^\([0-9]\)\.\([0-9]\).*/py\1\2/')
+    - tox -e py
 
 notifications:
   email: false


### PR DESCRIPTION
Apparently, we can call tox for the current Python version, in a way simpler fashion, from Travis, by simply calling `tox -e py`. This is how Werkzeug and Flask are doing it.