### PR TITLE
Prevent open_if_exists from raising an exception

### DIFF
--- a/jinja2/_compat.py
+++ b/jinja2/_compat.py
@@ -36,6 +36,7 @@ if not PY2:
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
         raise value
+    NotADirectoryError = NotADirectoryError
 
     ifilter = filter
     imap = map
@@ -62,6 +63,8 @@ else:
     NativeStringIO = BytesIO
 
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
+    class NotADirectoryError(Exception):
+        pass
 
     from itertools import imap, izip, ifilter
     intern = intern

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -13,7 +13,7 @@ import errno
 from collections import deque
 from threading import Lock
 from jinja2._compat import text_type, string_types, implements_iterator, \
-     url_quote
+     url_quote, NotADirectoryError
 
 
 _word_split_re = re.compile(r'(\s+)')

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -149,6 +149,8 @@ def open_if_exists(filename, mode='rb'):
     """
     try:
         return open(filename, mode)
+    except NotADirectoryError:
+        pass
     except IOError as e:
         if e.errno not in (errno.ENOENT, errno.EISDIR, errno.EINVAL):
             raise


### PR DESCRIPTION
If the directory filename supposedly lives in does not exist, open_if_exists raises a NotADirectoryError, which may, or may not, be the expected behavior.

Fixes #399, which caused https://github.com/noirbizarre/flask-restplus/issues/187 <- an exemple of client code where not raising the exception was the expected behavior.
