### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - pypy
   - "3.3"

--- a/docs/cache_extension.py
+++ b/docs/cache_extension.py
@@ -4,7 +4,7 @@ from jinja2.ext import Extension
 
 class FragmentCacheExtension(Extension):
     # a set of names that trigger the extension.
-    tags = set(['cache'])
+    tags = {'cache'}
 
     def __init__(self, environment):
         super(FragmentCacheExtension, self).__init__(environment)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -147,20 +147,21 @@ work in production environments::
 Credit for this snippet goes to `Thomas Johansson
 <http://stackoverflow.com/questions/3086091/debug-jinja2-in-google-app-engine/3694434#3694434>`_
 
-Why is there no Python 2.3/2.4/2.5/3.1/3.2 support?
+Why is there no Python 2.3/2.4/2.5/2.6/3.1/3.2 support?
 ---------------------------------------------------
 
 Python 2.3 is missing a lot of features that are used heavily in Jinja2.  This
-decision was made as with the upcoming Python 2.6 and 3.0 versions it becomes
-harder to maintain the code for older Python versions.  If you really need
-Python 2.3 support you either have to use `Jinja 1`_ or other templating
-engines that still support 2.3.
+decision was made because it becomes harder to maintain the code for older
+Python versions.  If you really need Python 2.3 support you either have to use
+`Jinja 1`_ or other templating engines that still support 2.3.
 
 Python 2.4/2.5/3.1/3.2 support was removed when we switched to supporting
 Python 2 and 3 by the same sourcecode (without using 2to3). It was required to
 drop support because only Python 2.6/2.7 and >=3.3 support byte and unicode
 literals in a way compatible to each other version. If you really need support
 for older Python 2 (or 3) versions, you can just use Jinja2 2.6.
+
+Python 2.6 support was removed once it was 3 years past end-of-life.
 
 My Macros are overridden by something
 -------------------------------------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -12,7 +12,7 @@ useful for templating environments.
 Prerequisites
 -------------
 
-Jinja2 works with Python 2.6.x, 2.7.x and >= 3.3.  If you are using Python
+Jinja2 works with Python 2.7.x and >= 3.3.  If you are using Python
 3.2 you can use an older release of Jinja2 (2.6) as support for Python 3.2
 was dropped in Jinja2 version 2.7.
 

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -155,7 +155,7 @@ def _make_new_ngettext(func):
 
 class InternationalizationExtension(Extension):
     """This extension adds gettext support to Jinja2."""
-    tags = set(['trans'])
+    tags = {'trans'}
 
     # TODO: the i18n extension is currently reevaluating values in a few
     # situations.  Take this example:
@@ -391,7 +391,7 @@ class ExprStmtExtension(Extension):
     """Adds a `do` tag to Jinja2 that works like the print statement just
     that it doesn't print the return value.
     """
-    tags = set(['do'])
+    tags = {'do'}
 
     def parse(self, parser):
         node = nodes.ExprStmt(lineno=next(parser.stream).lineno)
@@ -401,7 +401,7 @@ class ExprStmtExtension(Extension):
 
 class LoopControlExtension(Extension):
     """Adds break and continue to the template engine."""
-    tags = set(['break', 'continue'])
+    tags = {'break', 'continue'}
 
     def parse(self, parser):
         token = next(parser.stream)
@@ -412,7 +412,7 @@ class LoopControlExtension(Extension):
 
 class WithExtension(Extension):
     """Adds support for a django-like with block."""
-    tags = set(['with'])
+    tags = {'with'}
 
     def parse(self, parser):
         node = nodes.Scope(lineno=next(parser.stream).lineno)
@@ -433,7 +433,7 @@ class WithExtension(Extension):
 
 class AutoEscapeExtension(Extension):
     """Changes auto escape rules for a scope."""
-    tags = set(['autoescape'])
+    tags = {'autoescape'}
 
     def parse(self, parser):
         node = nodes.ScopedEvalContextModifier(lineno=next(parser.stream).lineno)

--- a/jinja2/lexer.py
+++ b/jinja2/lexer.py
@@ -129,7 +129,7 @@ operators = {
     ';':            TOKEN_SEMICOLON
 }
 
-reverse_operators = dict([(v, k) for k, v in iteritems(operators)])
+reverse_operators = {v: k for k, v in iteritems(operators)}
 assert len(operators) == len(reverse_operators), 'operators dropped'
 operator_re = re.compile('(%s)' % '|'.join(re.escape(x) for x in
                          sorted(operators, key=lambda x: -len(x))))

--- a/jinja2/meta.py
+++ b/jinja2/meta.py
@@ -39,7 +39,7 @@ def find_undeclared_variables(ast):
     >>> from jinja2 import Environment, meta
     >>> env = Environment()
     >>> ast = env.parse('{% set foo = 42 %}{{ bar + foo }}')
-    >>> meta.find_undeclared_variables(ast) == set(['bar'])
+    >>> meta.find_undeclared_variables(ast) == {'bar'}
     True
 
     .. admonition:: Implementation

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -24,8 +24,8 @@ MAX_RANGE = 100000
 
 #: attributes of function objects that are considered unsafe.
 if PY2:
-    UNSAFE_FUNCTION_ATTRIBUTES = set(['func_closure', 'func_code', 'func_dict',
-                                      'func_defaults', 'func_globals'])
+    UNSAFE_FUNCTION_ATTRIBUTES = {'func_closure', 'func_code', 'func_dict',
+                                  'func_defaults', 'func_globals'}
 else:
     # On versions > python 2 the special attributes on functions are gone,
     # but they remain on methods and generators for whatever reason.
@@ -33,16 +33,10 @@ else:
 
 
 #: unsafe method attributes.  function attributes are unsafe for methods too
-UNSAFE_METHOD_ATTRIBUTES = set(['im_class', 'im_func', 'im_self'])
+UNSAFE_METHOD_ATTRIBUTES = {'im_class', 'im_func', 'im_self'}
 
 #: unsafe generator attirbutes.
-UNSAFE_GENERATOR_ATTRIBUTES = set(['gi_frame', 'gi_code'])
-
-import warnings
-
-# make sure we don't warn in python 2.6 about stuff we don't care about
-warnings.filterwarnings('ignore', 'the sets module', DeprecationWarning,
-                        module='jinja2.sandbox')
+UNSAFE_GENERATOR_ATTRIBUTES = {'gi_frame', 'gi_code'}
 
 from collections import deque
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,14 +101,14 @@ class TestMeta():
     def test_find_undeclared_variables(self, env):
         ast = env.parse('{% set foo = 42 %}{{ bar + foo }}')
         x = meta.find_undeclared_variables(ast)
-        assert x == set(['bar'])
+        assert x == {'bar'}
 
         ast = env.parse('{% set foo = 42 %}{{ bar + foo }}'
                         '{% macro meh(x) %}{{ x }}{% endmacro %}'
                         '{% for item in seq %}{{ muh(item) + meh(seq) }}'
                         '{% endfor %}')
         x = meta.find_undeclared_variables(ast)
-        assert x == set(['bar', 'seq', 'muh'])
+        assert x == {'bar', 'seq', 'muh'}
 
     def test_find_refererenced_templates(self, env):
         ast = env.parse('{% extends "layout.html" %}{% include helper %}')

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -100,7 +100,7 @@ newstyle_i18n_env.install_gettext_callables(gettext, ngettext, newstyle=True)
 
 
 class ExampleExtension(Extension):
-    tags = set(['test'])
+    tags = {'test'}
     ext_attr = 42
 
     def parse(self, parser):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35
+envlist = py27,pypy,py33,py34,py35
 
 [testenv]
 commands = py.test {posargs}


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
