### PR TITLE
Don't skip an erroneous comma when parsing "from"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,11 +28,12 @@ Version 2.10
 - Add ``min`` and ``max`` filters. (`#475`_)
 - Add tests for all comparison operators: ``eq``, ``ne``, ``lt``, ``le``,
   ``gt``, ``ge``. (`#665`_)
-- ``import`` statement cannot end with a trailing comma. (`#618`_)
+- ``import`` statement cannot end with a trailing comma. (`#617`_, `#618`_)
 
 .. _#469: https://github.com/pallets/jinja/pull/469
 .. _#475: https://github.com/pallets/jinja/pull/475
 .. _#478: https://github.com/pallets/jinja/pull/478
+.. _#617: https://github.com/pallets/jinja/pull/617
 .. _#618: https://github.com/pallets/jinja/pull/618
 .. _#665: https://github.com/pallets/jinja/pull/665
 

--- a/jinja2/parser.py
+++ b/jinja2/parser.py
@@ -337,7 +337,6 @@ class Parser(object):
                 self.stream.expect('name')
         if not hasattr(node, 'with_context'):
             node.with_context = False
-            self.stream.skip_if('comma')
         return node
 
     def parse_signature(self, node):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -75,6 +75,12 @@ class TestImports(object):
         test_env.from_string('{% from "foo" import bar, with, context %}')
         test_env.from_string('{% from "foo" import bar, with with context %}')
 
+        with pytest.raises(TemplateSyntaxError):
+            test_env.from_string('{% from "foo" import bar,, with context %}')
+
+        with pytest.raises(TemplateSyntaxError):
+            test_env.from_string('{% from "foo" import bar with context, %}')
+
     def test_exports(self, test_env):
         m = test_env.from_string('''
             {% macro toplevel() %}...{% endmacro %}


### PR DESCRIPTION
Currently we skip an extra comma when "with context" is not provided to the "from" statement. This allows invalid code such as this:

``` django
{% from "functions.html" import my_function,, %}
```

The primary issue with this is that it is not consistent when providing "with context". The following code throws an error, contrary to the previous example:

``` django
{% from "functions.html" import my_function,, with context %}
```

It seems that the comma skipping was originally found in 0611e49 and was accidentally put inside the "with context" check in ea847c5. It was then updated to use "skip_if" in fdf9530.

There doesn't seem to be any reason for this check existing, as commas should never be allowed and serve no purpose in the statement.

Sadly this may be a "semi-breaking" change, as it removes some functionality that should have never existed and hopefully nobody relies on.

This PR ensures that both examples throw an error as expected.
