### PR TITLE
Escape target attribute in the urlize function in utils.py.

### DIFF
--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -203,7 +203,7 @@ def urlize(text, trim_url_limit=None, nofollow=False, target=None):
     words = _word_split_re.split(text_type(escape(text)))
     nofollow_attr = nofollow and ' rel="nofollow"' or ''
     if target is not None and isinstance(target, string_types):
-        target_attr = ' target="%s"' % target
+        target_attr = ' target="%s"' % escape(target)
     else:
         target_attr = ''
     for i, word in enumerate(words):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ import pytest
 
 import pickle
 
-from jinja2.utils import LRUCache, escape, object_type_repr
+from jinja2.utils import LRUCache, escape, object_type_repr, urlize
 
 
 @pytest.mark.utils
@@ -74,3 +74,14 @@ class TestMarkupLeak():
                 escape(u"<foo>")
             counts.add(len(gc.get_objects()))
         assert len(counts) == 1, 'ouch, c extension seems to leak objects'
+
+
+@pytest.mark.utils
+@pytest.mark.escapeUrlizeTarget
+class TestEscapeUrlizeTarget():
+    def test_escape_urlize_target(self):
+        url = "http://example.org"
+        target = "<script>"
+        assert urlize(url, target=target) == ('<a href="http://example.org"'
+                                              ' target="&lt;script&gt;">'
+                                              'http://example.org</a>')


### PR DESCRIPTION
See PR #356.