### PR TITLE
Change links for Babel to new docs location.

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -107,7 +107,7 @@ The usage of the `i18n` extension for template designers is covered as part
 :ref:`of the template documentation <i18n-in-templates>`.
 
 .. _gettext: http://docs.python.org/dev/library/gettext
-.. _Babel: http://babel.edgewall.org/
+.. _Babel: http://babel.pocoo.org/
 
 .. _newstyle-gettext:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -50,7 +50,7 @@ automatically.
    want that behavior you can add ``silent=false`` to the settings and
    exceptions are propagated.
 
-.. _mapping file: http://babel.edgewall.org/wiki/Documentation/messages.html#extraction-method-mapping-and-configuration
+.. _mapping file: http://babel.pocoo.org/en/latest/messages.html#extraction-method-mapping-and-configuration
 
 Pylons
 ------
@@ -97,5 +97,5 @@ The first one for text based templates, the latter for HTML templates.
 
 Copy the files into your `syntax` folder.
 
-.. _Babel: http://babel.edgewall.org/
+.. _Babel: http://babel.pocoo.org/
 .. _Vim: http://www.vim.org/


### PR DESCRIPTION
The header at https://babel.edgewall.org/ says

> **The Babel project has moved!**
> After this project has sadly been stalled for a long time, Armin Ronacher (@mitsuhiko) of Flask fame has kindly volunteered to get the project back up to speed. For a variety of reasons this means Babel is leaving the Edgewall.org umbrella.
> 
> The new home of the project is at babel.pocoo.org, the code is now hosted on Github at github.com/mitsuhiko/babel. In the coming days, we will make the Babel Trac environment on edgewall.org readonly