### PR TITLE
Subtraction from Undefined does not raise UndefinedError

### DIFF
--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -498,7 +498,7 @@ class Undefined(object):
         __truediv__ = __rtruediv__ = __floordiv__ = __rfloordiv__ = \
         __mod__ = __rmod__ = __pos__ = __neg__ = __call__ = \
         __getitem__ = __lt__ = __le__ = __gt__ = __ge__ = __int__ = \
-        __float__ = __complex__ = __pow__ = __rpow__ = \
+        __float__ = __complex__ = __pow__ = __rpow__ = __sub__ = \
         _fail_with_undefined_error
 
     def __eq__(self, other):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -244,6 +244,8 @@ class TestUndefined():
             == 'True'
         assert env.from_string('{{ foo.missing }}').render(foo=42) == ''
         assert env.from_string('{{ not missing }}').render() == 'True'
+        pytest.raises(UndefinedError,
+                      env.from_string('{{ missing - 1}}').render)
 
     def test_debug_undefined(self):
         env = Environment(undefined=DebugUndefined)


### PR DESCRIPTION
Setting **sub** equal to _fail_with_undefined_error so subtractions with undefined variables will fail properly like other arithemtic operations.
