### PR TITLE
Add async Support to Jinja 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install tox
 script:

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Version 2.9
   (Python 3.5 and later)
 - Corrected a long standing issue with operator precedence of math operations
   not being what was expected.
+- Added support for Python 3.6 async iterators through a new async mode.
 
 Version 2.8.1
 -------------

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	py.test tests
+	py.test tests --tb=short
 
 develop:
 	pip install --editable .

--- a/jinja2/__init__.py
+++ b/jinja2/__init__.py
@@ -68,3 +68,14 @@ __all__ = [
     'environmentfunction', 'contextfunction', 'clear_caches', 'is_undefined',
     'evalcontextfilter', 'evalcontextfunction', 'make_logging_undefined',
 ]
+
+
+def _patch_async():
+    from jinja2.utils import have_async_gen
+    if have_async_gen:
+        from jinja2.asyncsupport import patch_all
+        patch_all()
+
+
+_patch_async()
+del _patch_async

--- a/jinja2/asyncfilters.py
+++ b/jinja2/asyncfilters.py
@@ -1,0 +1,34 @@
+from functools import wraps
+from jinja2.asyncsupport import auto_aiter
+from jinja2 import filters
+
+
+async def auto_to_seq(value):
+    seq = []
+    if hasattr(value, '__aiter__'):
+        async for item in value:
+            seq.append(item)
+    else:
+        for item in value:
+            seq.append(item)
+    return seq
+
+
+async def async_do_first(environment, seq):
+    try:
+        return await auto_aiter(seq).__anext__()
+    except StopAsyncIteration:
+        return environment.undefined('No first item, sequence was empty.')
+
+
+@wraps(filters.do_first)
+@filters.environmentfilter
+def do_first(environment, seq):
+    if environment.is_async:
+        return async_do_first(environment, seq)
+    return filters.do_first(environment, seq)
+
+
+ASYNC_FILTERS = {
+    'first': do_first,
+}

--- a/jinja2/asyncfilters.py
+++ b/jinja2/asyncfilters.py
@@ -1,4 +1,5 @@
 from functools import wraps
+
 from jinja2.asyncsupport import auto_aiter
 from jinja2 import filters
 
@@ -53,6 +54,15 @@ async def do_first(environment, seq):
         return environment.undefined('No first item, sequence was empty.')
 
 
+@asyncfiltervariant(filters.do_groupby)
+async def do_groupby(environment, value, attribute):
+    expr = filters.make_attrgetter(environment, attribute)
+    return [filters._GroupTuple(key, await auto_to_seq(values))
+            for key, values in filters.groupby(sorted(
+                await auto_to_seq(value), key=expr), expr)]
+
+
 ASYNC_FILTERS = {
     'first':        do_first,
+    'groupby':      do_groupby,
 }

--- a/jinja2/asyncfilters.py
+++ b/jinja2/asyncfilters.py
@@ -122,6 +122,11 @@ async def do_sum(environment, iterable, attribute=None, start=0):
     return rv
 
 
+@asyncfiltervariant(filters.do_slice)
+async def do_slice(value, slices, fill_with=None):
+    return filters.do_slice(await auto_to_seq(value), slices, fill_with)
+
+
 ASYNC_FILTERS = {
     'first':        do_first,
     'groupby':      do_groupby,
@@ -135,4 +140,5 @@ ASYNC_FILTERS = {
     'select':       do_select,
     'selectattr':   do_selectattr,
     'sum':          do_sum,
+    'slice':        do_slice,
 }

--- a/jinja2/asyncfilters.py
+++ b/jinja2/asyncfilters.py
@@ -87,12 +87,33 @@ async def do_rejectattr(*args, **kwargs):
     return async_select_or_reject(args, kwargs, lambda x: not x, True)
 
 
+@asyncfiltervariant(filters.do_select)
+async def do_select(*args, **kwargs):
+    return async_select_or_reject(args, kwargs, lambda x: x, False)
+
+
+@asyncfiltervariant(filters.do_selectattr)
+async def do_selectattr(*args, **kwargs):
+    return async_select_or_reject(args, kwargs, lambda x: x, True)
+
+
+@asyncfiltervariant(filters.do_map)
+async def do_map(*args, **kwargs):
+    seq, func = filters.prepare_map(args, kwargs)
+    if seq:
+        async for item in seq:
+            yield func(item)
+
+
 ASYNC_FILTERS = {
     'first':        do_first,
     'groupby':      do_groupby,
     'join':         do_join,
     # we intentionally do not support do_last because that would be
     # ridiculous
-    'reject':               do_reject,
-    'rejectattr':           do_rejectattr,
+    'reject':       do_reject,
+    'rejectattr':   do_rejectattr,
+    'map':          do_map,
+    'select':       do_select,
+    'selectattr':   do_selectattr,
 }

--- a/jinja2/asyncfilters.py
+++ b/jinja2/asyncfilters.py
@@ -17,11 +17,11 @@ async def auto_to_seq(value):
 
 def dualfilter(normal_filter, async_filter):
     wrap_evalctx = False
-    if getattr(normal_filter, 'environmentfilter'):
+    if getattr(normal_filter, 'environmentfilter', False):
         is_async = lambda args: args[0].is_async
         wrap_evalctx = False
     else:
-        if not getattr(normal_filter, 'evalcontextfilter'):
+        if not getattr(normal_filter, 'evalcontextfilter', False):
             wrap_evalctx = True
         is_async = lambda args: args[0].environment.is_async
 
@@ -62,7 +62,13 @@ async def do_groupby(environment, value, attribute):
                 await auto_to_seq(value), key=expr), expr)]
 
 
+@asyncfiltervariant(filters.do_join)
+async def do_join(eval_ctx, value, d=u'', attribute=None):
+    return filters.do_join(eval_ctx, await auto_to_seq(value), d, attribute)
+
+
 ASYNC_FILTERS = {
     'first':        do_first,
     'groupby':      do_groupby,
+    'join':         do_join,
 }

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -1,0 +1,43 @@
+import sys
+import asyncio
+
+from jinja2.utils import concat
+
+
+async def render_async(self, *args, **kwargs):
+    if not self.environment._async:
+        raise RuntimeError('The environment was not created with async mode '
+                           'enabled.')
+
+    vars = dict(*args, **kwargs)
+    ctx = self.new_context(vars)
+    rv = []
+    async def collect():
+        async for event in self.root_render_func(ctx):
+            rv.append(event)
+
+    try:
+        await collect()
+        return concat(rv)
+    except Exception:
+        exc_info = sys.exc_info()
+    return self.environment.handle_exception(exc_info, True)
+
+
+def wrap_render_func(original_render):
+    def render(self, *args, **kwargs):
+        if not self.environment._async:
+            return original_render(self, *args, **kwargs)
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.render_async(self, *args, **kwargs))
+    return render
+
+
+def patch_template():
+    from jinja2 import Template
+    Template.render_async = render_async
+    Template.render = wrap_render_func(Template.render)
+
+
+def patch_all():
+    patch_template()

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -64,6 +64,13 @@ async def get_default_module_async(self):
     return rv
 
 
+@internalcode
+def get_default_module_impl(self):
+    if self.environment._async:
+        return self._get_default_module_async()
+    return self._get_default_module()
+
+
 def wrap_default_module(original_default_module):
     @internalcode
     def _get_default_module(self):
@@ -89,6 +96,7 @@ def patch_template():
     Template._get_default_module = wrap_default_module(
         Template._get_default_module)
     Template._get_default_module_async = get_default_module_async
+    Template._get_default_module_impl = get_default_module_impl
     Template.make_module_async = make_module_async
 
 

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -64,13 +64,6 @@ async def get_default_module_async(self):
     return rv
 
 
-@internalcode
-def get_default_module_impl(self):
-    if self.environment._async:
-        return self._get_default_module_async()
-    return self._get_default_module()
-
-
 def wrap_default_module(original_default_module):
     @internalcode
     def _get_default_module(self):
@@ -84,7 +77,7 @@ def wrap_default_module(original_default_module):
 async def make_module_async(self, vars=None, shared=False, locals=None):
     context = self.new_context(vars, shared, locals)
     body_stream = []
-    async for item in template.root_render_func(context):
+    async for item in self.root_render_func(context):
         body_stream.append(item)
     return TemplateModule(self, context, body_stream)
 
@@ -96,7 +89,6 @@ def patch_template():
     Template._get_default_module = wrap_default_module(
         Template._get_default_module)
     Template._get_default_module_async = get_default_module_async
-    Template._get_default_module_impl = get_default_module_impl
     Template.make_module_async = make_module_async
 
 

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -135,3 +135,12 @@ async def auto_await(value):
     if inspect.isawaitable(value):
         return await value
     return value
+
+
+async def auto_iter(iterable):
+    if hasattr(iterable, '__aiter__'):
+        async for item in iterable:
+            yield item
+        return
+    for item in iterable:
+        yield item

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -2,7 +2,16 @@ import sys
 import asyncio
 import inspect
 
-from jinja2.utils import concat
+from jinja2.utils import concat, internalcode, concat, Markup
+
+
+async def concat_async(async_gen):
+    rv = []
+    async def collect():
+        async for event in async_gen:
+            rv.append(event)
+    await collect()
+    return concat(rv)
 
 
 async def render_async(self, *args, **kwargs):
@@ -12,14 +21,9 @@ async def render_async(self, *args, **kwargs):
 
     vars = dict(*args, **kwargs)
     ctx = self.new_context(vars)
-    rv = []
-    async def collect():
-        async for event in self.root_render_func(ctx):
-            rv.append(event)
 
     try:
-        await collect()
-        return concat(rv)
+        return await concat_async(self.root_render_func(ctx))
     except Exception:
         exc_info = sys.exc_info()
     return self.environment.handle_exception(exc_info, True)
@@ -34,14 +38,37 @@ def wrap_render_func(original_render):
     return render
 
 
+def wrap_block_reference_call(original_call):
+    @internalcode
+    async def async_call(self):
+        rv = await concat_async(self._stack[self._depth](self._context))
+        if self._context.eval_ctx.autoescape:
+            rv = Markup(rv)
+        return rv
+
+    @internalcode
+    def __call__(self):
+        if not self._context.environment._async:
+            return original_call(self)
+        return async_call(self)
+
+    return __call__
+
+
 def patch_template():
     from jinja2 import Template
     Template.render_async = render_async
     Template.render = wrap_render_func(Template.render)
 
 
+def patch_runtime():
+    from jinja2.runtime import BlockReference
+    BlockReference.__call__ = wrap_block_reference_call(BlockReference.__call__)
+
+
 def patch_all():
     patch_template()
+    patch_runtime()
 
 
 async def auto_await(value):

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -49,14 +49,14 @@ def wrap_generate_func(original_generate):
         except StopAsyncIteration:
             pass
     def generate(self, *args, **kwargs):
-        if not self.environment._async:
+        if not self.environment.is_async:
             return original_generate(self, *args, **kwargs)
         return _convert_generator(self, asyncio.get_event_loop(), args, kwargs)
     return update_wrapper(generate, original_generate)
 
 
 async def render_async(self, *args, **kwargs):
-    if not self.environment._async:
+    if not self.environment.is_async:
         raise RuntimeError('The environment was not created with async mode '
                            'enabled.')
 
@@ -72,7 +72,7 @@ async def render_async(self, *args, **kwargs):
 
 def wrap_render_func(original_render):
     def render(self, *args, **kwargs):
-        if not self.environment._async:
+        if not self.environment.is_async:
             return original_render(self, *args, **kwargs)
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(self.render_async(*args, **kwargs))
@@ -89,7 +89,7 @@ def wrap_block_reference_call(original_call):
 
     @internalcode
     def __call__(self):
-        if not self._context.environment._async:
+        if not self._context.environment.is_async:
             return original_call(self)
         return async_call(self)
 
@@ -107,7 +107,7 @@ async def get_default_module_async(self):
 def wrap_default_module(original_default_module):
     @internalcode
     def _get_default_module(self):
-        if self.environment._async:
+        if self.environment.is_async:
             raise RuntimeError('Template module attribute is unavailable '
                                'in async mode')
         return original_default_module(self)

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -1,5 +1,6 @@
 import sys
 import asyncio
+import inspect
 
 from jinja2.utils import concat
 
@@ -41,3 +42,9 @@ def patch_template():
 
 def patch_all():
     patch_template()
+
+
+async def auto_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -34,7 +34,7 @@ def wrap_render_func(original_render):
         if not self.environment._async:
             return original_render(self, *args, **kwargs)
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(self.render_async(self, *args, **kwargs))
+        return loop.run_until_complete(self.render_async(*args, **kwargs))
     return render
 
 

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -139,12 +139,20 @@ def patch_template():
 
 def patch_runtime():
     from jinja2.runtime import BlockReference
-    BlockReference.__call__ = wrap_block_reference_call(BlockReference.__call__)
+    BlockReference.__call__ = wrap_block_reference_call(
+        BlockReference.__call__)
+
+
+def patch_filters():
+    from jinja2.filters import FILTERS
+    from jinja2.asyncfilters import ASYNC_FILTERS
+    FILTERS.update(ASYNC_FILTERS)
 
 
 def patch_all():
     patch_template()
     patch_runtime()
+    patch_filters()
 
 
 async def auto_await(value):

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -971,10 +971,11 @@ class CodeGenerator(NodeVisitor):
             self.writeline('else:')
             self.indent()
 
+        loop = self.environment._async and 'async for' or 'for'
         if node.with_context:
-            self.writeline('for event in template.root_render_func('
+            self.writeline('%s event in template.root_render_func('
                            'template.new_context(context.parent, True, '
-                           'locals())):')
+                           'locals())):' % loop)
         else:
             self.writeline('for event in template._get_default_module()'
                            '._body_stream:')
@@ -999,7 +1000,7 @@ class CodeGenerator(NodeVisitor):
         if node.with_context:
             self.write('make_module(context.parent, True, locals())')
         else:
-            self.write('module')
+            self.write('_get_default_module()')
         if frame.toplevel and not node.target.startswith('_'):
             self.writeline('context.exported_vars.discard(%r)' % node.target)
         frame.assigned_names.add(node.target)
@@ -1013,7 +1014,7 @@ class CodeGenerator(NodeVisitor):
         if node.with_context:
             self.write('make_module(context.parent, True)')
         else:
-            self.write('module')
+            self.write('_get_default_module()')
 
         var_names = []
         discarded_names = []

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -47,6 +47,13 @@ try:
 except SyntaxError:
     pass
 
+# does this python version support async for in and async generators?
+try:
+    exec('async def _():\n async for _ in ():\n  yield _')
+    have_async_gen = True
+except SyntaxError:
+    have_async_gen = False
+
 
 # does if 0: dummy(x) get us x into the scope?
 def unoptimize_before_dead_code():

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1145,7 +1145,7 @@ class CodeGenerator(NodeVisitor):
         # "outer frame".
         if extended_loop and node.test is not None:
             if self.environment._async:
-                self.fail('loop filters in async mode are currently if the '
+                self.fail('loop filters in async mode are unavailable if the '
                           'loop uses the special "loop" variable or is '
                           'recursive.', node.lineno)
             self.write('(')

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1615,6 +1615,8 @@ class CodeGenerator(NodeVisitor):
             self.visit(node.step, frame)
 
     def visit_Filter(self, node, frame):
+        if self.environment.is_async:
+            self.write('await auto_await(')
         self.write(self.filters[node.name] + '(')
         func = self.environment.filters.get(node.name)
         if func is None:
@@ -1640,6 +1642,8 @@ class CodeGenerator(NodeVisitor):
             self.write('concat(%s)' % frame.buffer)
         self.signature(node, frame)
         self.write(')')
+        if self.environment.is_async:
+            self.write(')')
 
     def visit_Test(self, node, frame):
         self.write(self.tests[node.name] + '(')

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -782,6 +782,9 @@ class CodeGenerator(NodeVisitor):
         if not unoptimize_before_dead_code:
             self.writeline('dummy = lambda *x: None')
 
+        if self.environment._async:
+            self.writeline('from jinja2.asyncsupport import auto_await')
+
         # if we want a deferred initialization we cannot move the
         # environment into a local name
         envenv = not self.defer_init and ', environment=environment' or ''
@@ -1625,6 +1628,8 @@ class CodeGenerator(NodeVisitor):
         self.write(')')
 
     def visit_Call(self, node, frame, forward_caller=False):
+        if self.environment._async:
+            self.write('await auto_await(')
         if self.environment.sandboxed:
             self.write('environment.call(context, ')
         else:
@@ -1633,6 +1638,8 @@ class CodeGenerator(NodeVisitor):
         extra_kwargs = forward_caller and {'caller': 'caller'} or None
         self.signature(node, frame, extra_kwargs)
         self.write(')')
+        if self.environment._async:
+            self.write(')')
 
     def visit_Keyword(self, node, frame):
         self.write(node.key + '=')

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -976,7 +976,8 @@ class CodeGenerator(NodeVisitor):
                            'template.new_context(context.parent, True, '
                            'locals())):')
         else:
-            self.writeline('for event in template._get_default_module()._body_stream:')
+            self.writeline('for event in template._get_default_module()'
+                           '._body_stream:')
 
         self.indent()
         self.simple_write('event', frame)

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -976,7 +976,7 @@ class CodeGenerator(NodeVisitor):
                            'template.new_context(context.parent, True, '
                            'locals())):')
         else:
-            self.writeline('for event in template.module._body_stream:')
+            self.writeline('for event in template._get_default_module()._body_stream:')
 
         self.indent()
         self.simple_write('event', frame)

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -887,8 +887,10 @@ class CodeGenerator(NodeVisitor):
                 self.indent()
                 level += 1
         context = node.scoped and 'context.derived(locals())' or 'context'
-        self.writeline('for event in context.blocks[%r][0](%s):' % (
-                       node.name, context), node)
+
+        loop = self.environment._async and 'async for' or 'for'
+        self.writeline('%s event in context.blocks[%r][0](%s):' % (
+                       loop, node.name, context), node)
         self.indent()
         self.simple_write('event', frame)
         self.outdent(level)

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1042,6 +1042,10 @@ class Template(object):
         self._module = rv = self.make_module()
         return rv
 
+    # This is what the compiler dispatches to from generated code.  It
+    # might get swapped out by the async support
+    _get_default_module_impl = _get_default_module
+
     @property
     def module(self):
         """The template as module.  This is used for imports in the

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -991,6 +991,11 @@ class Template(object):
             exc_info = sys.exc_info()
         return self.environment.handle_exception(exc_info, True)
 
+    def render_async(self, *args, **kwargs):
+        # see asyncsupport for the actual implementation
+        raise NotImplementedError('This feature is not available for this '
+                                  'version of Python')
+
     def stream(self, *args, **kwargs):
         """Works exactly like :meth:`generate` but returns a
         :class:`TemplateStream`.
@@ -1015,6 +1020,11 @@ class Template(object):
             return
         yield self.environment.handle_exception(exc_info, True)
 
+    def generate_async(self, *args, **kwargs):
+        # see asyncsupport for the actual implementation
+        raise NotImplementedError('This feature is not available for this '
+                                  'version of Python')
+
     def new_context(self, vars=None, shared=False, locals=None):
         """Create a new :class:`Context` for this template.  The vars
         provided will be passed to the template.  Per default the globals
@@ -1034,6 +1044,11 @@ class Template(object):
         as for the :meth:`new_context` method.
         """
         return TemplateModule(self, self.new_context(vars, shared, locals))
+
+    def make_module_async(self, vars=None, shared=False, locals=None):
+        # see asyncsupport for the actual implementation
+        raise NotImplementedError('This feature is not available for this '
+                                  'version of Python')
 
     @internalcode
     def _get_default_module(self):

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -217,6 +217,11 @@ class Environment(object):
             have to be parsed if they were not changed.
 
             See :ref:`bytecode-cache` for more information.
+
+        `enable_async`
+            If set to true this enables async template execution which allows
+            you to take advantage of newer Python features.  This requires
+            Python 3.6 or later.
     """
 
     #: if this environment is sandboxed.  Modifying this variable won't make
@@ -268,7 +273,8 @@ class Environment(object):
                  loader=None,
                  cache_size=400,
                  auto_reload=True,
-                 bytecode_cache=None):
+                 bytecode_cache=None,
+                 enable_async=False):
         # !!Important notice!!
         #   The constructor accepts quite a few arguments that should be
         #   passed by keyword rather than position.  However it's important to
@@ -313,6 +319,8 @@ class Environment(object):
 
         # load extensions
         self.extensions = load_extensions(self, extensions)
+
+        self.enable_async = enable_async
 
         _environment_sanity_check(self)
 
@@ -908,14 +916,15 @@ class Template(object):
                 optimized=True,
                 undefined=Undefined,
                 finalize=None,
-                autoescape=False):
+                autoescape=False,
+                enable_async=False):
         env = get_spontaneous_environment(
             block_start_string, block_end_string, variable_start_string,
             variable_end_string, comment_start_string, comment_end_string,
             line_statement_prefix, line_comment_prefix, trim_blocks,
             lstrip_blocks, newline_sequence, keep_trailing_newline,
             frozenset(extensions), optimized, undefined, finalize, autoescape,
-            None, 0, False, None)
+            None, 0, False, None, enable_async)
         return env.from_string(source, template_class=cls)
 
     @classmethod

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1097,7 +1097,9 @@ class TemplateModule(object):
         if body_stream is None:
             if context.environment._async:
                 raise RuntimeError('Async mode requires a body stream '
-                                   'to be passed in.')
+                                   'to be passed to a template module.  Use '
+                                   'the async methods of the API you are '
+                                   'using.')
             body_stream = list(template.root_render_func(context))
         self._body_stream = body_stream
         self.__dict__.update(context.get_exported())

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -427,6 +427,11 @@ class Environment(object):
                     context=None, eval_ctx=None):
         """Invokes a filter on a value the same way the compiler does it.
 
+        Note that on Python 3 this might return a coroutine in case the
+        filter is running from an environment in async mode and the filter
+        supports async execution.  It's your responsibility to await this
+        if needed.
+
         .. versionadded:: 2.7
         """
         func = self.filters.get(name)

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -28,7 +28,7 @@ from jinja2.runtime import Undefined, new_context, Context
 from jinja2.exceptions import TemplateSyntaxError, TemplateNotFound, \
      TemplatesNotFound, TemplateRuntimeError
 from jinja2.utils import import_string, LRUCache, Markup, missing, \
-     concat, consume, internalcode
+     concat, consume, internalcode, have_async_gen
 from jinja2._compat import imap, ifilter, string_types, iteritems, \
      text_type, reraise, implements_iterator, implements_to_string, \
      encode_filename, PY2, PYPY
@@ -321,6 +321,7 @@ class Environment(object):
         self.extensions = load_extensions(self, extensions)
 
         self.enable_async = enable_async
+        self._async = self.enable_async and have_async_gen
 
         _environment_sanity_check(self)
 

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1042,10 +1042,6 @@ class Template(object):
         self._module = rv = self.make_module()
         return rv
 
-    # This is what the compiler dispatches to from generated code.  It
-    # might get swapped out by the async support
-    _get_default_module_impl = _get_default_module
-
     @property
     def module(self):
         """The template as module.  This is used for imports in the

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1035,6 +1035,12 @@ class Template(object):
         """
         return TemplateModule(self, self.new_context(vars, shared, locals))
 
+    def _get_default_module(self):
+        if self._module is not None:
+            return self._module
+        self._module = rv = self.make_module()
+        return rv
+
     @property
     def module(self):
         """The template as module.  This is used for imports in the
@@ -1047,10 +1053,7 @@ class Template(object):
         >>> t.module.foo() == u'42'
         True
         """
-        if self._module is not None:
-            return self._module
-        self._module = rv = self.make_module()
-        return rv
+        return self._get_default_module()
 
     def get_corresponding_lineno(self, lineno):
         """Return the source line number of a line number in the

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -321,7 +321,7 @@ class Environment(object):
         self.extensions = load_extensions(self, extensions)
 
         self.enable_async = enable_async
-        self._async = self.enable_async and have_async_gen
+        self.is_async = self.enable_async and have_async_gen
 
         _environment_sanity_check(self)
 
@@ -1128,7 +1128,7 @@ class TemplateModule(object):
 
     def __init__(self, template, context, body_stream=None):
         if body_stream is None:
-            if context.environment._async:
+            if context.environment.is_async:
                 raise RuntimeError('Async mode requires a body stream '
                                    'to be passed to a template module.  Use '
                                    'the async methods of the API you are '

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -992,6 +992,14 @@ class Template(object):
         return self.environment.handle_exception(exc_info, True)
 
     def render_async(self, *args, **kwargs):
+        """This works similar to :meth:`render` but returns a coroutine
+        that when awaited returns the entire rendered template string.  This
+        requires the async feature to be enabled.
+
+        Example usage::
+
+            await template.render_async(knights='that say nih; asynchronously')
+        """
         # see asyncsupport for the actual implementation
         raise NotImplementedError('This feature is not available for this '
                                   'version of Python')
@@ -1021,6 +1029,9 @@ class Template(object):
         yield self.environment.handle_exception(exc_info, True)
 
     def generate_async(self, *args, **kwargs):
+        """An async version of :meth:`generate`.  Works very similarly but
+        returns an async iterator instead.
+        """
         # see asyncsupport for the actual implementation
         raise NotImplementedError('This feature is not available for this '
                                   'version of Python')
@@ -1046,6 +1057,11 @@ class Template(object):
         return TemplateModule(self, self.new_context(vars, shared, locals))
 
     def make_module_async(self, vars=None, shared=False, locals=None):
+        """As template module creation can invoke template code for
+        asynchronous exections this method must be used instead of the
+        normal :meth:`make_module` one.  Likewise the module attribute
+        becomes unavailable in async mode.
+        """
         # see asyncsupport for the actual implementation
         raise NotImplementedError('This feature is not available for this '
                                   'version of Python')
@@ -1068,6 +1084,8 @@ class Template(object):
         '23'
         >>> t.module.foo() == u'42'
         True
+
+        This attribute is not available if async mode is enabled.
         """
         return self._get_default_module()
 

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1035,6 +1035,7 @@ class Template(object):
         """
         return TemplateModule(self, self.new_context(vars, shared, locals))
 
+    @internalcode
     def _get_default_module(self):
         if self._module is not None:
             return self._module
@@ -1092,8 +1093,13 @@ class TemplateModule(object):
     converting it into an unicode- or bytestrings renders the contents.
     """
 
-    def __init__(self, template, context):
-        self._body_stream = list(template.root_render_func(context))
+    def __init__(self, template, context, body_stream=None):
+        if body_stream is None:
+            if context.environment._async:
+                raise RuntimeError('Async mode requires a body stream '
+                                   'to be passed in.')
+            body_stream = list(template.root_render_func(context))
+        self._body_stream = body_stream
         self.__dict__.update(context.get_exported())
         self.__name__ = template.name
 

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -860,7 +860,7 @@ def do_select(*args, **kwargs):
 
     .. versionadded:: 2.7
     """
-    return _select_or_reject(args, kwargs, lambda x: x, False)
+    return select_or_reject(args, kwargs, lambda x: x, False)
 
 
 @contextfilter
@@ -878,7 +878,7 @@ def do_reject(*args, **kwargs):
 
     .. versionadded:: 2.7
     """
-    return _select_or_reject(args, kwargs, lambda x: not x, False)
+    return select_or_reject(args, kwargs, lambda x: not x, False)
 
 
 @contextfilter
@@ -899,7 +899,7 @@ def do_selectattr(*args, **kwargs):
 
     .. versionadded:: 2.7
     """
-    return _select_or_reject(args, kwargs, lambda x: x, True)
+    return select_or_reject(args, kwargs, lambda x: x, True)
 
 
 @contextfilter
@@ -918,10 +918,10 @@ def do_rejectattr(*args, **kwargs):
 
     .. versionadded:: 2.7
     """
-    return _select_or_reject(args, kwargs, lambda x: not x, True)
+    return select_or_reject(args, kwargs, lambda x: not x, True)
 
 
-def _select_or_reject(args, kwargs, modfunc, lookup_attr):
+def prepare_select_or_reject(args, kwargs, modfunc, lookup_attr):
     context = args[0]
     seq = args[1]
     if lookup_attr:
@@ -943,9 +943,14 @@ def _select_or_reject(args, kwargs, modfunc, lookup_attr):
     except LookupError:
         func = bool
 
+    return seq, lambda item: modfunc(func(transfunc(item)))
+
+
+def select_or_reject(args, kwargs, modfunc, lookup_attr):
+    seq, func = prepare_select_or_reject(args, kwargs, modfunc, lookup_attr)
     if seq:
         for item in seq:
-            if modfunc(func(transfunc(item))):
+            if func(item):
                 yield item
 
 

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -821,24 +821,7 @@ def do_map(*args, **kwargs):
 
     .. versionadded:: 2.7
     """
-    context = args[0]
-    seq = args[1]
-
-    if len(args) == 2 and 'attribute' in kwargs:
-        attribute = kwargs.pop('attribute')
-        if kwargs:
-            raise FilterArgumentError('Unexpected keyword argument %r' %
-                next(iter(kwargs)))
-        func = make_attrgetter(context.environment, attribute)
-    else:
-        try:
-            name = args[2]
-            args = args[3:]
-        except LookupError:
-            raise FilterArgumentError('map requires a filter argument')
-        func = lambda item: context.environment.call_filter(
-            name, item, args, kwargs, context=context)
-
+    seq, func = prepare_map(args, kwargs)
     if seq:
         for item in seq:
             yield func(item)
@@ -919,6 +902,28 @@ def do_rejectattr(*args, **kwargs):
     .. versionadded:: 2.7
     """
     return select_or_reject(args, kwargs, lambda x: not x, True)
+
+
+def prepare_map(args, kwargs):
+    context = args[0]
+    seq = args[1]
+
+    if len(args) == 2 and 'attribute' in kwargs:
+        attribute = kwargs.pop('attribute')
+        if kwargs:
+            raise FilterArgumentError('Unexpected keyword argument %r' %
+                next(iter(kwargs)))
+        func = make_attrgetter(context.environment, attribute)
+    else:
+        try:
+            name = args[2]
+            args = args[3:]
+        except LookupError:
+            raise FilterArgumentError('map requires a filter argument')
+        func = lambda item: context.environment.call_filter(
+            name, item, args, kwargs, context=context)
+
+    return seq, func
 
 
 def prepare_select_or_reject(args, kwargs, modfunc, lookup_attr):

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -280,13 +280,14 @@ class BlockReference(object):
         return rv
 
 
-class LoopContext(object):
+class LoopContextBase(object):
     """A loop context for dynamic iteration."""
 
+    _after = _last_iteration
+    _length = None
+
     def __init__(self, iterable, recurse=None, depth0=0):
-        self._iterator = iter(iterable)
         self._recurse = recurse
-        self._after = self._safe_next()
         self.index0 = -1
         self.depth0 = depth0
 
@@ -314,15 +315,6 @@ class LoopContext(object):
 
     def __len__(self):
         return self.length
-
-    def __iter__(self):
-        return LoopContextIterator(self)
-
-    def _safe_next(self):
-        try:
-            return next(self._iterator)
-        except StopIteration:
-            return _last_iteration
 
     @internalcode
     def loop(self, iterable):
@@ -355,6 +347,23 @@ class LoopContext(object):
             self.index,
             self.length
         )
+
+
+class LoopContext(LoopContextBase):
+
+    def __init__(self, iterable, recurse=None, depth0=0):
+        self._iterator = iter(iterable)
+        LoopContextBase.__init__(self, iterable, recurse, depth0)
+        self._after = self._safe_next()
+
+    def __iter__(self):
+        return LoopContextIterator(self)
+
+    def _safe_next(self):
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            return _last_iteration
 
 
 @implements_iterator

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -527,5 +527,13 @@ class Joiner(object):
         return self.sep
 
 
+# does this python version support async for in and async generators?
+try:
+    exec('async def _():\n async for _ in ():\n  yield _')
+    have_async_gen = True
+except SyntaxError:
+    have_async_gen = False
+
+
 # Imported here because that's where it was in the past
 from markupsafe import Markup, escape, soft_unicode

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ license_file = LICENSE
 [aliases]
 release = egg_info -RDb ''
 
-[pytest]
-norecursedirs = .* *.egg *.egg-info env* artwork docs examples
+[tool:pytest]
+norecursedirs = .* *.egg *.egg-info env* artwork docs examples venv*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,14 @@ import sys
 from traceback import format_exception
 from jinja2 import loaders
 from jinja2._compat import PY2
+from jinja2.utils import have_async_gen
 from jinja2 import Environment
+
+
+def pytest_ignore_collect(path, config):
+    if path.basename == 'test_async.py' and not have_async_gen:
+        return True
+    return False
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from jinja2 import Environment
 
 
 def pytest_ignore_collect(path, config):
-    if path.basename == 'test_async.py' and not have_async_gen:
+    if 'async' in path.basename and not have_async_gen:
         return True
     return False
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -3,7 +3,8 @@ import asyncio
 
 from jinja2 import Template, Environment, DictLoader
 from jinja2.utils import have_async_gen
-from jinja2.exceptions import TemplateNotFound, TemplatesNotFound
+from jinja2.exceptions import TemplateNotFound, TemplatesNotFound, \
+     UndefinedError
 
 
 def run(coro):
@@ -252,3 +253,177 @@ class TestAsyncIncludes(object):
             {{ outer("FOO") }}
         """)
         assert t.render().strip() == '(FOO)'
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+@pytest.mark.core_tags
+@pytest.mark.for_loop
+class TestAsyncForLoop(object):
+
+    def test_simple(self, test_env_async):
+        tmpl = test_env_async.from_string('{% for item in seq %}{{ item }}{% endfor %}')
+        assert tmpl.render(seq=list(range(10))) == '0123456789'
+
+    def test_else(self, test_env_async):
+        tmpl = test_env_async.from_string(
+            '{% for item in seq %}XXX{% else %}...{% endfor %}')
+        assert tmpl.render() == '...'
+
+    def test_empty_blocks(self, test_env_async):
+        tmpl = test_env_async.from_string('<{% for item in seq %}{% else %}{% endfor %}>')
+        assert tmpl.render() == '<>'
+
+    def test_context_vars(self, test_env_async):
+        slist = [42, 24]
+        for seq in [slist, iter(slist), reversed(slist), (_ for _ in slist)]:
+            tmpl = test_env_async.from_string('''{% for item in seq -%}
+            {{ loop.index }}|{{ loop.index0 }}|{{ loop.revindex }}|{{
+                loop.revindex0 }}|{{ loop.first }}|{{ loop.last }}|{{
+               loop.length }}###{% endfor %}''')
+            one, two, _ = tmpl.render(seq=seq).split('###')
+            (one_index, one_index0, one_revindex, one_revindex0, one_first,
+             one_last, one_length) = one.split('|')
+            (two_index, two_index0, two_revindex, two_revindex0, two_first,
+             two_last, two_length) = two.split('|')
+
+            assert int(one_index) == 1 and int(two_index) == 2
+            assert int(one_index0) == 0 and int(two_index0) == 1
+            assert int(one_revindex) == 2 and int(two_revindex) == 1
+            assert int(one_revindex0) == 1 and int(two_revindex0) == 0
+            assert one_first == 'True' and two_first == 'False'
+            assert one_last == 'False' and two_last == 'True'
+            assert one_length == two_length == '2'
+
+    def test_cycling(self, test_env_async):
+        tmpl = test_env_async.from_string('''{% for item in seq %}{{
+            loop.cycle('<1>', '<2>') }}{% endfor %}{%
+            for item in seq %}{{ loop.cycle(*through) }}{% endfor %}''')
+        output = tmpl.render(seq=list(range(4)), through=('<1>', '<2>'))
+        assert output == '<1><2>' * 4
+
+    def test_scope(self, test_env_async):
+        tmpl = test_env_async.from_string('{% for item in seq %}{% endfor %}{{ item }}')
+        output = tmpl.render(seq=list(range(10)))
+        assert not output
+
+    def test_varlen(self, test_env_async):
+        def inner():
+            for item in range(5):
+                yield item
+        tmpl = test_env_async.from_string('{% for item in iter %}{{ item }}{% endfor %}')
+        output = tmpl.render(iter=inner())
+        assert output == '01234'
+
+    def test_noniter(self, test_env_async):
+        tmpl = test_env_async.from_string('{% for item in none %}...{% endfor %}')
+        pytest.raises(TypeError, tmpl.render)
+
+    def test_recursive(self, test_env_async):
+        tmpl = test_env_async.from_string('''{% for item in seq recursive -%}
+            [{{ item.a }}{% if item.b %}<{{ loop(item.b) }}>{% endif %}]
+        {%- endfor %}''')
+        assert tmpl.render(seq=[
+            dict(a=1, b=[dict(a=1), dict(a=2)]),
+            dict(a=2, b=[dict(a=1), dict(a=2)]),
+            dict(a=3, b=[dict(a='a')])
+        ]) == '[1<[1][2]>][2<[1][2]>][3<[a]>]'
+
+    def test_recursive_depth0(self, test_env_async):
+        tmpl = test_env_async.from_string('''{% for item in seq recursive -%}
+            [{{ loop.depth0 }}:{{ item.a }}{% if item.b %}<{{ loop(item.b) }}>{% endif %}]
+        {%- endfor %}''')
+        assert tmpl.render(seq=[
+            dict(a=1, b=[dict(a=1), dict(a=2)]),
+            dict(a=2, b=[dict(a=1), dict(a=2)]),
+            dict(a=3, b=[dict(a='a')])
+        ]) == '[0:1<[1:1][1:2]>][0:2<[1:1][1:2]>][0:3<[1:a]>]'
+
+    def test_recursive_depth(self, test_env_async):
+        tmpl = test_env_async.from_string('''{% for item in seq recursive -%}
+            [{{ loop.depth }}:{{ item.a }}{% if item.b %}<{{ loop(item.b) }}>{% endif %}]
+        {%- endfor %}''')
+        assert tmpl.render(seq=[
+            dict(a=1, b=[dict(a=1), dict(a=2)]),
+            dict(a=2, b=[dict(a=1), dict(a=2)]),
+            dict(a=3, b=[dict(a='a')])
+        ]) == '[1:1<[2:1][2:2]>][1:2<[2:1][2:2]>][1:3<[2:a]>]'
+
+    def test_looploop(self, test_env_async):
+        tmpl = test_env_async.from_string('''{% for row in table %}
+            {%- set rowloop = loop -%}
+            {% for cell in row -%}
+                [{{ rowloop.index }}|{{ loop.index }}]
+            {%- endfor %}
+        {%- endfor %}''')
+        assert tmpl.render(table=['ab', 'cd']) == '[1|1][1|2][2|1][2|2]'
+
+    def test_reversed_bug(self, test_env_async):
+        tmpl = test_env_async.from_string('{% for i in items %}{{ i }}'
+                               '{% if not loop.last %}'
+                               ',{% endif %}{% endfor %}')
+        assert tmpl.render(items=reversed([3, 2, 1])) == '1,2,3'
+
+    def test_loop_errors(self, test_env_async):
+        tmpl = test_env_async.from_string('''{% for item in [1] if loop.index
+                                      == 0 %}...{% endfor %}''')
+        pytest.raises(UndefinedError, tmpl.render)
+        tmpl = test_env_async.from_string('''{% for item in [] %}...{% else
+            %}{{ loop }}{% endfor %}''')
+        assert tmpl.render() == ''
+
+    def test_loop_filter(self, test_env_async):
+        tmpl = test_env_async.from_string('{% for item in range(10) if item '
+                               'is even %}[{{ item }}]{% endfor %}')
+        assert tmpl.render() == '[0][2][4][6][8]'
+        tmpl = test_env_async.from_string('''
+            {%- for item in range(10) if item is even %}[{{
+                loop.index }}:{{ item }}]{% endfor %}''')
+        assert tmpl.render() == '[1:0][2:2][3:4][4:6][5:8]'
+
+    def test_scoped_special_var(self, test_env_async):
+        t = test_env_async.from_string(
+            '{% for s in seq %}[{{ loop.first }}{% for c in s %}'
+            '|{{ loop.first }}{% endfor %}]{% endfor %}')
+        assert t.render(seq=('ab', 'cd')) \
+            == '[True|True|False][False|True|False]'
+
+    def test_scoped_loop_var(self, test_env_async):
+        t = test_env_async.from_string('{% for x in seq %}{{ loop.first }}'
+                            '{% for y in seq %}{% endfor %}{% endfor %}')
+        assert t.render(seq='ab') == 'TrueFalse'
+        t = test_env_async.from_string('{% for x in seq %}{% for y in seq %}'
+                            '{{ loop.first }}{% endfor %}{% endfor %}')
+        assert t.render(seq='ab') == 'TrueFalseTrueFalse'
+
+    def test_recursive_empty_loop_iter(self, test_env_async):
+        t = test_env_async.from_string('''
+        {%- for item in foo recursive -%}{%- endfor -%}
+        ''')
+        assert t.render(dict(foo=[])) == ''
+
+    def test_call_in_loop(self, test_env_async):
+        t = test_env_async.from_string('''
+        {%- macro do_something() -%}
+            [{{ caller() }}]
+        {%- endmacro %}
+
+        {%- for i in [1, 2, 3] %}
+            {%- call do_something() -%}
+                {{ i }}
+            {%- endcall %}
+        {%- endfor -%}
+        ''')
+        assert t.render() == '[1][2][3]'
+
+    def test_scoping_bug(self, test_env_async):
+        t = test_env_async.from_string('''
+        {%- for item in foo %}...{{ item }}...{% endfor %}
+        {%- macro item(a) %}...{{ a }}...{% endmacro %}
+        {{- item(2) -}}
+        ''')
+        assert t.render(foo=(1,)) == '...1......2...'
+
+    def test_unpacking(self, test_env_async):
+        tmpl = test_env_async.from_string('{% for a, b, c in [[1, 2, 3]] %}'
+                               '{{ a }}|{{ b }}|{{ c }}{% endfor %}')
+        assert tmpl.render() == '1|2|3'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -99,6 +99,7 @@ def test_env_async():
     return env
 
 
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 @pytest.mark.imports
 class TestAsyncImports(object):
 
@@ -146,6 +147,7 @@ class TestAsyncImports(object):
         assert not hasattr(m, 'notthere')
 
 
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 @pytest.mark.imports
 @pytest.mark.includes
 class TestAsyncIncludes(object):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -19,3 +19,24 @@ def test_basic_async():
 
     rv = run(func)
     assert rv == '[1][2][3]'
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_await_on_calls():
+    t = Template('{{ async_func() + normal_func() }}',
+                 enable_async=True)
+
+    async def async_func():
+        return 42
+
+    def normal_func():
+        return 23
+
+    async def func():
+        return await t.render_async(
+            async_func=async_func,
+            normal_func=normal_func
+        )
+
+    rv = run(func)
+    assert rv == '65'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,7 +12,6 @@ def run(coro):
     return loop.run_until_complete(coro)
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_basic_async():
     t = Template('{% for item in [1, 2, 3] %}[{{ item }}]{% endfor %}',
                  enable_async=True)
@@ -23,7 +22,6 @@ def test_basic_async():
     assert rv == '[1][2][3]'
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_await_on_calls():
     t = Template('{{ async_func() + normal_func() }}',
                  enable_async=True)
@@ -44,7 +42,6 @@ def test_await_on_calls():
     assert rv == '65'
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_await_on_calls_normal_render():
     t = Template('{{ async_func() + normal_func() }}',
                  enable_async=True)
@@ -63,7 +60,6 @@ def test_await_on_calls_normal_render():
     assert rv == '65'
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_await_and_macros():
     t = Template('{% macro foo(x) %}[{{ x }}][{{ async_func() }}]'
                  '{% endmacro %}{{ foo(42) }}', enable_async=True)
@@ -78,7 +74,6 @@ def test_await_and_macros():
     assert rv == '[42][42]'
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_async_blocks():
     t = Template('{% block foo %}<Test>{% endblock %}{{ self.foo() }}',
                  enable_async=True, autoescape=True)
@@ -89,7 +84,6 @@ def test_async_blocks():
     assert rv == '<Test><Test>'
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_async_generate():
     t = Template('{% for x in [1, 2, 3] %}{{ x }}{% endfor %}',
                  enable_async=True)
@@ -97,7 +91,6 @@ def test_async_generate():
     assert rv == ['1', '2', '3']
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_async_iteration_in_templates():
     t = Template('{% for x in rng %}{{ x }}{% endfor %}',
                  enable_async=True)
@@ -108,7 +101,6 @@ def test_async_iteration_in_templates():
     assert rv == ['1', '2', '3']
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_async_iteration_in_templates_extended():
     t = Template('{% for x in rng %}{{ loop.index0 }}/{{ x }}{% endfor %}',
                  enable_async=True)
@@ -130,7 +122,6 @@ def test_env_async():
     return env
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 @pytest.mark.imports
 class TestAsyncImports(object):
 
@@ -178,7 +169,6 @@ class TestAsyncImports(object):
         assert not hasattr(m, 'notthere')
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 @pytest.mark.imports
 @pytest.mark.includes
 class TestAsyncIncludes(object):
@@ -255,7 +245,6 @@ class TestAsyncIncludes(object):
         assert t.render().strip() == '(FOO)'
 
 
-@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 @pytest.mark.core_tags
 @pytest.mark.for_loop
 class TestAsyncForLoop(object):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -96,6 +96,17 @@ def test_async_generate():
     assert rv == ['1', '2', '3']
 
 
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_async_iteration_in_tmeplates():
+    t = Template('{% for x in rng %}{{ x }}{% endfor %}',
+                 enable_async=True)
+    async def async_iterator():
+        for item in [1, 2, 3]:
+            yield item
+    rv = list(t.generate(rng=async_iterator()))
+    assert rv == ['1', '2', '3']
+
+
 @pytest.fixture
 def test_env_async():
     env = Environment(loader=DictLoader(dict(

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,21 @@
+import pytest
+import asyncio
+
+from jinja2 import Template
+from jinja2.utils import have_async_gen
+
+
+def run(func):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(func())
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_basic_async():
+    t = Template('{% for item in [1, 2, 3] %}[{{ item }}]{% endfor %}',
+                 enable_async=True)
+    async def func():
+        return await t.render_async()
+
+    rv = run(func)
+    assert rv == '[1][2][3]'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -43,6 +43,25 @@ def test_await_on_calls():
 
 
 @pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_await_on_calls_normal_render():
+    t = Template('{{ async_func() + normal_func() }}',
+                 enable_async=True)
+
+    async def async_func():
+        return 42
+
+    def normal_func():
+        return 23
+
+    rv = t.render(
+        async_func=async_func,
+        normal_func=normal_func
+    )
+
+    assert rv == '65'
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_await_and_macros():
     t = Template('{% macro foo(x) %}[{{ x }}][{{ async_func() }}]'
                  '{% endmacro %}{{ foo(42) }}', enable_async=True)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -44,11 +44,14 @@ def test_await_on_calls():
 
 @pytest.mark.skipif(not have_async_gen, reason='No async generators')
 def test_await_and_macros():
-    t = Template('{% macro foo(x) %}[{{ x }}]{% endmacro %}{{ foo(42) }}',
-                 enable_async=True)
+    t = Template('{% macro foo(x) %}[{{ x }}][{{ async_func() }}]'
+                 '{% endmacro %}{{ foo(42) }}', enable_async=True)
+
+    async def async_func():
+        return 42
 
     async def func():
-        return await t.render_async()
+        return await t.render_async(async_func=async_func)
 
     rv = run(func)
-    assert rv == '[42]'
+    assert rv == '[42][42]'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -55,3 +55,14 @@ def test_await_and_macros():
 
     rv = run(func)
     assert rv == '[42][42]'
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_async_blocks():
+    t = Template('{% block foo %}<Test>{% endblock %}{{ self.foo() }}',
+                 enable_async=True, autoescape=True)
+    async def func():
+        return await t.render_async()
+
+    rv = run(func)
+    assert rv == '<Test><Test>'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -40,3 +40,15 @@ def test_await_on_calls():
 
     rv = run(func)
     assert rv == '65'
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_await_and_macros():
+    t = Template('{% macro foo(x) %}[{{ x }}]{% endmacro %}{{ foo(42) }}',
+                 enable_async=True)
+
+    async def func():
+        return await t.render_async()
+
+    rv = run(func)
+    assert rv == '[42]'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,13 +1,14 @@
 import pytest
 import asyncio
 
-from jinja2 import Template
+from jinja2 import Template, Environment, DictLoader
 from jinja2.utils import have_async_gen
+from jinja2.exceptions import TemplateNotFound, TemplatesNotFound
 
 
-def run(func):
+def run(coro):
     loop = asyncio.get_event_loop()
-    return loop.run_until_complete(func())
+    return loop.run_until_complete(coro)
 
 
 @pytest.mark.skipif(not have_async_gen, reason='No async generators')
@@ -17,7 +18,7 @@ def test_basic_async():
     async def func():
         return await t.render_async()
 
-    rv = run(func)
+    rv = run(func())
     assert rv == '[1][2][3]'
 
 
@@ -38,7 +39,7 @@ def test_await_on_calls():
             normal_func=normal_func
         )
 
-    rv = run(func)
+    rv = run(func())
     assert rv == '65'
 
 
@@ -72,7 +73,7 @@ def test_await_and_macros():
     async def func():
         return await t.render_async(async_func=async_func)
 
-    rv = run(func)
+    rv = run(func())
     assert rv == '[42][42]'
 
 
@@ -83,5 +84,139 @@ def test_async_blocks():
     async def func():
         return await t.render_async()
 
-    rv = run(func)
+    rv = run(func())
     assert rv == '<Test><Test>'
+
+
+@pytest.fixture
+def test_env_async():
+    env = Environment(loader=DictLoader(dict(
+        module='{% macro test() %}[{{ foo }}|{{ bar }}]{% endmacro %}',
+        header='[{{ foo }}|{{ 23 }}]',
+        o_printer='({{ o }})'
+    )), enable_async=True)
+    env.globals['bar'] = 23
+    return env
+
+
+@pytest.mark.imports
+class TestAsyncImports(object):
+
+    def test_context_imports(self, test_env_async):
+        t = test_env_async.from_string('{% import "module" as m %}{{ m.test() }}')
+        assert t.render(foo=42) == '[|23]'
+        t = test_env_async.from_string(
+            '{% import "module" as m without context %}{{ m.test() }}'
+        )
+        assert t.render(foo=42) == '[|23]'
+        t = test_env_async.from_string(
+            '{% import "module" as m with context %}{{ m.test() }}'
+        )
+        assert t.render(foo=42) == '[42|23]'
+        t = test_env_async.from_string('{% from "module" import test %}{{ test() }}')
+        assert t.render(foo=42) == '[|23]'
+        t = test_env_async.from_string(
+            '{% from "module" import test without context %}{{ test() }}'
+        )
+        assert t.render(foo=42) == '[|23]'
+        t = test_env_async.from_string(
+            '{% from "module" import test with context %}{{ test() }}'
+        )
+        assert t.render(foo=42) == '[42|23]'
+
+    def test_trailing_comma(self, test_env_async):
+        test_env_async.from_string('{% from "foo" import bar, baz with context %}')
+        test_env_async.from_string('{% from "foo" import bar, baz, with context %}')
+        test_env_async.from_string('{% from "foo" import bar, with context %}')
+        test_env_async.from_string('{% from "foo" import bar, with, context %}')
+        test_env_async.from_string('{% from "foo" import bar, with with context %}')
+
+    def test_exports(self, test_env_async):
+        m = run(test_env_async.from_string('''
+            {% macro toplevel() %}...{% endmacro %}
+            {% macro __private() %}...{% endmacro %}
+            {% set variable = 42 %}
+            {% for item in [1] %}
+                {% macro notthere() %}{% endmacro %}
+            {% endfor %}
+        ''')._get_default_module_async())
+        assert run(m.toplevel()) == '...'
+        assert not hasattr(m, '__missing')
+        assert m.variable == 42
+        assert not hasattr(m, 'notthere')
+
+
+@pytest.mark.imports
+@pytest.mark.includes
+class TestAsyncIncludes(object):
+
+    def test_context_include(self, test_env_async):
+        t = test_env_async.from_string('{% include "header" %}')
+        assert t.render(foo=42) == '[42|23]'
+        t = test_env_async.from_string('{% include "header" with context %}')
+        assert t.render(foo=42) == '[42|23]'
+        t = test_env_async.from_string('{% include "header" without context %}')
+        assert t.render(foo=42) == '[|23]'
+
+    def test_choice_includes(self, test_env_async):
+        t = test_env_async.from_string('{% include ["missing", "header"] %}')
+        assert t.render(foo=42) == '[42|23]'
+
+        t = test_env_async.from_string(
+            '{% include ["missing", "missing2"] ignore missing %}'
+        )
+        assert t.render(foo=42) == ''
+
+        t = test_env_async.from_string('{% include ["missing", "missing2"] %}')
+        pytest.raises(TemplateNotFound, t.render)
+        try:
+            t.render()
+        except TemplatesNotFound as e:
+            assert e.templates == ['missing', 'missing2']
+            assert e.name == 'missing2'
+        else:
+            assert False, 'thou shalt raise'
+
+        def test_includes(t, **ctx):
+            ctx['foo'] = 42
+            assert t.render(ctx) == '[42|23]'
+
+        t = test_env_async.from_string('{% include ["missing", "header"] %}')
+        test_includes(t)
+        t = test_env_async.from_string('{% include x %}')
+        test_includes(t, x=['missing', 'header'])
+        t = test_env_async.from_string('{% include [x, "header"] %}')
+        test_includes(t, x='missing')
+        t = test_env_async.from_string('{% include x %}')
+        test_includes(t, x='header')
+        t = test_env_async.from_string('{% include x %}')
+        test_includes(t, x='header')
+        t = test_env_async.from_string('{% include [x] %}')
+        test_includes(t, x='header')
+
+    def test_include_ignoring_missing(self, test_env_async):
+        t = test_env_async.from_string('{% include "missing" %}')
+        pytest.raises(TemplateNotFound, t.render)
+        for extra in '', 'with context', 'without context':
+            t = test_env_async.from_string('{% include "missing" ignore missing ' +
+                                     extra + ' %}')
+            assert t.render() == ''
+
+    def test_context_include_with_overrides(self, test_env_async):
+        env = Environment(loader=DictLoader(dict(
+            main="{% for item in [1, 2, 3] %}{% include 'item' %}{% endfor %}",
+            item="{{ item }}"
+        )))
+        assert env.get_template("main").render() == "123"
+
+    def test_unoptimized_scopes(self, test_env_async):
+        t = test_env_async.from_string("""
+            {% macro outer(o) %}
+            {% macro inner() %}
+            {% include "o_printer" %}
+            {% endmacro %}
+            {{ inner() }}
+            {% endmacro %}
+            {{ outer("FOO") }}
+        """)
+        assert t.render().strip() == '(FOO)'

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -97,7 +97,7 @@ def test_async_generate():
 
 
 @pytest.mark.skipif(not have_async_gen, reason='No async generators')
-def test_async_iteration_in_tmeplates():
+def test_async_iteration_in_templates():
     t = Template('{% for x in rng %}{{ x }}{% endfor %}',
                  enable_async=True)
     async def async_iterator():
@@ -105,6 +105,17 @@ def test_async_iteration_in_tmeplates():
             yield item
     rv = list(t.generate(rng=async_iterator()))
     assert rv == ['1', '2', '3']
+
+
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_async_iteration_in_templates_extended():
+    t = Template('{% for x in rng %}{{ loop.index0 }}/{{ x }}{% endfor %}',
+                 enable_async=True)
+    async def async_iterator():
+        for item in [1, 2, 3]:
+            yield item
+    rv = list(t.generate(rng=async_iterator()))
+    assert rv == ['0/1', '1/2', '2/3']
 
 
 @pytest.fixture

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -88,6 +88,14 @@ def test_async_blocks():
     assert rv == '<Test><Test>'
 
 
+@pytest.mark.skipif(not have_async_gen, reason='No async generators')
+def test_async_generate():
+    t = Template('{% for x in [1, 2, 3] %}{{ x }}{% endfor %}',
+                 enable_async=True)
+    rv = list(t.generate())
+    assert rv == ['1', '2', '3']
+
+
 @pytest.fixture
 def test_env_async():
     env = Environment(loader=DictLoader(dict(

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -2,21 +2,81 @@ import pytest
 from jinja2 import Environment
 
 
+async def make_aiter(iter):
+    for item in iter:
+        yield item
+
+
 @pytest.fixture
 def env_async():
     return Environment(enable_async=True)
 
 
-def test_first(env_async):
-    tmpl = env_async.from_string('{{ foo|first }}')
-    out = tmpl.render(foo=list(range(10)))
-    assert out == '0'
-
-
-def test_first_aiter(env_async):
-    async def foo():
-        for x in range(10):
-            yield x
+@pytest.mark.parametrize('foo', [
+    lambda: range(10),
+    lambda: make_aiter(range(10)),
+])
+def test_first(env_async, foo):
     tmpl = env_async.from_string('{{ foo()|first }}')
     out = tmpl.render(foo=foo)
     assert out == '0'
+
+
+def test_groupby(env_async):
+    tmpl = env_async.from_string('''
+    {%- for grouper, list in [{'foo': 1, 'bar': 2},
+                              {'foo': 2, 'bar': 3},
+                              {'foo': 1, 'bar': 1},
+                              {'foo': 3, 'bar': 4}]|groupby('foo') -%}
+        {{ grouper }}{% for x in list %}: {{ x.foo }}, {{ x.bar }}{% endfor %}|
+    {%- endfor %}''')
+    assert tmpl.render().split('|') == [
+        "1: 1, 2: 1, 1",
+        "2: 2, 3",
+        "3: 3, 4",
+        ""
+    ]
+
+
+def test_groupby_tuple_index(env_async):
+    tmpl = env_async.from_string('''
+    {%- for grouper, list in [('a', 1), ('a', 2), ('b', 1)]|groupby(0) -%}
+        {{ grouper }}{% for x in list %}:{{ x.1 }}{% endfor %}|
+    {%- endfor %}''')
+    assert tmpl.render() == 'a:1:2|b:1|'
+
+
+def make_articles():
+    class Date(object):
+        def __init__(self, day, month, year):
+            self.day = day
+            self.month = month
+            self.year = year
+
+    class Article(object):
+        def __init__(self, title, *date):
+            self.date = Date(*date)
+            self.title = title
+
+    return [
+        Article('aha', 1, 1, 1970),
+        Article('interesting', 2, 1, 1970),
+        Article('really?', 3, 1, 1970),
+        Article('totally not', 1, 1, 1971)
+    ]
+
+
+@pytest.mark.parametrize('articles', [
+    make_articles,
+    lambda: make_aiter(make_articles()),
+])
+def test_groupby_multidot(env_async, articles):
+    tmpl = env_async.from_string('''
+    {%- for year, list in articles()|groupby('date.year') -%}
+        {{ year }}{% for x in list %}[{{ x.title }}]{% endfor %}|
+    {%- endfor %}''')
+    assert tmpl.render(articles=articles).split('|') == [
+        '1970[aha][interesting][really?]',
+        '1971[totally not]',
+        ''
+    ]

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -1,0 +1,22 @@
+import pytest
+from jinja2 import Environment
+
+
+@pytest.fixture
+def env_async():
+    return Environment(enable_async=True)
+
+
+def test_first(env_async):
+    tmpl = env_async.from_string('{{ foo|first }}')
+    out = tmpl.render(foo=list(range(10)))
+    assert out == '0'
+
+
+def test_first_aiter(env_async):
+    async def foo():
+        for x in range(10):
+            yield x
+    tmpl = env_async.from_string('{{ foo()|first }}')
+    out = tmpl.render(foo=foo)
+    assert out == '0'

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -116,3 +116,15 @@ def make_users():
 def test_join_attribute(env_async, users):
     tmpl = env_async.from_string('''{{ users()|join(', ', 'username') }}''')
     assert tmpl.render(users=users) == 'foo, bar'
+
+
+def test_simple_reject(env_async):
+    tmpl = env_async.from_string('{{ [1, 2, 3, 4, 5]|reject("odd")|join("|") }}')
+    assert tmpl.render() == '2|4'
+
+
+def test_bool_reject(env_async):
+    tmpl = env_async.from_string(
+        '{{ [none, false, 0, 1, 2, 3, 4, 5]|reject|join("|") }}'
+    )
+    assert tmpl.render() == 'None|False|0'

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -7,30 +7,39 @@ async def make_aiter(iter):
         yield item
 
 
+def mark_dualiter(parameter, factory):
+    def decorator(f):
+        return pytest.mark.parametrize(parameter, [
+            lambda: factory(),
+            lambda: make_aiter(factory()),
+        ])(f)
+    return decorator
+
+
 @pytest.fixture
 def env_async():
     return Environment(enable_async=True)
 
 
-@pytest.mark.parametrize('foo', [
-    lambda: range(10),
-    lambda: make_aiter(range(10)),
-])
+@mark_dualiter('foo', lambda: range(10))
 def test_first(env_async, foo):
     tmpl = env_async.from_string('{{ foo()|first }}')
     out = tmpl.render(foo=foo)
     assert out == '0'
 
 
-def test_groupby(env_async):
+@mark_dualiter('items', lambda: [
+    {'foo': 1, 'bar': 2},
+    {'foo': 2, 'bar': 3},
+    {'foo': 1, 'bar': 1},
+    {'foo': 3, 'bar': 4}
+])
+def test_groupby(env_async, items):
     tmpl = env_async.from_string('''
-    {%- for grouper, list in [{'foo': 1, 'bar': 2},
-                              {'foo': 2, 'bar': 3},
-                              {'foo': 1, 'bar': 1},
-                              {'foo': 3, 'bar': 4}]|groupby('foo') -%}
+    {%- for grouper, list in items()|groupby('foo') -%}
         {{ grouper }}{% for x in list %}: {{ x.foo }}, {{ x.bar }}{% endfor %}|
     {%- endfor %}''')
-    assert tmpl.render().split('|') == [
+    assert tmpl.render(items=items).split('|') == [
         "1: 1, 2: 1, 1",
         "2: 2, 3",
         "3: 3, 4",
@@ -38,12 +47,13 @@ def test_groupby(env_async):
     ]
 
 
-def test_groupby_tuple_index(env_async):
+@mark_dualiter('items', lambda: [('a', 1), ('a', 2), ('b', 1)])
+def test_groupby_tuple_index(env_async, items):
     tmpl = env_async.from_string('''
-    {%- for grouper, list in [('a', 1), ('a', 2), ('b', 1)]|groupby(0) -%}
+    {%- for grouper, list in items()|groupby(0) -%}
         {{ grouper }}{% for x in list %}:{{ x.1 }}{% endfor %}|
     {%- endfor %}''')
-    assert tmpl.render() == 'a:1:2|b:1|'
+    assert tmpl.render(items=items) == 'a:1:2|b:1|'
 
 
 def make_articles():
@@ -66,10 +76,7 @@ def make_articles():
     ]
 
 
-@pytest.mark.parametrize('articles', [
-    make_articles,
-    lambda: make_aiter(make_articles()),
-])
+@mark_dualiter('articles', make_articles)
 def test_groupby_multidot(env_async, articles):
     tmpl = env_async.from_string('''
     {%- for year, list in articles()|groupby('date.year') -%}

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -184,18 +184,20 @@ def test_empty_map(env_async):
     assert tmpl.render() == '[]'
 
 
-def test_sum(env_async):
-    tmpl = env_async.from_string('''{{ [1, 2, 3, 4, 5, 6]|sum }}''')
-    assert tmpl.render() == '21'
+@mark_dualiter('items', lambda: [1, 2, 3, 4, 5, 6])
+def test_sum(env_async, items):
+    tmpl = env_async.from_string('''{{ items()|sum }}''')
+    assert tmpl.render(items=items) == '21'
 
 
-def test_sum_attributes(env_async):
-    tmpl = env_async.from_string('''{{ values|sum('value') }}''')
-    assert tmpl.render(values=[
-        {'value': 23},
-        {'value': 1},
-        {'value': 18},
-    ]) == '42'
+@mark_dualiter('items', lambda: [
+    {'value': 23},
+    {'value': 1},
+    {'value': 18},
+])
+def test_sum_attributes(env_async, items):
+    tmpl = env_async.from_string('''{{ items()|sum('value') }}''')
+    assert tmpl.render(items=items)
 
 
 def test_sum_attributes_nested(env_async):

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -165,3 +165,52 @@ def test_simple_select_attr(env_async, users):
         'map(attribute="name")|join("|") }}'
     )
     assert tmpl.render(users=users) == 'john|jane'
+
+
+@mark_dualiter('items', lambda: list('123'))
+def test_simple_map(env_async, items):
+    tmpl = env_async.from_string('{{ items()|map("int")|sum }}')
+    assert tmpl.render(items=items) == '6'
+
+
+@mark_dualiter('users', make_users)
+def test_attribute_map(env_async, users):
+    tmpl = env_async.from_string('{{ users()|map(attribute="name")|join("|") }}')
+    assert tmpl.render(users=users) == 'john|jane|mike'
+
+
+def test_empty_map(env_async):
+    tmpl = env_async.from_string('{{ none|map("upper")|list }}')
+    assert tmpl.render() == '[]'
+
+
+def test_sum(env_async):
+    tmpl = env_async.from_string('''{{ [1, 2, 3, 4, 5, 6]|sum }}''')
+    assert tmpl.render() == '21'
+
+
+def test_sum_attributes(env_async):
+    tmpl = env_async.from_string('''{{ values|sum('value') }}''')
+    assert tmpl.render(values=[
+        {'value': 23},
+        {'value': 1},
+        {'value': 18},
+    ]) == '42'
+
+
+def test_sum_attributes_nested(env_async):
+    tmpl = env_async.from_string('''{{ values|sum('real.value') }}''')
+    assert tmpl.render(values=[
+        {'real': {'value': 23}},
+        {'real': {'value': 1}},
+        {'real': {'value': 18}},
+    ]) == '42'
+
+
+def test_sum_attributes_tuple(env_async):
+    tmpl = env_async.from_string('''{{ values.items()|sum('1') }}''')
+    assert tmpl.render(values={
+        'foo': 23,
+        'bar': 1,
+        'baz': 18,
+    }) == '42'

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -132,30 +132,36 @@ def test_bool_reject(env_async, items):
     assert tmpl.render(items=items) == 'None|False|0'
 
 
-def test_simple_select(env_async):
-    tmpl = env_async.from_string('{{ [1, 2, 3, 4, 5]|select("odd")|join("|") }}')
-    assert tmpl.render() == '1|3|5'
+@mark_dualiter('items', lambda: [1, 2, 3, 4, 5])
+def test_simple_select(env_async, items):
+    tmpl = env_async.from_string('{{ items()|select("odd")|join("|") }}')
+    assert tmpl.render(items=items) == '1|3|5'
 
 
-def test_bool_select(env_async):
+@mark_dualiter('items', lambda: [None, False, 0, 1, 2, 3, 4, 5])
+def test_bool_select(env_async, items):
     tmpl = env_async.from_string(
-        '{{ [none, false, 0, 1, 2, 3, 4, 5]|select|join("|") }}'
+        '{{ items()|select|join("|") }}'
     )
-    assert tmpl.render() == '1|2|3|4|5'
+    assert tmpl.render(items=items) == '1|2|3|4|5'
 
 
-def test_simple_select_attr(env_async):
+def make_users():
     class User(object):
         def __init__(self, name, is_active):
             self.name = name
             self.is_active = is_active
-    users = [
+    return [
         User('john', True),
         User('jane', True),
         User('mike', False),
     ]
+
+
+@mark_dualiter('users', make_users)
+def test_simple_select_attr(env_async, users):
     tmpl = env_async.from_string(
-        '{{ users|selectattr("is_active")|'
+        '{{ users()|selectattr("is_active")|'
         'map(attribute="name")|join("|") }}'
     )
     assert tmpl.render(users=users) == 'john|jane'

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -216,3 +216,12 @@ def test_sum_attributes_tuple(env_async):
         'bar': 1,
         'baz': 18,
     }) == '42'
+
+
+@mark_dualiter('items', lambda: range(10))
+def test_slice(env_async, items):
+    tmpl = env_async.from_string('{{ items()|slice(3)|list }}|'
+                                 '{{ items()|slice(3, "X")|list }}')
+    out = tmpl.render(items=items)
+    assert out == ("[[0, 1, 2, 3], [4, 5, 6], [7, 8, 9]]|"
+                   "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]")

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -118,13 +118,15 @@ def test_join_attribute(env_async, users):
     assert tmpl.render(users=users) == 'foo, bar'
 
 
-def test_simple_reject(env_async):
-    tmpl = env_async.from_string('{{ [1, 2, 3, 4, 5]|reject("odd")|join("|") }}')
-    assert tmpl.render() == '2|4'
+@mark_dualiter('items', lambda: [1, 2, 3, 4, 5])
+def test_simple_reject(env_async, items):
+    tmpl = env_async.from_string('{{ items()|reject("odd")|join("|") }}')
+    assert tmpl.render(items=items) == '2|4'
 
 
-def test_bool_reject(env_async):
+@mark_dualiter('items', lambda: [None, False, 0, 1, 2, 3, 4, 5])
+def test_bool_reject(env_async, items):
     tmpl = env_async.from_string(
-        '{{ [none, false, 0, 1, 2, 3, 4, 5]|reject|join("|") }}'
+        '{{ items()|reject|join("|") }}'
     )
-    assert tmpl.render() == 'None|False|0'
+    assert tmpl.render(items=items) == 'None|False|0'

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -130,3 +130,32 @@ def test_bool_reject(env_async, items):
         '{{ items()|reject|join("|") }}'
     )
     assert tmpl.render(items=items) == 'None|False|0'
+
+
+def test_simple_select(env_async):
+    tmpl = env_async.from_string('{{ [1, 2, 3, 4, 5]|select("odd")|join("|") }}')
+    assert tmpl.render() == '1|3|5'
+
+
+def test_bool_select(env_async):
+    tmpl = env_async.from_string(
+        '{{ [none, false, 0, 1, 2, 3, 4, 5]|select|join("|") }}'
+    )
+    assert tmpl.render() == '1|2|3|4|5'
+
+
+def test_simple_select_attr(env_async):
+    class User(object):
+        def __init__(self, name, is_active):
+            self.name = name
+            self.is_active = is_active
+    users = [
+        User('john', True),
+        User('jane', True),
+        User('mike', False),
+    ]
+    tmpl = env_async.from_string(
+        '{{ users|selectattr("is_active")|'
+        'map(attribute="name")|join("|") }}'
+    )
+    assert tmpl.render(users=users) == 'john|jane'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -14,7 +14,7 @@ from jinja2._compat import text_type, implements_to_string
 
 
 @pytest.mark.filter
-class TestFilter():
+class TestFilter(object):
 
     def test_filter_calling(self, env):
         rv = env.call_filter('sum', [1, 2, 3])


### PR DESCRIPTION
This experimental branch adds support for async generators in most places
in Jinja2.  This means that filters now work with async iterators just as
much as the entirety of Jinja2 can now render to an async generator.

More importantly this also means that you can now call things that return
coroutines in templates and Jinja2 will automatically await the call.

The implementation is based on an internal monkeypatch which is not the
nicest in the book but seems to work good enough to make the code
maintainable for different Python versions.

The intro to the feature is here: https://github.com/pallets/jinja/blob/2b03052c9b6f7028e5cb79fb96440a0560bc4340/docs/api.rst#async-support