### PR TITLE
ignore error when gettext string formatting fails with % in source text

### DIFF
--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -140,7 +140,7 @@ def _make_new_gettext(func):
             rv = Markup(rv)
         try:
             return rv % variables
-        except:
+        except TypeError:
             return rv
     return gettext
 
@@ -154,7 +154,7 @@ def _make_new_ngettext(func):
             rv = Markup(rv)
         try:
             return rv % variables
-        except:
+        except TypeError:
             return rv
     return ngettext
 

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -138,7 +138,10 @@ def _make_new_gettext(func):
         rv = __context.call(func, __string)
         if __context.eval_ctx.autoescape:
             rv = Markup(rv)
-        return rv % variables
+        try:
+            return rv % variables
+        except:
+            return rv
     return gettext
 
 
@@ -149,7 +152,10 @@ def _make_new_ngettext(func):
         rv = __context.call(func, __singular, __plural, __num)
         if __context.eval_ctx.autoescape:
             rv = Markup(rv)
-        return rv % variables
+        try:
+            return rv % variables
+        except:
+            return rv
     return ngettext
 
 


### PR DESCRIPTION
If the string returned by gettext has a %, but there is no substitution to be performed (and indeed, the % may prefix an invalid character), then instead of raising an exception and failing completely, we return the original text.
