### PR TITLE
Add stricter checking to "from ... import ..."

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,10 +28,12 @@ Version 2.10
 - Add ``min`` and ``max`` filters. (`#475`_)
 - Add tests for all comparison operators: ``eq``, ``ne``, ``lt``, ``le``,
   ``gt``, ``ge``. (`#665`_)
+- ``import`` statement cannot end with a trailing comma. (`#618`_)
 
 .. _#469: https://github.com/pallets/jinja/pull/469
 .. _#475: https://github.com/pallets/jinja/pull/475
 .. _#478: https://github.com/pallets/jinja/pull/478
+.. _#618: https://github.com/pallets/jinja/pull/618
 .. _#665: https://github.com/pallets/jinja/pull/665
 
 Version 2.9.6

--- a/jinja2/parser.py
+++ b/jinja2/parser.py
@@ -334,7 +334,7 @@ class Parser(object):
                 if parse_context() or self.stream.current.type != 'comma':
                     break
             else:
-                break
+                self.stream.expect('name')
         if not hasattr(node, 'with_context'):
             node.with_context = False
             self.stream.skip_if('comma')

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -11,7 +11,8 @@
 import pytest
 
 from jinja2 import Environment, DictLoader
-from jinja2.exceptions import TemplateNotFound, TemplatesNotFound
+from jinja2.exceptions import TemplateNotFound, TemplatesNotFound, \
+    TemplateSyntaxError
 
 
 @pytest.fixture
@@ -50,7 +51,24 @@ class TestImports(object):
         )
         assert t.render(foo=42) == '[42|23]'
 
-    def test_trailing_comma(self, test_env):
+    def test_import_needs_name(self, test_env):
+        test_env.from_string('{% from "foo" import bar %}')
+        test_env.from_string('{% from "foo" import bar, baz %}')
+
+        with pytest.raises(TemplateSyntaxError):
+            test_env.from_string('{% from "foo" import %}')
+
+    def test_no_trailing_comma(self, test_env):
+        with pytest.raises(TemplateSyntaxError):
+            test_env.from_string('{% from "foo" import bar, %}')
+
+        with pytest.raises(TemplateSyntaxError):
+            test_env.from_string('{% from "foo" import bar,, %}')
+
+        with pytest.raises(TemplateSyntaxError):
+            test_env.from_string('{% from "foo" import, %}')
+
+    def test_trailing_comma_with_context(self, test_env):
         test_env.from_string('{% from "foo" import bar, baz with context %}')
         test_env.from_string('{% from "foo" import bar, baz, with context %}')
         test_env.from_string('{% from "foo" import bar, with context %}')


### PR DESCRIPTION
Currently token parsing on "from ... import ..." is rather loose — it sees the following invalid code as perfectly valid:

``` django
{% from "functions" import my_function, %}
{% from "functions" import, %}
{% from "functions" import %}
```

This is caused by the parser ignoring non-name values where there should be names, either as the first value or after commas.

This PR ensures only name values are allowed as the first value and any values after commas in the import section.

Sadly this may be a "semi-breaking" change, as it removes some functionality that should have never existed and hopefully nobody relies on.
