### PR TITLE
Move version headings directly beneath topic headings in documentation

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -44,22 +44,24 @@ additional methods:
 
 .. method:: jinja2.Environment.install_gettext_translations(translations, newstyle=False)
 
+    .. versionchanged:: 2.5 newstyle gettext added
+
     Installs a translation globally for that environment.  The translations
     object provided must implement at least `ugettext` and `ungettext`.
     The `gettext.NullTranslations` and `gettext.GNUTranslations` classes
     as well as `Babel`_\s `Translations` class are supported.
 
-    .. versionchanged:: 2.5 newstyle gettext added
-
 .. method:: jinja2.Environment.install_null_translations(newstyle=False)
+
+    .. versionchanged:: 2.5 newstyle gettext added
 
     Install dummy gettext functions.  This is useful if you want to prepare
     the application for internationalization but don't want to implement the
     full internationalization system yet.
 
-    .. versionchanged:: 2.5 newstyle gettext added
-
 .. method:: jinja2.Environment.install_gettext_callables(gettext, ngettext, newstyle=False)
+
+    .. versionadded:: 2.5
 
     Installs the given `gettext` and `ngettext` callables into the
     environment as globals.  They are supposed to behave exactly like the
@@ -69,7 +71,6 @@ additional methods:
     If `newstyle` is activated, the callables are wrapped to work like
     newstyle callables.  See :ref:`newstyle-gettext` for more information.
 
-    .. versionadded:: 2.5
 
 .. method:: jinja2.Environment.uninstall_gettext_translations()
 

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -136,10 +136,10 @@ class Environment(object):
             statements.  See also :ref:`line-statements`.
 
         `line_comment_prefix`
+            .. versionadded:: 2.2
+
             If given and a string, this will be used as prefix for line based
             comments.  See also :ref:`line-statements`.
-
-            .. versionadded:: 2.2
 
         `trim_blocks`
             If this is set to ``True`` the first newline after a block is
@@ -156,11 +156,11 @@ class Environment(object):
             applications.
 
         `keep_trailing_newline`
+            .. versionadded:: 2.7
+
             Preserve the trailing newline when rendering templates.
             The default is ``False``, which causes a single newline,
             if present, to be stripped from the end of the template.
-
-            .. versionadded:: 2.7
 
         `extensions`
             List of Jinja extensions to use.  This can either be import paths
@@ -180,6 +180,9 @@ class Environment(object):
             ``None`` implicitly into an empty string here.
 
         `autoescape`
+            .. versionchanged:: 2.4
+               `autoescape` can now be a function
+
             If set to ``True`` the XML/HTML autoescaping feature is enabled by
             default.  For more details about autoescaping see
             :class:`~jinja2.utils.Markup`.  As of Jinja 2.4 this can also
@@ -187,21 +190,19 @@ class Environment(object):
             return ``True`` or ``False`` depending on autoescape should be
             enabled by default.
 
-            .. versionchanged:: 2.4
-               `autoescape` can now be a function
 
         `loader`
             The template loader for this environment.
 
         `cache_size`
+            .. versionchanged:: 2.8
+               The cache size was increased to 400 from a low 50.
+
             The size of the cache.  Per default this is ``400`` which means
             that if more than 400 templates are loaded the loader will clean
             out the least recently used template.  If the cache size is set to
             ``0`` templates are recompiled all the time, if the cache size is
             ``-1`` the cache will not be cleaned.
-
-            .. versionchanged:: 2.8
-               The cache size was increased to 400 from a low 50.
 
         `auto_reload`
             Some loaders load templates from locations where the template
@@ -317,9 +318,10 @@ class Environment(object):
         _environment_sanity_check(self)
 
     def add_extension(self, extension):
-        """Adds an extension after the environment was created.
-
+        """
         .. versionadded:: 2.5
+
+        Adds an extension after the environment was created.
         """
         self.extensions.update(load_extensions(self, [extension]))
 
@@ -416,9 +418,10 @@ class Environment(object):
 
     def call_filter(self, name, value, args=None, kwargs=None,
                     context=None, eval_ctx=None):
-        """Invokes a filter on a value the same way the compiler does it.
-
+        """
         .. versionadded:: 2.7
+
+        Invokes a filter on a value the same way the compiler does it.
         """
         func = self.filters.get(name)
         if func is None:
@@ -441,9 +444,10 @@ class Environment(object):
         return func(*args, **(kwargs or {}))
 
     def call_test(self, name, value, args=None, kwargs=None):
-        """Invokes a test on a value the same way the compiler does it.
-
+        """
         .. versionadded:: 2.7
+
+        Invokes a test on a value the same way the compiler does it.
         """
         func = self.tests.get(name)
         if func is None:
@@ -508,25 +512,31 @@ class Environment(object):
         return stream
 
     def _generate(self, source, name, filename, defer_init=False):
-        """Internal hook that can be overridden to hook a different generate
-        method in.
-
+        """
         .. versionadded:: 2.5
+
+        Internal hook that can be overridden to hook a different generate
+        method in.
         """
         return generate(source, self, name, filename, defer_init=defer_init)
 
     def _compile(self, source, filename):
-        """Internal hook that can be overridden to hook a different compile
-        method in.
-
+        """
         .. versionadded:: 2.5
+
+        Internal hook that can be overridden to hook a different compile
+        method in.
         """
         return compile(source, filename, 'exec')
 
     @internalcode
     def compile(self, source, name=None, filename=None, raw=False,
                 defer_init=False):
-        """Compile a node or template source code.  The `name` parameter is
+        """
+        .. versionadded:: 2.4
+           `defer_init` parameter added.
+
+        Compile a node or template source code.  The `name` parameter is
         the load name of the template after it was joined using
         :meth:`join_path` if necessary, not the filename on the file system.
         the `filename` parameter is the estimated filename of the template on
@@ -541,9 +551,6 @@ class Environment(object):
         `defer_init` is use internally to aid the module code generator.  This
         causes the generated code to be able to import without the global
         environment variable to be set.
-
-        .. versionadded:: 2.4
-           `defer_init` parameter added.
         """
         source_hint = None
         try:
@@ -566,7 +573,10 @@ class Environment(object):
         self.handle_exception(exc_info, source_hint=source_hint)
 
     def compile_expression(self, source, undefined_to_none=True):
-        """A handy helper method that returns a callable that accepts keyword
+        """
+        .. versionadded:: 2.1
+
+        A handy helper method that returns a callable that accepts keyword
         arguments that appear as variables in the expression.  If called it
         returns the result of the expression.
 
@@ -590,8 +600,6 @@ class Environment(object):
         True
         >>> env.compile_expression('var', undefined_to_none=False)()
         Undefined
-
-        .. versionadded:: 2.1
         """
         parser = Parser(self, source, state='variable')
         exc_info = None
@@ -613,7 +621,10 @@ class Environment(object):
     def compile_templates(self, target, extensions=None, filter_func=None,
                           zip='deflated', log_function=None,
                           ignore_errors=True, py_compile=False):
-        """Finds all the templates the loader can find, compiles them
+        """
+        .. versionadded:: 2.4
+
+        Finds all the templates the loader can find, compiles them
         and stores them in `target`.  If `zip` is `None`, instead of in a
         zipfile, the templates will be stored in a directory.
         By default a deflate zip algorithm is used. To switch to
@@ -632,8 +643,6 @@ class Environment(object):
         target instead of standard .py files.  This flag does not do anything
         on pypy and Python 3 where pyc files are not picked up by itself and
         don't give much benefit.
-
-        .. versionadded:: 2.4
         """
         from jinja2.loaders import ModuleLoader
 
@@ -706,7 +715,10 @@ class Environment(object):
         log_function('Finished compiling templates')
 
     def list_templates(self, extensions=None, filter_func=None):
-        """Returns a list of templates for this environment.  This requires
+        """
+        .. versionadded:: 2.4
+
+        Returns a list of templates for this environment.  This requires
         that the loader supports the loader's
         :meth:`~BaseLoader.list_templates` method.
 
@@ -718,8 +730,6 @@ class Environment(object):
         in the result list.
 
         If the loader does not support that, a :exc:`TypeError` is raised.
-
-        .. versionadded:: 2.4
         """
         x = self.loader.list_templates()
         if extensions is not None:
@@ -783,7 +793,12 @@ class Environment(object):
 
     @internalcode
     def get_template(self, name, parent=None, globals=None):
-        """Load a template from the loader.  If a loader is configured this
+        """
+        .. versionchanged:: 2.4
+           If `name` is a :class:`Template` object it is returned from the
+           function unchanged.
+
+        Load a template from the loader.  If a loader is configured this
         method ask the loader for the template and returns a :class:`Template`.
         If the `parent` parameter is not `None`, :meth:`join_path` is called
         to get the real template name before loading.
@@ -793,10 +808,6 @@ class Environment(object):
 
         If the template does not exist a :exc:`TemplateNotFound` exception is
         raised.
-
-        .. versionchanged:: 2.4
-           If `name` is a :class:`Template` object it is returned from the
-           function unchanged.
         """
         if isinstance(name, Template):
             return name
@@ -806,15 +817,15 @@ class Environment(object):
 
     @internalcode
     def select_template(self, names, parent=None, globals=None):
-        """Works like :meth:`get_template` but tries a number of templates
-        before it fails.  If it cannot find any of the templates, it will
-        raise a :exc:`TemplatesNotFound` exception.
-
+        """
         .. versionadded:: 2.3
-
         .. versionchanged:: 2.4
            If `names` contains a :class:`Template` object it is returned
            from the function unchanged.
+
+        Works like :meth:`get_template` but tries a number of templates
+        before it fails.  If it cannot find any of the templates, it will
+        raise a :exc:`TemplatesNotFound` exception.
         """
         if not names:
             raise TemplatesNotFound(message=u'Tried to select from an empty list '
@@ -834,11 +845,12 @@ class Environment(object):
     @internalcode
     def get_or_select_template(self, template_name_or_list,
                                parent=None, globals=None):
-        """Does a typecheck and dispatches to :meth:`select_template`
+        """
+        .. versionadded:: 2.3
+
+        Does a typecheck and dispatches to :meth:`select_template`
         if an iterable of template names is given, otherwise to
         :meth:`get_template`.
-
-        .. versionadded:: 2.3
         """
         if isinstance(template_name_or_list, string_types):
             return self.get_template(template_name_or_list, parent, globals)
@@ -934,10 +946,11 @@ class Template(object):
 
     @classmethod
     def from_module_dict(cls, environment, module_dict, globals):
-        """Creates a template object from a module.  This is used by the
-        module loader to create a template object.
-
+        """
         .. versionadded:: 2.4
+
+        Creates a template object from a module.  This is used by the
+        module loader to create a template object.
         """
         return cls._from_namespace(environment, module_dict, globals)
 

--- a/jinja2/exceptions.py
+++ b/jinja2/exceptions.py
@@ -62,11 +62,12 @@ class TemplateNotFound(IOError, LookupError, TemplateError):
 
 
 class TemplatesNotFound(TemplateNotFound):
-    """Like :class:`TemplateNotFound` but raised if multiple templates
+    """
+    .. versionadded:: 2.2
+
+    Like :class:`TemplateNotFound` but raised if multiple templates
     are selected.  This is a subclass of :class:`TemplateNotFound`
     exception, so just catching the base exception will catch both.
-
-    .. versionadded:: 2.2
     """
 
     def __init__(self, names=(), message=None):

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -551,8 +551,7 @@ class _CommentFinder(object):
 
 
 def babel_extract(fileobj, keywords, comment_tags, options):
-    """Babel extraction method for Jinja templates.
-
+    """
     .. versionchanged:: 2.3
        Basic support for translation comments was added.  If `comment_tags`
        is now set to a list of keywords for extraction, the extractor will
@@ -568,6 +567,8 @@ def babel_extract(fileobj, keywords, comment_tags, options):
     .. versionchanged:: 2.7
        A `silent` option can now be provided.  If set to `False` template
        syntax errors are propagated instead of being ignored.
+
+    Babel extraction method for Jinja templates.
 
     :param fileobj: the file-like object the messages should be extracted from
     :param keywords: a list of keywords (i.e. function names) that should be

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -34,11 +34,12 @@ def contextfilter(f):
 
 
 def evalcontextfilter(f):
-    """Decorator for marking eval-context dependent filters.  An eval
+    """
+    .. versionadded:: 2.4
+
+    Decorator for marking eval-context dependent filters.  An eval
     context object is passed as first argument.  For more information
     about the eval context, see :ref:`eval-context`.
-
-    .. versionadded:: 2.4
     """
     f.evalcontextfilter = True
     return f
@@ -79,10 +80,11 @@ def do_forceescape(value):
 
 
 def do_urlencode(value):
-    """Escape strings for use in URLs (uses UTF-8 encoding).  It accepts both
-    dictionaries and regular strings as well as pairwise iterables.
-
+    """
     .. versionadded:: 2.7
+
+    Escape strings for use in URLs (uses UTF-8 encoding).  It accepts both
+    dictionaries and regular strings as well as pairwise iterables.
     """
     itemiter = None
     if isinstance(value, dict):
@@ -225,7 +227,11 @@ def do_dictsort(value, case_sensitive=False, by='key'):
 @environmentfilter
 def do_sort(environment, value, reverse=False, case_sensitive=False,
             attribute=None):
-    """Sort an iterable.  Per default it sorts ascending, if you pass it
+    """
+    .. versionchanged:: 2.6
+       The `attribute` parameter was added.
+
+    Sort an iterable.  Per default it sorts ascending, if you pass it
     true as first argument it will reverse the sorting.
 
     If the iterable is made of strings the third parameter can be used to
@@ -246,9 +252,6 @@ def do_sort(environment, value, reverse=False, case_sensitive=False,
         {% for item in iterable|sort(attribute='date') %}
             ...
         {% endfor %}
-
-    .. versionchanged:: 2.6
-       The `attribute` parameter was added.
     """
     if not case_sensitive:
         def sort_func(item):
@@ -288,7 +291,11 @@ def do_default(value, default_value=u'', boolean=False):
 
 @evalcontextfilter
 def do_join(eval_ctx, value, d=u'', attribute=None):
-    """Return a string which is the concatenation of the strings in the
+    """
+    .. versionadded:: 2.6
+       The `attribute` parameter was added.
+
+    Return a string which is the concatenation of the strings in the
     sequence. The separator between elements is an empty string per
     default, you can define it with the optional parameter:
 
@@ -305,9 +312,6 @@ def do_join(eval_ctx, value, d=u'', attribute=None):
     .. sourcecode:: jinja
 
         {{ users|join(', ', attribute='username') }}
-
-    .. versionadded:: 2.6
-       The `attribute` parameter was added.
     """
     if attribute is not None:
         value = imap(make_attrgetter(eval_ctx.environment, attribute), value)
@@ -410,7 +414,11 @@ def do_pprint(value, verbose=False):
 @evalcontextfilter
 def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False,
               target=None):
-    """Converts URLs in plain text into clickable links.
+    """
+    .. versionchanged:: 2.8+
+       The *target* parameter was added.
+
+    Converts URLs in plain text into clickable links.
 
     If you pass the filter an additional integer it will shorten the urls
     to that number. Also a third argument exists that makes the urls
@@ -427,9 +435,6 @@ def do_urlize(eval_ctx, value, trim_url_limit=None, nofollow=False,
     .. sourcecode:: jinja
 
        {{ mytext|urlize(40, target='_blank') }}
-
-    .. versionchanged:: 2.8+
-       The *target* parameter was added.
     """
     rv = urlize(value, trim_url_limit, nofollow, target)
     if eval_ctx.autoescape:
@@ -487,15 +492,15 @@ def do_truncate(s, length=255, killwords=False, end='...'):
 def do_wordwrap(environment, s, width=79, break_long_words=True,
                 wrapstring=None):
     """
+    .. versionadded:: 2.7
+       Added support for the `wrapstring` parameter.
+
     Return a copy of the string passed to the filter wrapped after
     ``79`` characters.  You can override this default using the first
     parameter.  If you set the second parameter to `false` Jinja will not
     split words apart if they are longer than `width`. By default, the newlines
     will be the default newlines for the environment, but this can be changed
     using the wrapstring keyword argument.
-
-    .. versionadded:: 2.7
-       Added support for the `wrapstring` parameter.
     """
     if not wrapstring:
         wrapstring = environment.newline_sequence
@@ -675,7 +680,12 @@ _GroupTuple = namedtuple('_GroupTuple', ['grouper', 'list'])
 
 @environmentfilter
 def do_groupby(environment, value, attribute):
-    """Group a sequence of objects by a common attribute.
+    """
+    .. versionchanged:: 2.6
+       It's now possible to use dotted notation to group by the child
+       attribute of another attribute.
+
+    Group a sequence of objects by a common attribute.
 
     If you for example have a list of dicts or objects that represent persons
     with `gender`, `first_name` and `last_name` attributes and you want to
@@ -707,10 +717,6 @@ def do_groupby(environment, value, attribute):
     As you can see the item we're grouping by is stored in the `grouper`
     attribute and the `list` contains all the objects that have this grouper
     in common.
-
-    .. versionchanged:: 2.6
-       It's now possible to use dotted notation to group by the child
-       attribute of another attribute.
     """
     expr = make_attrgetter(environment, attribute)
     return [_GroupTuple(key, list(values)) for key, values in groupby(sorted(value, key=expr), expr)]
@@ -718,7 +724,12 @@ def do_groupby(environment, value, attribute):
 
 @environmentfilter
 def do_sum(environment, iterable, attribute=None, start=0):
-    """Returns the sum of a sequence of numbers plus the value of parameter
+    """
+    .. versionchanged:: 2.6
+       The `attribute` parameter was added to allow suming up over
+       attributes.  Also the `start` parameter was moved on to the right.
+
+    Returns the sum of a sequence of numbers plus the value of parameter
     'start' (which defaults to 0).  When the sequence is empty it returns
     start.
 
@@ -727,10 +738,6 @@ def do_sum(environment, iterable, attribute=None, start=0):
     .. sourcecode:: jinja
 
         Total: {{ items|sum(attribute='price') }}
-
-    .. versionchanged:: 2.6
-       The `attribute` parameter was added to allow suming up over
-       attributes.  Also the `start` parameter was moved on to the right.
     """
     if attribute is not None:
         iterable = imap(make_attrgetter(environment, attribute), iterable)
@@ -800,7 +807,10 @@ def do_attr(environment, obj, name):
 
 @contextfilter
 def do_map(*args, **kwargs):
-    """Applies a filter on a sequence of objects or looks up an attribute.
+    """
+    .. versionadded:: 2.7
+
+    Applies a filter on a sequence of objects or looks up an attribute.
     This is useful when dealing with lists of objects but you are really
     only interested in a certain value of it.
 
@@ -818,8 +828,6 @@ def do_map(*args, **kwargs):
     .. sourcecode:: jinja
 
         Users on this page: {{ titles|map('lower')|join(', ') }}
-
-    .. versionadded:: 2.7
     """
     context = args[0]
     seq = args[1]
@@ -846,7 +854,10 @@ def do_map(*args, **kwargs):
 
 @contextfilter
 def do_select(*args, **kwargs):
-    """Filters a sequence of objects by applying a test to each object,
+    """
+    .. versionadded:: 2.7
+
+    Filters a sequence of objects by applying a test to each object,
     and only selecting the objects with the test succeeding.
 
     If no test is specified, each object will be evaluated as a boolean.
@@ -857,15 +868,16 @@ def do_select(*args, **kwargs):
 
         {{ numbers|select("odd") }}
         {{ numbers|select("odd") }}
-
-    .. versionadded:: 2.7
     """
     return _select_or_reject(args, kwargs, lambda x: x, False)
 
 
 @contextfilter
 def do_reject(*args, **kwargs):
-    """Filters a sequence of objects by applying a test to each object,
+    """
+    .. versionadded:: 2.7
+
+    Filters a sequence of objects by applying a test to each object,
     and rejecting the objects with the test succeeding.
 
     If no test is specified, each object will be evaluated as a boolean.
@@ -875,15 +887,16 @@ def do_reject(*args, **kwargs):
     .. sourcecode:: jinja
 
         {{ numbers|reject("odd") }}
-
-    .. versionadded:: 2.7
     """
     return _select_or_reject(args, kwargs, lambda x: not x, False)
 
 
 @contextfilter
 def do_selectattr(*args, **kwargs):
-    """Filters a sequence of objects by applying a test to the specified
+    """
+    .. versionadded:: 2.7
+
+    Filters a sequence of objects by applying a test to the specified
     attribute of each object, and only selecting the objects with the
     test succeeding.
 
@@ -896,15 +909,16 @@ def do_selectattr(*args, **kwargs):
 
         {{ users|selectattr("is_active") }}
         {{ users|selectattr("email", "none") }}
-
-    .. versionadded:: 2.7
     """
     return _select_or_reject(args, kwargs, lambda x: x, True)
 
 
 @contextfilter
 def do_rejectattr(*args, **kwargs):
-    """Filters a sequence of objects by applying a test to the specified
+    """
+    .. versionadded:: 2.7
+
+    Filters a sequence of objects by applying a test to the specified
     attribute of each object, and rejecting the objects with the test
     succeeding.
 
@@ -915,8 +929,6 @@ def do_rejectattr(*args, **kwargs):
 
         {{ users|rejectattr("is_active") }}
         {{ users|rejectattr("email", "none") }}
-
-    .. versionadded:: 2.7
     """
     return _select_or_reject(args, kwargs, lambda x: not x, True)
 

--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -136,7 +136,11 @@ class BaseLoader(object):
 
 
 class FileSystemLoader(BaseLoader):
-    """Loads templates from the file system.  This loader can find templates
+    """
+    .. versionchanged:: 2.8+
+       The *followlinks* parameter was added.
+
+    Loads templates from the file system.  This loader can find templates
     in folders on the file system and is the preferred way to load them.
 
     The loader takes the path to the templates as string, or if multiple
@@ -152,9 +156,6 @@ class FileSystemLoader(BaseLoader):
     To follow symbolic links, set the *followlinks* parameter to ``True``::
 
     >>> loader = FileSystemLoader('/path/to/templates', followlinks=True)
-
-    .. versionchanged:: 2.8+
-       The *followlinks* parameter was added.
     """
 
     def __init__(self, searchpath, encoding='utf-8', followlinks=False):

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -357,15 +357,16 @@ class Expr(Node):
     abstract = True
 
     def as_const(self, eval_ctx=None):
-        """Return the value of the expression as constant or raise
+        """
+        .. versionchanged:: 2.4
+           the `eval_ctx` parameter was added.
+
+        Return the value of the expression as constant or raise
         :exc:`Impossible` if this was not possible.
 
         An :class:`EvalContext` can be provided, if none is given
         a default context is created which requires the nodes to have
         an attached environment.
-
-        .. versionchanged:: 2.4
-           the `eval_ctx` parameter was added.
         """
         raise Impossible()
 
@@ -851,10 +852,11 @@ class MarkSafe(Expr):
 
 
 class MarkSafeIfAutoescape(Expr):
-    """Mark the wrapped expression as safe (wrap it as `Markup`) but
-    only if autoescaping is active.
-
+    """
     .. versionadded:: 2.5
+
+    Mark the wrapped expression as safe (wrap it as `Markup`) but
+    only if autoescaping is active.
     """
     fields = ('expr',)
 

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -529,7 +529,10 @@ class Undefined(object):
 
 
 def make_logging_undefined(logger=None, base=None):
-    """Given a logger object this returns a new undefined class that will
+    """
+    .. versionadded:: 2.8
+
+    Given a logger object this returns a new undefined class that will
     log certain failures.  It will log iterations and printing.  If no
     logger is given a default logger is created.
 
@@ -540,8 +543,6 @@ def make_logging_undefined(logger=None, base=None):
             logger=logger,
             base=Undefined
         )
-
-    .. versionadded:: 2.8
 
     :param logger: the logger to use.  If not provided, a default logger
                    is created.

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -209,6 +209,8 @@ class SandboxedEnvironment(Environment):
         '-':        operator.neg
     }
 
+    #: .. versionadded:: 2.6
+    #:
     #: a set of binary operators that should be intercepted.  Each operator
     #: that is added to this set (empty by default) is delegated to the
     #: :meth:`call_binop` method that will perform the operator.  The default
@@ -222,9 +224,10 @@ class SandboxedEnvironment(Environment):
     #: operator call, so make sure only to intercept the ones you are
     #: interested in.
     #:
-    #: .. versionadded:: 2.6
     intercepted_binops = frozenset()
 
+    #: .. versionadded:: 2.6
+    #:
     #: a set of unary operators that should be intercepted.  Each operator
     #: that is added to this set (empty by default) is delegated to the
     #: :meth:`call_unop` method that will perform the operator.  The default
@@ -236,12 +239,13 @@ class SandboxedEnvironment(Environment):
     #: builtin function.  Intercepted calls are always slower than the native
     #: operator call, so make sure only to intercept the ones you are
     #: interested in.
-    #:
-    #: .. versionadded:: 2.6
     intercepted_unops = frozenset()
 
     def intercept_unop(self, operator):
-        """Called during template compilation with the name of a unary
+        """
+        .. versionadded:: 2.6
+
+        Called during template compilation with the name of a unary
         operator to check if it should be intercepted at runtime.  If this
         method returns `True`, :meth:`call_unop` is excuted for this unary
         operator.  The default implementation of :meth:`call_unop` will use
@@ -252,8 +256,6 @@ class SandboxedEnvironment(Environment):
 
         Intercepted calls are always slower than the native operator call,
         so make sure only to intercept the ones you are interested in.
-
-        .. versionadded:: 2.6
         """
         return False
 
@@ -283,20 +285,22 @@ class SandboxedEnvironment(Environment):
                     getattr(obj, 'alters_data', False))
 
     def call_binop(self, context, operator, left, right):
-        """For intercepted binary operator calls (:meth:`intercepted_binops`)
+        """
+        .. versionadded:: 2.6
+
+        For intercepted binary operator calls (:meth:`intercepted_binops`)
         this function is executed instead of the builtin operator.  This can
         be used to fine tune the behavior of certain operators.
-
-        .. versionadded:: 2.6
         """
         return self.binop_table[operator](left, right)
 
     def call_unop(self, context, operator, arg):
-        """For intercepted unary operator calls (:meth:`intercepted_unops`)
+        """
+        .. versionadded:: 2.6
+
+        For intercepted unary operator calls (:meth:`intercepted_unops`)
         this function is executed instead of the builtin operator.  This can
         be used to fine tune the behavior of certain operators.
-
-        .. versionadded:: 2.6
         """
         return self.unop_table[operator](arg)
 

--- a/jinja2/tests.py
+++ b/jinja2/tests.py
@@ -79,9 +79,10 @@ def test_string(value):
 
 
 def test_mapping(value):
-    """Return true if the object is a mapping (dict etc.).
-
+    """
     .. versionadded:: 2.6
+
+    Return true if the object is a mapping (dict etc.).
     """
     return isinstance(value, Mapping)
 
@@ -104,7 +105,10 @@ def test_sequence(value):
 
 
 def test_equalto(value, other):
-    """Check if an object has the same value as another object:
+    """
+    .. versionadded:: 2.8
+
+    Check if an object has the same value as another object:
 
     .. sourcecode:: jinja
 
@@ -119,8 +123,6 @@ def test_equalto(value, other):
     .. sourcecode:: jinja
 
         {{ users|selectattr("email", "equalto", "foo@bar.invalid") }}
-
-    .. versionadded:: 2.8
     """
     return value == other
 

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -55,13 +55,14 @@ def contextfunction(f):
 
 
 def evalcontextfunction(f):
-    """This decorator can be used to mark a function or method as an eval
+    """
+    .. versionadded:: 2.4
+
+    This decorator can be used to mark a function or method as an eval
     context callable.  This is similar to the :func:`contextfunction`
     but instead of passing the context, an evaluation context object is
     passed.  For more information about the eval context, see
     :ref:`eval-context`.
-
-    .. versionadded:: 2.4
     """
     f.evalcontextfunction = True
     return f


### PR DESCRIPTION
To someone reading the documentation, "how do I use Jinja" is their first question and "how do I accomplish a specific task" is their second question. When documented options are not available to most users yet, it's important for readability that disclaimers be treated as section headings, not footers. https://www.prismnet.com/~hcexres/textbook/headings.html

I realize that Python docs themselves put version info in the footer of each section, but I feel that is an anti-pattern unless the entire docs are versioned (I spent about 5 minutes futilely hunting for "Jinja 2.7 docs" -- the only docs I found are these "Warning: development version" docs.)

*tl;dr: version tags are top-level information, not footer-level information. Manuals are for people who are new, and may not understand your writing style yet.*

**This is a blind untested edit just to do the work I'm requesting be done; it should be double-checked and tested before merging.**