### PR TITLE
Added a GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.rst
+++ b/.github/ISSUE_TEMPLATE.rst
@@ -1,0 +1,2 @@
+The issue tracker is a tool to address bugs.
+Please use the #pocoo IRC channel on freenode or Stack Overflow for questions.


### PR DESCRIPTION
#594
Project contributors will automatically see the template's contents in the issue form body. Templates customize and standardize the information you'd like included when contributors open issues.

More info: https://help.github.com/articles/creating-an-issue-template-for-your-repository/