### PR TITLE
Change cache key definition in environment

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -769,15 +769,7 @@ class Environment(object):
     def _load_template(self, name, globals):
         if self.loader is None:
             raise TypeError('no loader for this environment specified')
-        try:
-            # use abs path for cache key
-            cache_key = self.loader.get_source(self, name)[1]
-        except RuntimeError:
-            # if loader does not implement get_source()
-            cache_key = None
-        # if template is not file, use name for cache key
-        if cache_key is None:
-            cache_key = name
+        cache_key = (id(self.loader), name)
         if self.cache is not None:
             template = self.cache.get(cache_key)
             if template is not None and (not self.auto_reload or


### PR DESCRIPTION
In 6671b973e6de5abc46829a27fd3bbb989d68ca3a the load_template method
was altered to use a cache key other than the template name. The key
chosen was the abs path as returned from the loader get_source
method. Unless there is no path in which case the name is
used. Unfortunately this introduced a performance regression, #485, as
the get_source method (in the FileStoreLoader) loads the template
(causing IO).

The purpose of #332 was to allow the loader to change whilst ensuring
the correct template was loaded, i.e. to fix this case

    env.loader = loader1
    env.get_template('index.html') # return loader1/index.html
    env.loader = loader2
    env.get_template('index.html') # also return loader1/index.html because of cache

This commit changes the cache key to be a combination of a hash of the
loader and the template name. Therefore fixing the above case without
calling the get_source method and thereby avoiding the IO load.

This additionally fixes the above use case for loaders that do not return filenames, e.g. `DictLoader`. However it will likely introduce cache misses should properties of the loader change (and hence the hash changes).