### PR TITLE
Added Python 3.4 and 3.5 to the classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing :: Markup :: HTML'


### PR DESCRIPTION
It seems that somebody forgot to keep the compatible Python versions listed in `setup.py` up to date. Python 3.5 is already out, and the tests are already performed and pass there. However, in `setup.py`, Python 3.3 is the latest version listed.