### PR TITLE
Fix a warning and a test failure.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,5 @@ universal = 1
 [aliases]
 release = egg_info -RDb ''
 
-[pytest]
+[tool:pytest]
 norecursedirs = .* *.egg *.egg-info env* artwork docs examples

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -133,7 +133,7 @@ class TestFilter():
                        'foo bar foo bar\n  foo bar foo bar')
 
     def test_int(self, env):
-        class IntIsh(object):
+        class IntIsh:
             def __int__(self):
                 return 42
 
@@ -141,7 +141,7 @@ class TestFilter():
                                '{{ "32.32"|int }}|{{ "0x4d32"|int(0, 16) }}|'
                                '{{ "011"|int(0, 8)}}|{{ "0x33FU"|int(0, 16) }}|'
                                '{{ obj|int }}')
-        out = tmpl.render(obj=IntIsh())
+        out = tmpl.render(obj=int(IntIsh()))
         assert out == '42|0|32|19762|9|0|42'
 
     def test_join(self, env):


### PR DESCRIPTION
Doing some test runs locally I ran into this failure in test_filters. I am using the same versions that are run on travis and I don't know why the failure does not show up there. I reduced to a simple test case and the IntIsh fails in Python 3.5.2. I don't know travis but I am curious to know why there's no failure there.

I ran pytest locally and encountered this failure.
