### PR TITLE
Add support for preserving context when importing

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1001,10 +1001,21 @@ This behavior can be changed explicitly: by adding `with context`
 or `without context` to the import/include directive, the current context
 can be passed to the template and caching is disabled automatically.
 
-Here are two examples::
+Internally the *parent* context is passed to the imported / included template.
+This is usually the same as passing the context itself, except in the situation
+of variables defined in the template.  Normally, variables defined in the
+template are perfectly accessible inside the imported / included template.
+The main difference is noticeable when importing / including inside a block —
+the variables defined in the template are no longer accessible!  This can be
+fixed by telling the template engine to pass the current context instead of the
+parent context by using `keep context`.
+
+Here are a few examples::
 
     {% from 'forms.html' import input with context %}
     {% include 'header.html' without context %}
+    {% from 'forms.html' import input keep context %}
+    {% include 'header.html' keep context %}
 
 .. admonition:: Note
 

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -953,9 +953,10 @@ class CodeGenerator(NodeVisitor):
             self.indent()
 
         if node.with_context:
+            context_value = node.keep_context and 'context' or 'context.parent'
             self.writeline('for event in template.root_render_func('
-                           'template.new_context(context.parent, True, '
-                           'locals())):')
+                           'template.new_context(%s, True, '
+                           'locals())):' % context_value)
         else:
             self.writeline('for event in template.module._body_stream:')
 
@@ -977,7 +978,8 @@ class CodeGenerator(NodeVisitor):
         self.visit(node.template, frame)
         self.write(', %r).' % self.name)
         if node.with_context:
-            self.write('make_module(context.parent, True, locals())')
+            context_value = node.keep_context and 'context' or 'context.parent'
+            self.write('make_module(%s, True, locals())' % context_value)
         else:
             self.write('module')
         if frame.toplevel and not node.target.startswith('_'):
@@ -990,8 +992,9 @@ class CodeGenerator(NodeVisitor):
         self.write('included_template = environment.get_template(')
         self.visit(node.template, frame)
         self.write(', %r).' % self.name)
-        if node.with_context:
-            self.write('make_module(context.parent, True)')
+        if node.with_context or node.keep_context:
+            context_value = node.keep_context and 'context' or 'context.parent'
+            self.write('make_module(%s, True)' % context_value)
         else:
             self.write('module')
 

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -315,12 +315,12 @@ class Block(Stmt):
 
 class Include(Stmt):
     """A node that represents the include tag."""
-    fields = ('template', 'with_context', 'ignore_missing')
+    fields = ('template', 'with_context', 'keep_context', 'ignore_missing')
 
 
 class Import(Stmt):
     """A node that represents the import tag."""
-    fields = ('template', 'target', 'with_context')
+    fields = ('template', 'target', 'with_context', 'keep_context')
 
 
 class FromImport(Stmt):
@@ -334,7 +334,7 @@ class FromImport(Stmt):
 
     The list of names may contain tuples if aliases are wanted.
     """
-    fields = ('template', 'names', 'with_context')
+    fields = ('template', 'names', 'with_context', 'keep_context')
 
 
 class ExprStmt(Stmt):

--- a/jinja2/parser.py
+++ b/jinja2/parser.py
@@ -238,12 +238,16 @@ class Parser(object):
         return node
 
     def parse_import_context(self, node, default):
-        if self.stream.current.test_any('name:with', 'name:without') and \
+        if self.stream.current.test_any('name:with', 'name:without',
+                                        'name:keep') and \
            self.stream.look().test('name:context'):
-            node.with_context = next(self.stream).value == 'with'
+            token_value = next(self.stream).value
+            node.with_context = token_value in ('with', 'keep')
+            node.keep_context = token_value == 'keep'
             self.stream.skip()
         else:
             node.with_context = default
+            node.keep_context = False
         return node
 
     def parse_include(self):
@@ -271,9 +275,11 @@ class Parser(object):
         node.names = []
 
         def parse_context():
-            if self.stream.current.value in ('with', 'without') and \
+            if self.stream.current.value in ('with', 'without', 'keep') and \
                self.stream.look().test('name:context'):
-                node.with_context = next(self.stream).value == 'with'
+                token_value = next(self.stream).value
+                node.with_context = token_value in ('with', 'keep')
+                node.keep_context = token_value == 'keep'
                 self.stream.skip()
                 return True
             return False
@@ -301,6 +307,8 @@ class Parser(object):
         if not hasattr(node, 'with_context'):
             node.with_context = False
             self.stream.skip_if('comma')
+        if not hasattr(node, 'keep_context'):
+            node.keep_context = False
         return node
 
     def parse_signature(self, node):


### PR DESCRIPTION
Contrary to the documentation on the subject (see [Import Context Behavior](http://jinja.pocoo.org/docs/dev/templates/#import-visibility)), the context's _parent_ is currently passed to imported / included templates. This has the unintended side effect of variables defined in the template being inaccessible inside includes that are inside blocks (see #352 and #603).

This PR adds the `keep context` option to imports and includes, which tells the template engine to pass the current context instead of the parent context to the imported / included templates:

``` django
{% from "functions.html" import my_function keep context %}
{% import "functions.html" keep context %}
{% include "partial.html" keep context %}
```

This PR fixes #352 and #603 and should not be a breaking change.
