### PR TITLE
Uses re.compile flags argument, not inline flags

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -21,8 +21,8 @@ from jinja2.exceptions import FilterArgumentError
 from jinja2._compat import imap, string_types, text_type, iteritems
 
 
-_word_re = re.compile(r'\w+(?u)')
-_word_beginning_split_re = re.compile(r'([-\s\(\{\[\<]+)(?u)')
+_word_re = re.compile(r'\w+', re.UNICODE)
+_word_beginning_split_re = re.compile(r'([-\s\(\{\[\<]+)', re.UNICODE)
 
 
 def contextfilter(f):


### PR DESCRIPTION
This commit replaces the use of terminal inline flags in a regular expression in
`re.compile`,

    re.compile(r'\w+(?u)')

with arguments to the `re.compile` function itself,

    re.compile(r'\w+', re.UNICODE)

because the former is deprecated as of Python 3.6 (see https://bugs.python.org/issue22493).