### PR TITLE
Bug: Jinja fails with unknown tags in {% for %} which is not executed

### DIFF
--- a/tests/res/templates/unknown_tag_in_for_loop.html
+++ b/tests/res/templates/unknown_tag_in_for_loop.html
@@ -1,0 +1,7 @@
+{% set PLUGINS = ['something-else'] %}
+{% for name in PLUGINS if name == 'assets' %}
+  {% assets %}
+  {% endassets %}
+{% else %}
+  assets is disabled
+{% endfor %}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -35,6 +35,11 @@ class TestLoaders():
         assert tmpl.render().strip() == 'BAR'
         pytest.raises(TemplateNotFound, env.get_template, 'missing.html')
 
+    def test_unknown_tag_in_for_loop(self, package_loader):
+        env = Environment(loader=package_loader)
+        tmpl = env.get_template('unknown_tag_in_for_loop.html')
+        assert tmpl.render().strip() == 'assets is disabled'
+
     def test_filesystem_loader(self, filesystem_loader):
         env = Environment(loader=filesystem_loader)
         tmpl = env.get_template('test.html')


### PR DESCRIPTION
Hey guys,
I have a code similar to this test, which loops over defined (Pelican) plugins and tries to use the webassets module if the plugin is enabled. If not falls back to not using it. However when rendering the template Jinja raises
```
TemplateSyntaxError: Encountered unknown tag 'assets'. Jinja was looking for the following tags: 'endfor' or 'else'. The innermost block that needs to be closed is 'for'.
```

which tells me that it tries to parse the `{% assets %}` tag before actually running the loop (or not running it more precisely). Is there any way to solve this or that's a known limitation and can't be solved ? 