### PR TITLE
Add test for greater/less than

### DIFF
--- a/jinja2/tests.py
+++ b/jinja2/tests.py
@@ -152,6 +152,16 @@ def test_escaped(value):
     return hasattr(value, '__html__')
 
 
+def test_greaterthan(value, other):
+    """Check if value is greater than other."""
+    return value > other
+
+
+def test_lessthan(value, other):
+    """Check if value is less than other."""
+    return value < other
+
+
 TESTS = {
     'odd':              test_odd,
     'even':             test_even,
@@ -169,5 +179,7 @@ TESTS = {
     'callable':         test_callable,
     'sameas':           test_sameas,
     'equalto':          test_equalto,
-    'escaped':          test_escaped
+    'escaped':          test_escaped,
+    'greaterthan':      test_greaterthan,
+    'lessthan':         test_lessthan
 }

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -102,3 +102,13 @@ class TestTestsCase():
         env = Environment(autoescape=True)
         tmpl = env.from_string('{{ x is escaped }}|{{ y is escaped }}')
         assert tmpl.render(x='foo', y=Markup('foo')) == 'False|True'
+
+    def test_greaterthan(self, env):
+        tmpl = env.from_string('{{ 1 is greaterthan 0 }}|'
+                               '{{ 0 is greaterthan 1 }}')
+        assert tmpl.render() == 'True|False'
+
+    def test_lessthan(self, env):
+        tmpl = env.from_string('{{ 0 is lessthan 1 }}|'
+                               '{{ 1 is lessthan 0 }}')
+        assert tmpl.render() == 'True|False'


### PR DESCRIPTION
It can be helpful to have a test for values that are greater or less than
another value, especially when looping over lists and using `select()` or
`selectattr()` filters. This patch adds tests that allow a developer to
check if a value is greater or less than another value.

For example, if I have a list of vehicles and I want to find the motorcycles:

    vehicles | selectattr('wheels', 'lessthan', 3)

Or, if I want to find large trucks:

    vehicles | selectattr('wheels', 'greaterthan', 4)

Tests are included.