### PR TITLE
Safely wrap str.format

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Version 2.9
 - Corrected a long standing issue with operator precedence of math operations
   not being what was expected.
 - Added support for Python 3.6 async iterators through a new async mode.
+- Intercept string format calls through the sandbox if the sandbox is enabled.
+  The sandbox now also prevents access to some newer Python features.
 
 Version 2.8.1
 -------------

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -604,7 +604,7 @@ class Call(Expr):
 
     def as_const(self, eval_ctx=None):
         eval_ctx = get_eval_context(self, eval_ctx)
-        if eval_ctx.volatile:
+        if eval_ctx.volatile or eval_ctx.environment.sandboxed:
             raise Impossible()
         obj = self.node.as_const(eval_ctx)
 

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -14,9 +14,17 @@
 """
 import types
 import operator
+from collections import Mapping
 from jinja2.environment import Environment
 from jinja2.exceptions import SecurityError
-from jinja2._compat import string_types, PY2
+from jinja2._compat import string_types, text_type, PY2
+from jinja2.utils import Markup
+
+has_format = False
+if hasattr(text_type, 'format'):
+    from markupsafe import EscapeFormatter
+    from string import Formatter
+    has_format = True
 
 
 #: maximum number of items a range may produce
@@ -37,6 +45,12 @@ UNSAFE_METHOD_ATTRIBUTES = set(['im_class', 'im_func', 'im_self'])
 
 #: unsafe generator attirbutes.
 UNSAFE_GENERATOR_ATTRIBUTES = set(['gi_frame', 'gi_code'])
+
+#: unsafe attributes on coroutines
+UNSAFE_COROUTINE_ATTRIBUTES = set(['cr_frame', 'cr_code'])
+
+#: unsafe attributes on async generators
+UNSAFE_ASYNC_GENERATOR_ATTRIBUTES = set(['ag_code', 'ag_frame'])
 
 import warnings
 
@@ -94,6 +108,49 @@ _mutable_spec = (
 )
 
 
+class _MagicFormatMapping(Mapping):
+    """This class implements a dummy wrapper to fix a bug in the Python
+    standard library for string formatting.
+
+    See http://bugs.python.org/issue13598 for information about why
+    this is necessary.
+    """
+
+    def __init__(self, args, kwargs):
+        self._args = args
+        self._kwargs = kwargs
+        self._last_index = 0
+
+    def __getitem__(self, key):
+        if key == '':
+            idx = self._last_index
+            self._last_index += 1
+            try:
+                return self._args[idx]
+            except LookupError:
+                pass
+            key = str(idx)
+        return self._kwargs[key]
+
+    def __iter__(self):
+        return iter(self._kwargs)
+
+    def __len__(self):
+        return len(self._kwargs)
+
+
+def is_format_method(callable):
+    if not has_format:
+        return None
+    if not isinstance(callable, (types.MethodType,
+                                 types.BuiltinMethodType)) or \
+       callable.__name__ != 'format':
+        return None
+    obj = callable.__self__
+    if isinstance(obj, string_types):
+        return obj
+
+
 def safe_range(*args):
     """A range that can't generate ranges with a length of more than
     MAX_RANGE items.
@@ -144,6 +201,12 @@ def is_internal_attribute(obj, attr):
         return True
     elif isinstance(obj, types.GeneratorType):
         if attr in UNSAFE_GENERATOR_ATTRIBUTES:
+            return True
+    elif hasattr(types, 'CoroutineType') and isinstance(obj, types.CoroutineType):
+        if attr in UNSAFE_COROUTINE_ATTRIBUTES:
+            return True
+    elif hasattr(types, 'AsyncGeneratorType') and isinstance(obj, types.AsyncGeneratorType):
+        if attri in UNSAFE_ASYNC_GENERATOR_ATTRIBUTES:
             return True
     return attr.startswith('__')
 
@@ -346,8 +409,24 @@ class SandboxedEnvironment(Environment):
             obj.__class__.__name__
         ), name=attribute, obj=obj, exc=SecurityError)
 
+    def format_string(self, s, args, kwargs):
+        """If a format call is detected, then this is routed through this
+        method so that our safety sandbox can be used for it.
+        """
+        if isinstance(s, Markup):
+            formatter = SandboxedEscapeFormatter(self, s.escape)
+        else:
+            formatter = SandboxedFormatter(self)
+        kwargs = _MagicFormatMapping(args, kwargs)
+        rv = formatter.vformat(s, args, kwargs)
+        return type(s)(rv)
+
     def call(__self, __context, __obj, *args, **kwargs):
         """Call an object from sandboxed code."""
+        fmt = is_format_method(__obj)
+        if fmt is not None:
+            return __self.format_string(fmt, args, kwargs)
+
         # the double prefixes are to avoid double keyword argument
         # errors when proxying the call.
         if not __self.is_safe_callable(__obj):
@@ -365,3 +444,37 @@ class ImmutableSandboxedEnvironment(SandboxedEnvironment):
         if not SandboxedEnvironment.is_safe_attribute(self, obj, attr, value):
             return False
         return not modifies_known_mutable(obj, attr)
+
+
+if has_format:
+    # This really is not a public API apparenlty.
+    try:
+        from _string import formatter_field_name_split
+    except ImportError:
+        def formatter_field_name_split(field_name):
+            return field_name._formatter_field_name_split()
+
+    class SandboxedFormatterMixin(object):
+
+        def __init__(self, env):
+            self._env = env
+
+        def get_field(self, field_name, args, kwargs):
+            first, rest = formatter_field_name_split(field_name)
+            obj = self.get_value(first, args, kwargs)
+            for is_attr, i in rest:
+                if is_attr:
+                    obj = self._env.getattr(obj, i)
+                else:
+                    obj = self._env.getitem(obj, i)
+            return obj, first
+
+    class SandboxedFormatter(SandboxedFormatterMixin, Formatter):
+        def __init__(self, env):
+            SandboxedFormatterMixin.__init__(self, env)
+            Formatter.__init__(self)
+
+    class SandboxedEscapeFormatter(SandboxedFormatterMixin, EscapeFormatter):
+        def __init__(self, env, escape):
+            SandboxedFormatterMixin.__init__(self, env)
+            EscapeFormatter.__init__(self, escape)

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -139,7 +139,7 @@ class _MagicFormatMapping(Mapping):
         return len(self._kwargs)
 
 
-def is_format_method(callable):
+def inspect_format_method(callable):
     if not has_format:
         return None
     if not isinstance(callable, (types.MethodType,
@@ -423,7 +423,7 @@ class SandboxedEnvironment(Environment):
 
     def call(__self, __context, __obj, *args, **kwargs):
         """Call an object from sandboxed code."""
-        fmt = is_format_method(__obj)
+        fmt = inspect_format_method(__obj)
         if fmt is not None:
             return __self.format_string(fmt, args, kwargs)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,7 +12,7 @@ import pytest
 
 from jinja2 import Environment
 from jinja2.sandbox import SandboxedEnvironment, \
-     ImmutableSandboxedEnvironment, unsafe
+     ImmutableSandboxedEnvironment, unsafe, has_format
 from jinja2 import Markup, escape
 from jinja2.exceptions import SecurityError, TemplateSyntaxError, \
      TemplateRuntimeError
@@ -41,7 +41,7 @@ class PublicStuff(object):
 
 
 @pytest.mark.sandbox
-class TestSandbox():
+class TestSandbox(object):
 
     def test_unsafe(self, env):
         env = SandboxedEnvironment()
@@ -159,3 +159,18 @@ class TestSandbox():
                 pass
             else:
                 assert False, 'expected runtime error'
+
+
+@pytest.mark.sandbox
+@pytest.mark.skipif(not has_format, reason='No format support')
+class TestStringFormat(object):
+
+    def test_basic_format_safety(self):
+        env = SandboxedEnvironment()
+        t = env.from_string('{{ "a{0.__class__}b".format(int) }}')
+        assert t.render() == 'ab'
+
+    def test_basic_format_all_okay(self):
+        env = SandboxedEnvironment()
+        t = env.from_string('{{ "a{0.foo}b".format({"foo": 42}) }}')
+        assert t.render() == 'a42b'

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -167,10 +167,20 @@ class TestStringFormat(object):
 
     def test_basic_format_safety(self):
         env = SandboxedEnvironment()
-        t = env.from_string('{{ "a{0.__class__}b".format(int) }}')
+        t = env.from_string('{{ "a{0.__class__}b".format(42) }}')
         assert t.render() == 'ab'
 
     def test_basic_format_all_okay(self):
         env = SandboxedEnvironment()
         t = env.from_string('{{ "a{0.foo}b".format({"foo": 42}) }}')
         assert t.render() == 'a42b'
+
+    def test_basic_format_safety(self):
+        env = SandboxedEnvironment()
+        t = env.from_string('{{ ("a{0.__class__}b{1}"|safe).format(42, "<foo>") }}')
+        assert t.render() == 'ab&lt;foo&gt;'
+
+    def test_basic_format_all_okay(self):
+        env = SandboxedEnvironment()
+        t = env.from_string('{{ ("a{0.foo}b{1}"|safe).format({"foo": 42}, "<foo>") }}')
+        assert t.render() == 'a42b&lt;foo&gt;'


### PR DESCRIPTION
This intercepts `str.format` properly through the Jinja2 sandbox.  It uses
undocumented APIs in Python which is why this might break going forward
but there is no better way currently available.