### PR TITLE
WIP: Correct Identifier Tracking

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Version 2.9
 - Restored behavior of Cycler for Python 3 users.
 - Subtraction now follows the same behavior as other operators on undefined
   values.
+- `map` and friends will now give better error messages if you forgot to
+  quote the parameter.
 
 Version 2.8.2
 -------------

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1100,8 +1100,8 @@ class CodeGenerator(NodeVisitor):
                         self.newline(item)
                     close = 1
                     if frame.eval_ctx.volatile:
-                        self.write('(context.eval_ctx.autoescape and'
-                                   ' escape or to_string)(')
+                        self.write('(escape if context.eval_ctx.autoescape'
+                                   ' else to_string)(')
                     elif frame.eval_ctx.autoescape:
                         self.write('escape(')
                     else:
@@ -1138,8 +1138,8 @@ class CodeGenerator(NodeVisitor):
                 self.newline(argument)
                 close = 0
                 if frame.eval_ctx.volatile:
-                    self.write('(context.eval_ctx.autoescape and'
-                               ' escape or to_string)(')
+                    self.write('(escape if context.eval_ctx.autoescape else'
+                               ' to_string)(')
                     close += 1
                 elif frame.eval_ctx.autoescape:
                     self.write('escape(')
@@ -1241,7 +1241,7 @@ class CodeGenerator(NodeVisitor):
         try:
             self.write(repr(node.as_const(frame.eval_ctx)))
         except nodes.Impossible:
-            self.write('(context.eval_ctx.autoescape and Markup or identity)(%r)'
+            self.write('(Markup if context.eval_ctx.autoescape else identity)(%r)'
                        % node.data)
 
     def visit_Tuple(self, node, frame):

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -147,10 +147,6 @@ class Frame(object):
         rv.symbols = self.symbols.copy()
         return rv
 
-    def inspect(self, nodes):
-        # XXX: remove me
-        pass
-
     def inner(self):
         """Return an inner frame."""
         return Frame(self.eval_ctx, self)
@@ -159,6 +155,8 @@ class Frame(object):
         """Return a soft frame.  A soft frame may not be modified as
         standalone thing as it shares the resources with the frame it
         was created of, but it's not a rootlevel frame any longer.
+
+        This is only used to implement if-statements.
         """
         rv = self.copy()
         rv.rootlevel = False
@@ -909,8 +907,7 @@ class CodeGenerator(NodeVisitor):
                 if self.environment.is_async:
                     self.write(')')
             self.write(' if (')
-            test_frame = loop_frame.copy()
-            self.visit(node.test, test_frame)
+            self.visit(node.test, loop_frame)
             self.write('))')
 
         elif node.recursive:

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -581,7 +581,8 @@ class CodeGenerator(NodeVisitor):
         self.writeline('name = %r' % self.name)
 
         # generate the root render function.
-        self.writeline('%s(context%s):' % (self.func('root'), envenv), extra=1)
+        self.writeline('%s(context, missing=missing%s):' %
+                       (self.func('root'), envenv), extra=1)
         self.indent()
 
         # process the root
@@ -614,7 +615,8 @@ class CodeGenerator(NodeVisitor):
 
         # at this point we now have the blocks collected and can visit them too.
         for name, block in iteritems(self.blocks):
-            self.writeline('%s(context%s):' % (self.func('block_' + name), envenv),
+            self.writeline('%s(context, missing=missing%s):' %
+                           (self.func('block_' + name), envenv),
                            block, 1)
             self.indent()
             # It's important that we do not make this frame a child of the

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -582,6 +582,7 @@ class CodeGenerator(NodeVisitor):
 
         # generate the root render function.
         self.writeline('%s(context%s):' % (self.func('root'), envenv), extra=1)
+        self.indent()
 
         # process the root
         frame = Frame(eval_ctx)
@@ -591,7 +592,6 @@ class CodeGenerator(NodeVisitor):
         frame.symbols.analyze_node(node)
         frame.toplevel = frame.rootlevel = True
         frame.require_output_check = have_extends and not self.has_known_extends
-        self.indent()
         if have_extends:
             self.writeline('parent_template = None')
         self.enter_frame(frame)
@@ -614,6 +614,9 @@ class CodeGenerator(NodeVisitor):
 
         # at this point we now have the blocks collected and can visit them too.
         for name, block in iteritems(self.blocks):
+            self.writeline('%s(context%s):' % (self.func('block_' + name), envenv),
+                           block, 1)
+            self.indent()
             # It's important that we do not make this frame a child of the
             # toplevel template.  This would cause a variety of
             # interesting issues with identifier tracking.
@@ -628,9 +631,6 @@ class CodeGenerator(NodeVisitor):
                                'block_%s)' % (ref, name, name))
             block_frame.symbols.analyze_node(block)
             block_frame.block = name
-            self.writeline('%s(context%s):' % (self.func('block_' + name), envenv),
-                           block, 1)
-            self.indent()
             self.enter_frame(block_frame)
             self.pull_dependencies(block.body)
             self.blockvisit(block.body, block_frame)

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -948,7 +948,6 @@ class CodeGenerator(NodeVisitor):
         if node.else_:
             self.writeline('if %s:' % iteration_indicator)
             self.indent()
-            print(else_frame.symbols.__dict__)
             self.enter_frame(else_frame)
             self.blockvisit(node.else_, else_frame)
             self.leave_frame(else_frame)

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -595,7 +595,7 @@ class CodeGenerator(NodeVisitor):
         self.enter_frame(frame)
         self.pull_dependencies(node.body)
         self.blockvisit(node.body, frame)
-        self.leave_frame(frame)
+        self.leave_frame(frame, with_python_scope=True)
         self.outdent()
 
         # make sure that the parent root is called.

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -791,8 +791,9 @@ class CodeGenerator(NodeVisitor):
         self.visit(node.template, frame)
         self.write(', %r).' % self.name)
         if node.with_context:
-            self.write('make_module%s(context.parent, True)'
-                       % (self.environment.is_async and '_async' or ''))
+            self.write('make_module%s(context.parent, True, %s)'
+                       % (self.environment.is_async and '_async' or '',
+                          self.dump_local_context(frame)))
         elif self.environment.is_async:
             self.write('_get_default_module_async()')
         else:

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -345,11 +345,9 @@ class CodeGenerator(NodeVisitor):
         """Visit a list of nodes as block in a frame.  If the current frame
         is no buffer a dummy ``if 0: yield None`` is written automatically.
         """
-        if frame.buffer is None:
-            self.writeline('if 0: yield None')
-        else:
-            self.writeline('pass')
         try:
+            if not nodes:
+                self.writeline('pass')
             for node in nodes:
                 self.visit(node, frame)
         except CompilerExit:
@@ -555,6 +553,7 @@ class CodeGenerator(NodeVisitor):
     def write_commons(self):
         self.writeline('resolve = context.resolve_or_missing')
         self.writeline('undefined = environment.undefined')
+        self.writeline('if 0: yield None')
 
     # -- Statement Visitors
 

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -135,7 +135,6 @@ class Frame(object):
         self.block = parent and parent.block or None
 
         # a set of actually assigned names
-        self.assigned_names = set()
         self.toplevel_assignments = set()
 
         # the parent of this frame
@@ -783,7 +782,6 @@ class CodeGenerator(NodeVisitor):
             self.write('_get_default_module()')
         if frame.toplevel and not node.target.startswith('_'):
             self.writeline('context.exported_vars.discard(%r)' % node.target)
-        frame.assigned_names.add(node.target)
 
     def visit_FromImport(self, node, frame):
         """Visit named imports."""
@@ -826,7 +824,6 @@ class CodeGenerator(NodeVisitor):
                 var_names.append(alias)
                 if not alias.startswith('_'):
                     discarded_names.append(alias)
-            frame.assigned_names.add(alias)
 
         if var_names:
             if len(var_names) == 1:
@@ -997,7 +994,6 @@ class CodeGenerator(NodeVisitor):
             self.writeline('context.vars[%r] = ' % node.name)
         self.write('%s = ' % frame.symbols.ref(node.name))
         self.macro_def(macro_ref, macro_frame)
-        frame.assigned_names.add(node.name)
 
     def visit_CallBlock(self, node, frame):
         call_frame, macro_ref = self.macro_body(node, frame)
@@ -1226,7 +1222,6 @@ class CodeGenerator(NodeVisitor):
                        (node.name, ref, ref))
         else:
             self.write(ref)
-        frame.assigned_names.add(node.name)
 
     def visit_Const(self, node, frame):
         val = node.value

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -842,7 +842,8 @@ class CodeGenerator(NodeVisitor):
 
     def visit_For(self, node, frame):
         # TODO: this should really use two frames: one for the loop body
-        # and a separate one for the loop else block.
+        # and a separate one for the loop else block.  This also is needed
+        # because the loop variable must not be visible in the else block
         loop_frame = frame.inner()
 
         # try to figure out if we have an extended loop.  An extended loop

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -18,6 +18,8 @@ from jinja2.exceptions import TemplateAssertionError
 from jinja2.utils import Markup, concat, escape
 from jinja2._compat import range_type, text_type, string_types, \
      iteritems, NativeStringIO, imap
+from jinja2.idtracking import Symbols, VAR_LOAD_PARAMETER, \
+     VAR_LOAD_RESOLVE, VAR_LOAD_ALIAS, VAR_LOAD_UNDEFINED
 
 
 operators = {
@@ -46,19 +48,6 @@ try:
     code_features.append('generator_stop')
 except SyntaxError:
     pass
-
-
-# does if 0: dummy(x) get us x into the scope?
-def unoptimize_before_dead_code():
-    x = 42
-    def f():
-        if 0: dummy(x)
-    return f
-
-# The getattr is necessary for pypy which does not set this attribute if
-# no closure is on the function
-unoptimize_before_dead_code = bool(
-    getattr(unoptimize_before_dead_code(), '__closure__', None))
 
 
 def generate(node, environment, name, filename, stream=None,
@@ -108,49 +97,12 @@ def find_undeclared(nodes, names):
     return visitor.undeclared
 
 
-class Identifiers(object):
-    """Tracks the status of identifiers in frames."""
-
-    def __init__(self):
-        # variables that are known to be declared (probably from outer
-        # frames or because they are special for the frame)
-        self.declared = set()
-
-        # undeclared variables from outer scopes
-        self.outer_undeclared = set()
-
-        # names that are accessed without being explicitly declared by
-        # this one or any of the outer scopes.  Names can appear both in
-        # declared and undeclared.
-        self.undeclared = set()
-
-        # names that are declared locally
-        self.declared_locally = set()
-
-        # names that are declared by parameters
-        self.declared_parameter = set()
-
-    def add_special(self, name):
-        """Register a special name like `loop`."""
-        self.undeclared.discard(name)
-        self.declared.add(name)
-
-    def is_declared(self, name):
-        """Check if a name is declared in this or an outer scope."""
-        if name in self.declared_locally or name in self.declared_parameter:
-            return True
-        return name in self.declared
-
-    def copy(self):
-        return deepcopy(self)
-
-
 class Frame(object):
     """Holds compile time information for us."""
 
     def __init__(self, eval_ctx, parent=None):
         self.eval_ctx = eval_ctx
-        self.identifiers = Identifiers()
+        self.symbols = Symbols(parent and parent.symbols or None)
 
         # a toplevel frame is the root + soft frames such as if conditions.
         self.toplevel = False
@@ -175,47 +127,24 @@ class Frame(object):
 
         # a set of actually assigned names
         self.assigned_names = set()
+        self.toplevel_assignments = set()
 
         # the parent of this frame
         self.parent = parent
 
         if parent is not None:
-            self.identifiers.declared.update(
-                parent.identifiers.declared |
-                parent.identifiers.declared_parameter |
-                parent.assigned_names
-            )
-            self.identifiers.outer_undeclared.update(
-                parent.identifiers.undeclared -
-                self.identifiers.declared
-            )
             self.buffer = parent.buffer
 
     def copy(self):
         """Create a copy of the current one."""
         rv = object.__new__(self.__class__)
         rv.__dict__.update(self.__dict__)
-        rv.identifiers = object.__new__(self.identifiers.__class__)
-        rv.identifiers.__dict__.update(self.identifiers.__dict__)
+        rv.symbols = self.symbols.copy()
         return rv
 
     def inspect(self, nodes):
-        """Walk the node and check for identifiers.  If the scope is hard (eg:
-        enforce on a python level) overrides from outer scopes are tracked
-        differently.
-        """
-        visitor = FrameIdentifierVisitor(self.identifiers)
-        for node in nodes:
-            visitor.visit(node)
-
-    def find_shadowed(self, extra=()):
-        """Find all the shadowed names.  extra is an iterable of variables
-        that may be defined with `add_special` which may occour scoped.
-        """
-        i = self.identifiers
-        return (i.declared | i.outer_undeclared) & \
-               (i.declared_locally | i.declared_parameter) | \
-               set(x for x in extra if i.is_declared(x))
+        # XXX: remove me
+        pass
 
     def inner(self):
         """Return an inner frame."""
@@ -276,95 +205,6 @@ class UndeclaredNameVisitor(NodeVisitor):
 
     def visit_Block(self, node):
         """Stop visiting a blocks."""
-
-
-class FrameIdentifierVisitor(NodeVisitor):
-    """A visitor for `Frame.inspect`."""
-
-    def __init__(self, identifiers):
-        self.identifiers = identifiers
-
-    def visit_Name(self, node):
-        """All assignments to names go through this function."""
-        if node.ctx == 'store':
-            self.identifiers.declared_locally.add(node.name)
-        elif node.ctx == 'param':
-            self.identifiers.declared_parameter.add(node.name)
-        elif node.ctx == 'load' and not \
-             self.identifiers.is_declared(node.name):
-            self.identifiers.undeclared.add(node.name)
-
-    def visit_If(self, node):
-        self.visit(node.test)
-        real_identifiers = self.identifiers
-
-        old_names = real_identifiers.declared_locally | \
-                    real_identifiers.declared_parameter
-
-        def inner_visit(nodes):
-            if not nodes:
-                return set()
-            self.identifiers = real_identifiers.copy()
-            for subnode in nodes:
-                self.visit(subnode)
-            rv = self.identifiers.declared_locally - old_names
-            # we have to remember the undeclared variables of this branch
-            # because we will have to pull them.
-            real_identifiers.undeclared.update(self.identifiers.undeclared)
-            self.identifiers = real_identifiers
-            return rv
-
-        body = inner_visit(node.body)
-        else_ = inner_visit(node.else_ or ())
-
-        # the differences between the two branches are also pulled as
-        # undeclared variables
-        real_identifiers.undeclared.update(body.symmetric_difference(else_) -
-                                           real_identifiers.declared)
-
-        # remember those that are declared.
-        real_identifiers.declared_locally.update(body | else_)
-
-    def visit_Macro(self, node):
-        self.identifiers.declared_locally.add(node.name)
-
-    def visit_Import(self, node):
-        self.generic_visit(node)
-        self.identifiers.declared_locally.add(node.target)
-
-    def visit_FromImport(self, node):
-        self.generic_visit(node)
-        for name in node.names:
-            if isinstance(name, tuple):
-                self.identifiers.declared_locally.add(name[1])
-            else:
-                self.identifiers.declared_locally.add(name)
-
-    def visit_Assign(self, node):
-        """Visit assignments in the correct order."""
-        self.visit(node.node)
-        self.visit(node.target)
-
-    def visit_For(self, node):
-        """Visiting stops at for blocks.  However the block sequence
-        is visited as part of the outer scope.
-        """
-        self.visit(node.iter)
-
-    def visit_CallBlock(self, node):
-        self.visit(node.call)
-
-    def visit_FilterBlock(self, node):
-        self.visit(node.filter)
-
-    def visit_AssignBlock(self, node):
-        """Stop visiting at block assigns."""
-
-    def visit_Scope(self, node):
-        """Stop visiting at scopes."""
-
-    def visit_Block(self, node):
-        """Stop visiting at blocks."""
 
 
 class CompilerExit(Exception):
@@ -489,8 +329,7 @@ class CodeGenerator(NodeVisitor):
 
     def blockvisit(self, nodes, frame):
         """Visit a list of nodes as block in a frame.  If the current frame
-        is no buffer a dummy ``if 0: yield None`` is written automatically
-        unless the force_generator parameter is set to False.
+        is no buffer a dummy ``if 0: yield None`` is written automatically.
         """
         if frame.buffer is None:
             self.writeline('if 0: yield None')
@@ -582,11 +421,6 @@ class CodeGenerator(NodeVisitor):
             self.write(', **')
             self.visit(node.dyn_kwargs, frame)
 
-    def pull_locals(self, frame):
-        """Pull all the references identifiers into the local scope."""
-        for name in frame.identifiers.undeclared:
-            self.writeline('l_%s = context.resolve(%r)' % (name, name))
-
     def pull_dependencies(self, nodes):
         """Pull all the dependencies."""
         visitor = DependencyFinderVisitor()
@@ -600,127 +434,24 @@ class CodeGenerator(NodeVisitor):
                 self.writeline('%s = environment.%s[%r]' %
                                (mapping[name], dependency, name))
 
-    def unoptimize_scope(self, frame):
-        """Disable Python optimizations for the frame."""
-        # XXX: this is not that nice but it has no real overhead.  It
-        # mainly works because python finds the locals before dead code
-        # is removed.  If that breaks we have to add a dummy function
-        # that just accepts the arguments and does nothing.
-        if frame.identifiers.declared:
-            self.writeline('%sdummy(%s)' % (
-                unoptimize_before_dead_code and 'if 0: ' or '',
-                ', '.join('l_' + name for name in frame.identifiers.declared)
-            ))
-
-    def push_scope(self, frame, extra_vars=()):
-        """This function returns all the shadowed variables in a dict
-        in the form name: alias and will write the required assignments
-        into the current scope.  No indentation takes place.
-
-        This also predefines locally declared variables from the loop
-        body because under some circumstances it may be the case that
-
-        `extra_vars` is passed to `Frame.find_shadowed`.
-        """
-        aliases = {}
-        for name in frame.find_shadowed(extra_vars):
-            aliases[name] = ident = self.temporary_identifier()
-            self.writeline('%s = l_%s' % (ident, name))
-        to_declare = set()
-        for name in frame.identifiers.declared_locally:
-            if name not in aliases:
-                to_declare.add('l_' + name)
-        if to_declare:
-            self.writeline(' = '.join(to_declare) + ' = missing')
-        return aliases
-
-    def pop_scope(self, aliases, frame):
-        """Restore all aliases and delete unused variables."""
-        for name, alias in iteritems(aliases):
-            self.writeline('l_%s = %s' % (name, alias))
-        to_delete = set()
-        for name in frame.identifiers.declared_locally:
-            if name not in aliases:
-                to_delete.add('l_' + name)
-        if to_delete:
-            # we cannot use the del statement here because enclosed
-            # scopes can trigger a SyntaxError:
-            #   a = 42; b = lambda: a; del a
-            self.writeline(' = '.join(to_delete) + ' = missing')
+    def enter_frame(self, frame):
+        for target, (action, param) in iteritems(frame.symbols.loads):
+            if action == VAR_LOAD_PARAMETER:
+                pass
+            elif action == VAR_LOAD_RESOLVE:
+                self.writeline('%s = context.resolve_or_missing(%r)' %
+                               (target, param))
+            elif action == VAR_LOAD_ALIAS:
+                self.writeline('%s = %s' % (target, param))
+            elif action == VAR_LOAD_UNDEFINED:
+                self.writeline('%s = missing' % target)
+            else:
+                raise NotImplementedError('unknown load instruction')
 
     def func(self, name):
         if self.environment.is_async:
             return 'async def %s' % name
         return 'def %s' % name
-
-    def function_scoping(self, node, frame, children=None,
-                         find_special=True):
-        """In Jinja a few statements require the help of anonymous
-        functions.  Those are currently macros and call blocks and in
-        the future also recursive loops.  As there is currently
-        technical limitation that doesn't allow reading and writing a
-        variable in a scope where the initial value is coming from an
-        outer scope, this function tries to fall back with a common
-        error message.  Additionally the frame passed is modified so
-        that the argumetns are collected and callers are looked up.
-
-        This will return the modified frame.
-        """
-        # we have to iterate twice over it, make sure that works
-        if children is None:
-            children = node.iter_child_nodes()
-        children = list(children)
-        func_frame = frame.inner()
-        func_frame.inspect(children)
-
-        # variables that are undeclared (accessed before declaration) and
-        # declared locally *and* part of an outside scope raise a template
-        # assertion error. Reason: we can't generate reasonable code from
-        # it without aliasing all the variables.
-        # this could be fixed in Python 3 where we have the nonlocal
-        # keyword or if we switch to bytecode generation
-        overridden_closure_vars = (
-            func_frame.identifiers.undeclared &
-            func_frame.identifiers.declared &
-            (func_frame.identifiers.declared_locally |
-             func_frame.identifiers.declared_parameter)
-        )
-        if overridden_closure_vars:
-            self.fail('It\'s not possible to set and access variables '
-                      'derived from an outer scope! (affects: %s)' %
-                      ', '.join(sorted(overridden_closure_vars)), node.lineno)
-
-        # remove variables from a closure from the frame's undeclared
-        # identifiers.
-        func_frame.identifiers.undeclared -= (
-            func_frame.identifiers.undeclared &
-            func_frame.identifiers.declared
-        )
-
-        # no special variables for this scope, abort early
-        if not find_special:
-            return func_frame
-
-        func_frame.accesses_kwargs = False
-        func_frame.accesses_varargs = False
-        func_frame.accesses_caller = False
-        func_frame.arguments = args = ['l_' + x.name for x in node.args]
-
-        undeclared = find_undeclared(children, ('caller', 'kwargs', 'varargs'))
-
-        if 'caller' in undeclared:
-            func_frame.accesses_caller = True
-            func_frame.identifiers.add_special('caller')
-            args.append('l_caller')
-        if 'kwargs' in undeclared:
-            func_frame.accesses_kwargs = True
-            func_frame.identifiers.add_special('kwargs')
-            args.append('l_kwargs')
-        if 'varargs' in undeclared:
-            func_frame.accesses_varargs = True
-            func_frame.identifiers.add_special('varargs')
-            args.append('l_varargs')
-        return func_frame
 
     def macro_body(self, node, frame, children=None):
         """Dump the function def of a macro or call block."""
@@ -728,15 +459,6 @@ class CodeGenerator(NodeVisitor):
         # macros are delayed, they never require output checks
         frame.require_output_check = False
         args = frame.arguments
-        # XXX: this is an ugly fix for the loop nesting bug
-        # (tests.test_old_bugs.test_loop_call_bug).  This works around
-        # a identifier nesting problem we have in general.  It's just more
-        # likely to happen in loops which is why we work around it.  The
-        # real solution would be "nonlocal" all the identifiers that are
-        # leaking into a new python frame and might be used both unassigned
-        # and assigned.
-        if 'loop' in frame.identifiers.declared:
-            args = args + ['l_loop=l_loop']
         self.writeline('%s(%s):' % (self.func('macro'), ', '.join(args)), node)
         self.indent()
         self.buffer(frame)
@@ -770,6 +492,11 @@ class CodeGenerator(NodeVisitor):
             rv += ' in ' + repr(self.name)
         return rv
 
+    def dump_local_context(self, frame):
+        return '{%s}' % ', '.join(
+            '%r: %s' % (name, target) for name, target
+            in iteritems(frame.symbols.dump_stores()))
+
     # -- Statement Visitors
 
     def visit_Template(self, node, frame=None):
@@ -779,8 +506,6 @@ class CodeGenerator(NodeVisitor):
         from jinja2.runtime import __all__ as exported
         self.writeline('from __future__ import %s' % ', '.join(code_features))
         self.writeline('from jinja2.runtime import ' + ', '.join(exported))
-        if not unoptimize_before_dead_code:
-            self.writeline('dummy = lambda *x: None')
 
         if self.environment.is_async:
             self.writeline('from jinja2.asyncsupport import auto_await, '
@@ -820,16 +545,16 @@ class CodeGenerator(NodeVisitor):
 
         # process the root
         frame = Frame(eval_ctx)
-        frame.inspect(node.body)
+        if 'self' in find_undeclared(node.body, ('self',)):
+            ref = frame.symbols.declare_parameter('self')
+            self.writeline('%s = TemplateReference(context)' % ref)
+        frame.symbols.analyze_node(node)
         frame.toplevel = frame.rootlevel = True
         frame.require_output_check = have_extends and not self.has_known_extends
         self.indent()
         if have_extends:
             self.writeline('parent_template = None')
-        if 'self' in find_undeclared(node.body, ('self',)):
-            frame.identifiers.add_special('self')
-            self.writeline('l_self = TemplateReference(context)')
-        self.pull_locals(frame)
+        self.enter_frame(frame)
         self.pull_dependencies(node.body)
         self.blockvisit(node.body, frame)
         self.outdent()
@@ -848,21 +573,24 @@ class CodeGenerator(NodeVisitor):
 
         # at this point we now have the blocks collected and can visit them too.
         for name, block in iteritems(self.blocks):
+            # It's important that we do not make this frame a child of the
+            # toplevel template.  This would cause a variety of
+            # interesting issues with identifier tracking.
             block_frame = Frame(eval_ctx)
-            block_frame.inspect(block.body)
+            undeclared = find_undeclared(block.body, ('self', 'super'))
+            if 'self' in undeclared:
+                ref = block_frame.symbols.declare_parameter('self')
+                self.writeline('%s = TemplateReference(context)' % ref)
+            if 'super' in undeclared:
+                ref = block_frame.symbols.declare_parameter('super')
+                self.writeline('%s = context.super(%r, '
+                               'block_%s)' % (ref, name, name))
+            block_frame.symbols.analyze_node(block)
             block_frame.block = name
             self.writeline('%s(context%s):' % (self.func('block_' + name), envenv),
                            block, 1)
             self.indent()
-            undeclared = find_undeclared(block.body, ('self', 'super'))
-            if 'self' in undeclared:
-                block_frame.identifiers.add_special('self')
-                self.writeline('l_self = TemplateReference(context)')
-            if 'super' in undeclared:
-                block_frame.identifiers.add_special('super')
-                self.writeline('l_super = context.super(%r, '
-                               'block_%s)' % (name, name))
-            self.pull_locals(block_frame)
+            self.enter_frame(block_frame)
             self.pull_dependencies(block.body)
             self.blockvisit(block.body, block_frame)
             self.outdent()
@@ -887,7 +615,8 @@ class CodeGenerator(NodeVisitor):
                 self.writeline('if parent_template is None:')
                 self.indent()
                 level += 1
-        context = node.scoped and 'context.derived(locals())' or 'context'
+        context = node.scoped and (
+            'context.derived(%s)' % self.dump_local_context(frame)) or 'context'
 
         loop = self.environment.is_async and 'async for' or 'for'
         self.writeline('%s event in context.blocks[%r][0](%s):' % (
@@ -945,8 +674,6 @@ class CodeGenerator(NodeVisitor):
 
     def visit_Include(self, node, frame):
         """Handles includes."""
-        if node.with_context:
-            self.unoptimize_scope(frame)
         if node.ignore_missing:
             self.writeline('try:')
             self.indent()
@@ -976,7 +703,7 @@ class CodeGenerator(NodeVisitor):
             loop = self.environment.is_async and 'async for' or 'for'
             self.writeline('%s event in template.root_render_func('
                            'template.new_context(context.parent, True, '
-                           'locals())):' % loop)
+                           '%s)):' % (loop, self.dump_local_context(frame)))
         elif self.environment.is_async:
             self.writeline('for event in (await '
                            'template._get_default_module_async())'
@@ -994,8 +721,6 @@ class CodeGenerator(NodeVisitor):
 
     def visit_Import(self, node, frame):
         """Visit regular imports."""
-        if node.with_context:
-            self.unoptimize_scope(frame)
         self.writeline('l_%s = ' % node.target, node)
         if frame.toplevel:
             self.write('context.vars[%r] = ' % node.target)
@@ -1005,8 +730,9 @@ class CodeGenerator(NodeVisitor):
         self.visit(node.template, frame)
         self.write(', %r).' % self.name)
         if node.with_context:
-            self.write('make_module%s(context.parent, True, locals())'
-                       % (self.environment.is_async and '_async' or ''))
+            self.write('make_module%s(context.parent, True, %s)'
+                       % (self.environment.is_async and '_async' or '',
+                          self.dump_local_context(frame)))
         elif self.environment.is_async:
             self.write('_get_default_module_async()')
         else:
@@ -1073,15 +799,7 @@ class CodeGenerator(NodeVisitor):
                                'update((%s))' % ', '.join(imap(repr, discarded_names)))
 
     def visit_For(self, node, frame):
-        # when calculating the nodes for the inner frame we have to exclude
-        # the iterator contents from it
-        children = node.iter_child_nodes(exclude=('iter',))
-        if node.recursive:
-            loop_frame = self.function_scoping(node, frame, children,
-                                               find_special=False)
-        else:
-            loop_frame = frame.inner()
-            loop_frame.inspect(children)
+        loop_frame = Frame(frame.eval_ctx, frame)
 
         # try to figure out if we have an extended loop.  An extended loop
         # is necessary if the loop is in recursive mode if the special loop
@@ -1090,31 +808,30 @@ class CodeGenerator(NodeVisitor):
                         find_undeclared(node.iter_child_nodes(
                             only=('body',)), ('loop',))
 
+        loop_ref = None
+        if extended_loop:
+            loop_ref = loop_frame.symbols.declare_parameter('loop')
+        loop_frame.symbols.analyze_node(node)
+
         # if we don't have an recursive loop we have to find the shadowed
         # variables at that point.  Because loops can be nested but the loop
         # variable is a special one we have to enforce aliasing for it.
-        if not node.recursive:
-            aliases = self.push_scope(loop_frame, ('loop',))
-
-        # otherwise we set up a buffer and add a function def
-        else:
+        if node.recursive:
             self.writeline('%s(reciter, loop_render_func, depth=0):' %
                            self.func('loop'), node)
             self.indent()
             self.buffer(loop_frame)
-            aliases = {}
 
         # make sure the loop variable is a special one and raise a template
         # assertion error if a loop tries to write to loop
         if extended_loop:
-            self.writeline('l_loop = missing')
-            loop_frame.identifiers.add_special('loop')
+            self.writeline('%s = missing' % loop_ref)
+
         for name in node.find_all(nodes.Name):
             if name.ctx == 'store' and name.name == 'loop':
                 self.fail('Can\'t assign to special loop variable '
                           'in for-loop target', name.lineno)
 
-        self.pull_locals(loop_frame)
         if node.else_:
             iteration_indicator = self.temporary_identifier()
             self.writeline('%s = 1' % iteration_indicator)
@@ -1122,7 +839,7 @@ class CodeGenerator(NodeVisitor):
         # Create a fake parent loop if the else or test section of a
         # loop is accessing the special loop variable and no parent loop
         # exists.
-        if 'loop' not in aliases and 'loop' in find_undeclared(
+        if frame.symbols.find_ref('loop') is None and 'loop' in find_undeclared(
            node.iter_child_nodes(only=('else_', 'test')), ('loop',)):
             self.writeline("l_loop = environment.undefined(%r, name='loop')" %
                 ("'loop' is undefined. the filter section of a loop as well "
@@ -1176,17 +893,18 @@ class CodeGenerator(NodeVisitor):
         else:
             self.write(extended_loop and '):' or ':')
 
+        self.indent()
+        self.enter_frame(loop_frame)
+
         # tests in not extended loops become a continue
         if not extended_loop and node.test is not None:
-            self.indent()
             self.writeline('if not ')
             self.visit(node.test, loop_frame)
             self.write(':')
             self.indent()
             self.writeline('continue')
-            self.outdent(2)
+            self.outdent()
 
-        self.indent()
         self.blockvisit(node.body, loop_frame)
         if node.else_:
             self.writeline('%s = 0' % iteration_indicator)
@@ -1197,10 +915,6 @@ class CodeGenerator(NodeVisitor):
             self.indent()
             self.blockvisit(node.else_, loop_frame)
             self.outdent()
-
-        # reset the aliases if there are any.
-        if not node.recursive:
-            self.pop_scope(aliases, loop_frame)
 
         # if the node was recursive we have to return the buffer contents
         # and start the iteration code
@@ -1239,7 +953,9 @@ class CodeGenerator(NodeVisitor):
         if frame.toplevel:
             if not node.name.startswith('_'):
                 self.write('context.exported_vars.add(%r)' % node.name)
-            self.writeline('context.vars[%r] = ' % node.name)
+            ref = frame.symbols.find_ref(node.name)
+            assert ref is not None, 'unknown reference for macro'
+            self.writeline('context.vars[%r] = ' % ref)
         self.write('l_%s = ' % node.name)
         self.macro_def(node, macro_frame)
         frame.assigned_names.add(node.name)
@@ -1425,20 +1141,24 @@ class CodeGenerator(NodeVisitor):
         assignment_frame.toplevel_assignments = set()
         return assignment_frame
 
-    def export_assigned_vars(self, frame, assignment_frame):
+    def export_assigned_vars(self, frame):
         if not frame.toplevel:
             return
-        public_names = [x for x in assignment_frame.toplevel_assignments
+        public_names = [x for x in frame.toplevel_assignments
                         if not x.startswith('_')]
-        if len(assignment_frame.toplevel_assignments) == 1:
-            name = next(iter(assignment_frame.toplevel_assignments))
-            self.writeline('context.vars[%r] = l_%s' % (name, name))
+        if len(frame.toplevel_assignments) == 1:
+            name = next(iter(frame.toplevel_assignments))
+            ref = frame.symbols.find_ref(name)
+            assert ref is not None, 'missing ref in export'
+            self.writeline('context.vars[%r] = %s' % (name, ref))
         else:
             self.writeline('context.vars.update({')
             for idx, name in enumerate(assignment_frame.toplevel_assignments):
                 if idx:
                     self.write(', ')
-                self.write('%r: l_%s' % (name, name))
+                ref = frame.symbols.find_ref(name)
+                assert ref is not None, 'missing ref in export'
+                self.write('%r: %s' % (name, ref))
             self.write('})')
         if public_names:
             if len(public_names) == 1:
@@ -1450,11 +1170,10 @@ class CodeGenerator(NodeVisitor):
 
     def visit_Assign(self, node, frame):
         self.newline(node)
-        assignment_frame = self.make_assignment_frame(frame)
-        self.visit(node.target, assignment_frame)
+        self.visit(node.target, frame)
         self.write(' = ')
         self.visit(node.node, frame)
-        self.export_assigned_vars(frame, assignment_frame)
+        self.export_assigned_vars(frame)
 
     def visit_AssignBlock(self, node, frame):
         block_frame = frame.inner()
@@ -1469,18 +1188,23 @@ class CodeGenerator(NodeVisitor):
         self.blockvisit(node.body, block_frame)
         self.pop_scope(aliases, block_frame)
 
-        assignment_frame = self.make_assignment_frame(frame)
         self.newline(node)
-        self.visit(node.target, assignment_frame)
+        self.visit(node.target, frame)
         self.write(' = concat(%s)' % block_frame.buffer)
-        self.export_assigned_vars(frame, assignment_frame)
+        self.export_assigned_vars(frame)
 
     # -- Expression Visitors
 
     def visit_Name(self, node, frame):
         if node.ctx == 'store' and frame.toplevel:
             frame.toplevel_assignments.add(node.name)
-        self.write('l_' + node.name)
+        ref = frame.symbols.find_ref(node.name)
+        assert ref is not None, 'compiler error: undefined ref (%r)' % node.name
+        if node.ctx == 'load':
+            self.write('(environment.undefined(name=%r) if %s is missing else %s)' %
+                       (node.name, ref, ref))
+        else:
+            self.write(ref)
         frame.assigned_names.add(node.name)
 
     def visit_Const(self, node, frame):

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -942,7 +942,8 @@ class CodeGenerator(NodeVisitor):
         if node.else_:
             self.writeline('%s = 0' % iteration_indicator)
         self.outdent()
-        self.leave_frame(loop_frame)
+        self.leave_frame(loop_frame, with_python_scope=node.recursive
+                         and not node.else_)
 
         if node.else_:
             self.writeline('if %s:' % iteration_indicator)

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1167,17 +1167,6 @@ class CodeGenerator(NodeVisitor):
         if outdent_later:
             self.outdent()
 
-    def make_assignment_frame(self, frame):
-        # toplevel assignments however go into the local namespace and
-        # the current template's context.  We create a copy of the frame
-        # here and add a set so that the Name visitor can add the assigned
-        # names here.
-        if not frame.toplevel:
-            return frame
-        assignment_frame = frame.copy()
-        assignment_frame.toplevel_assignments = set()
-        return assignment_frame
-
     def export_assigned_vars(self, frame):
         if not frame.toplevel:
             return

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -841,7 +841,7 @@ class CodeGenerator(NodeVisitor):
                                'update((%s))' % ', '.join(imap(repr, discarded_names)))
 
     def visit_For(self, node, frame):
-        # TODO: this shoudl really use two frames: one for the loop body
+        # TODO: this should really use two frames: one for the loop body
         # and a separate one for the loop else block.
         loop_frame = frame.inner()
 

--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -205,7 +205,7 @@ def get_jinja_locals(real_locals):
     local_overrides = {}
 
     for name, value in iteritems(real_locals):
-        if not name.startswith('l_'):
+        if not name.startswith('l_') or value is missing:
             continue
         _, depth, name = name.split('_', 2)
         depth = int(depth)

--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -207,8 +207,11 @@ def get_jinja_locals(real_locals):
     for name, value in iteritems(real_locals):
         if not name.startswith('l_') or value is missing:
             continue
-        _, depth, name = name.split('_', 2)
-        depth = int(depth)
+        try:
+            _, depth, name = name.split('_', 2)
+            depth = int(depth)
+        except ValueError:
+            continue
         cur_depth = local_overrides.get(name, (-1,))[0]
         if cur_depth < depth:
             local_overrides[name] = (depth, value)

--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -216,7 +216,7 @@ def get_jinja_locals(real_locals):
         if cur_depth < depth:
             local_overrides[name] = (depth, value)
 
-    for name, (_, value) in local_overrides.iteritems():
+    for name, (_, value) in iteritems(local_overrides):
         if value is missing:
             locals.pop(name, None)
         else:

--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -195,21 +195,40 @@ def translate_exception(exc_info, initial_skip=0):
     return ProcessedTraceback(exc_info[0], exc_info[1], frames)
 
 
+def get_jinja_locals(real_locals):
+    ctx = real_locals.get('context')
+    if ctx:
+        locals = ctx.get_all()
+    else:
+        locals = {}
+
+    local_overrides = {}
+
+    for name, value in iteritems(real_locals):
+        if not name.startswith('l_'):
+            continue
+        _, depth, name = name.split('_', 2)
+        depth = int(depth)
+        cur_depth = local_overrides.get(name, (-1,))[0]
+        if cur_depth < depth:
+            local_overrides[name] = (depth, value)
+
+    for name, (_, value) in local_overrides.iteritems():
+        if value is missing:
+            locals.pop(name, None)
+        else:
+            locals[name] = value
+
+    return locals
+
+
 def fake_exc_info(exc_info, filename, lineno):
     """Helper for `translate_exception`."""
     exc_type, exc_value, tb = exc_info
 
     # figure the real context out
     if tb is not None:
-        real_locals = tb.tb_frame.f_locals.copy()
-        ctx = real_locals.get('context')
-        if ctx:
-            locals = ctx.get_all()
-        else:
-            locals = {}
-        for name, value in iteritems(real_locals):
-            if name.startswith('l_') and value is not missing:
-                locals[name[2:]] = value
+        locals = get_jinja_locals(tb.tb_frame.f_locals)
 
         # if there is a local called __jinja_exception__, we get
         # rid of it to not break the debug functionality.

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -88,6 +88,16 @@ def load_extensions(environment, extensions):
     return result
 
 
+def fail_for_missing_callable(string, name):
+    msg = string % name
+    if isinstance(name, Undefined):
+        try:
+            name._fail_with_undefined_error()
+        except Exception as e:
+            msg = '%s (%s; did you forget to quote the callable name?)' % (msg, e)
+    raise TemplateRuntimeError(msg)
+
+
 def _environment_sanity_check(environment):
     """Perform a sanity check on the environment."""
     assert issubclass(environment.undefined, Undefined), 'undefined must ' \
@@ -439,7 +449,7 @@ class Environment(object):
         """
         func = self.filters.get(name)
         if func is None:
-            raise TemplateRuntimeError('no filter named %r' % name)
+            fail_for_missing_callable('no filter named %r', name)
         args = [value] + list(args or ())
         if getattr(func, 'contextfilter', False):
             if context is None:
@@ -464,7 +474,7 @@ class Environment(object):
         """
         func = self.tests.get(name)
         if func is None:
-            raise TemplateRuntimeError('no test named %r' % name)
+            fail_for_missing_callable('no test named %r', name)
         return func(value, *(args or ()), **(kwargs or {}))
 
     @internalcode

--- a/jinja2/idtracking.py
+++ b/jinja2/idtracking.py
@@ -51,6 +51,13 @@ class Symbols(object):
         if self.parent is not None:
             return self.parent.find_ref(name)
 
+    def ref(self, name):
+        rv = self.find_ref(name)
+        if rv is None:
+            raise AssertionError('Tried to resolve a name to a reference that '
+                                 'was unknown to the frame (%r)' % name)
+        return rv
+
     def copy(self):
         rv = object.__new__(self.__class__)
         rv.__dict__.update(self.__dict__)

--- a/jinja2/idtracking.py
+++ b/jinja2/idtracking.py
@@ -1,0 +1,216 @@
+from jinja2.visitor import NodeVisitor
+from jinja2._compat import iteritems
+
+
+VAR_LOAD_PARAMETER = 'param'
+VAR_LOAD_RESOLVE = 'resolve'
+VAR_LOAD_ALIAS = 'alias'
+VAR_LOAD_UNDEFINED = 'undefined'
+
+
+def find_symbols(nodes, parent_symbols=None):
+    sym = Symbols(parent=parent_symbols)
+    visitor = FrameSymbolVisitor(sym)
+    for node in nodes:
+        visitor.visit(node)
+    return sym
+
+
+def symbols_for_node(node, parent_symbols=None):
+    sym = Symbols(parent=parent_symbols)
+    sym.analyze_node(node)
+    return sym
+
+
+class Symbols(object):
+
+    def __init__(self, parent=None):
+        if parent is None:
+            self.level = 0
+        else:
+            self.level = parent.level + 1
+        self.parent = parent
+        self.refs = {}
+        self.loads = {}
+        self.stores = set()
+
+    def analyze_node(self, node):
+        visitor = RootVisitor(self)
+        visitor.visit(node)
+
+    def _define_ref(self, name, load=None):
+        ident = 'l_%d_%s' % (self.level, name)
+        self.refs[name] = ident
+        if load is not None:
+            self.loads[ident] = load
+        return ident
+
+    def find_ref(self, name):
+        if name in self.refs:
+            return self.refs[name]
+        if self.parent is not None:
+            return self.parent.find_ref(name)
+
+    def copy(self):
+        rv = object.__new__(self.__class__)
+        rv.__dict__.update(self.__dict__)
+        rv.refs = self.refs.copy()
+        rv.loads = self.loads.copy()
+        rv.stores = self.stores.copy()
+        return rv
+
+    def store(self, name):
+        # We already have that name locally, so we can just bail
+        if name not in self.refs:
+            self._define_ref(name, load=(VAR_LOAD_UNDEFINED, None))
+        self.stores.add(name)
+
+    def declare_parameter(self, name):
+        self.stores.add(name)
+        return self._define_ref(name, load=(VAR_LOAD_PARAMETER, None))
+
+    def load(self, name):
+        target = self.find_ref(name)
+        if target is None:
+            self._define_ref(name, load=(VAR_LOAD_RESOLVE, name))
+
+    def branch_update(self, branch_symbols):
+        stores = {}
+        for branch in branch_symbols:
+            for target in branch.stores:
+                if target in self.stores:
+                    continue
+                stores[target] = stores.get(target, 0) + 1
+
+        for sym in branch_symbols:
+            self.refs.update(sym.refs)
+            self.loads.update(sym.loads)
+            self.stores.update(sym.stores)
+
+        for name, branch_count in iteritems(stores):
+            if branch_count == len(branch_symbols):
+                continue
+            target = self.find_ref(name)
+            assert target is not None, 'should not happen'
+
+            if self.parent is not None:
+                outer_target = self.parent.find_ref(name)
+                if outer_target is not None:
+                    self.loads[target] = (VAR_LOAD_ALIAS, outer_target)
+                    continue
+            self.loads[target] = (VAR_LOAD_RESOLVE, name)
+
+    def dump_stores(self):
+        rv = {}
+        node = self
+        while node is not None:
+            for name in node.stores:
+                if name not in rv:
+                    rv[name] = self.find_ref(name)
+            node = node.parent
+        return rv
+
+
+class RootVisitor(NodeVisitor):
+
+    def __init__(self, symbols):
+        self.sym_visitor = FrameSymbolVisitor(symbols)
+
+    def _simple_visit(self, node):
+        for child in node.iter_child_nodes():
+            self.sym_visitor.visit(child)
+
+    visit_Template = visit_Block = visit_Macro = visit_FilterBlock = \
+        visit_Scope = visit_If = visit_ScopedEvalContextModifier = \
+        _simple_visit
+
+    def visit_AssignBlock(self, node):
+        for child in self.body:
+            self.sym_visitor.visit(child)
+
+    def visit_CallBlock(self, node):
+        for child in node.iter_child_nodes(exclude=('call',)):
+            self.sym_visitor.visit(child)
+
+    def visit_For(self, node):
+        self.sym_visitor.visit(node.target, store_as_param=True)
+        for child in node.iter_child_nodes(exclude=('iter', 'target')):
+            self.sym_visitor.visit(child)
+
+    def generic_visit(self, node, *args, **kwargs):
+        raise NotImplementedError('Cannot find symbols for %r' %
+                                  node.__class__.__name__)
+
+
+class FrameSymbolVisitor(NodeVisitor):
+    """A visitor for `Frame.inspect`."""
+
+    def __init__(self, symbols):
+        self.symbols = symbols
+
+    def visit_Name(self, node, store_as_param=False, **kwargs):
+        """All assignments to names go through this function."""
+        if store_as_param or node.ctx == 'param':
+            self.symbols.declare_parameter(node.name)
+        elif node.ctx == 'store':
+            self.symbols.store(node.name)
+        elif node.ctx == 'load':
+            self.symbols.load(node.name)
+
+    def visit_If(self, node, **kwargs):
+        self.visit(node.test, **kwargs)
+
+        original_symbols = self.symbols
+
+        def inner_visit(nodes):
+            self.symbols = rv = original_symbols.copy()
+            for subnode in nodes:
+                self.visit(subnode, **kwargs)
+            self.symbols = original_symbols
+            return rv
+
+        body_symbols = inner_visit(node.body)
+        else_symbols = inner_visit(node.else_ or ())
+
+        self.symbols.branch_update([body_symbols, else_symbols])
+
+    def visit_Macro(self, node, **kwargs):
+        self.symbols.store(node.name)
+
+    def visit_Import(self, node, **kwargs):
+        self.generic_visit(node, **kwargs)
+        self.symbols.store(node.target)
+
+    def visit_FromImport(self, node, **kwargs):
+        self.generic_visit(node, **kwargs)
+        for name in node.names:
+            if isinstance(name, tuple):
+                self.symbols.store(name[1])
+            else:
+                self.symbols.store(name)
+
+    def visit_Assign(self, node, **kwargs):
+        """Visit assignments in the correct order."""
+        self.visit(node.node, **kwargs)
+        self.visit(node.target, **kwargs)
+
+    def visit_For(self, node, **kwargs):
+        """Visiting stops at for blocks.  However the block sequence
+        is visited as part of the outer scope.
+        """
+        self.visit(node.iter, **kwargs)
+
+    def visit_CallBlock(self, node, **kwargs):
+        self.visit(node.call, **kwargs)
+
+    def visit_FilterBlock(self, node, **kwargs):
+        self.visit(node.filter, **kwargs)
+
+    def visit_AssignBlock(self, node, **kwargs):
+        """Stop visiting at block assigns."""
+
+    def visit_Scope(self, node, **kwargs):
+        """Stop visiting at scopes."""
+
+    def visit_Block(self, node, **kwargs):
+        """Stop visiting at blocks."""

--- a/jinja2/idtracking.py
+++ b/jinja2/idtracking.py
@@ -132,7 +132,7 @@ class RootVisitor(NodeVisitor):
         _simple_visit
 
     def visit_AssignBlock(self, node):
-        for child in self.body:
+        for child in node.body:
             self.sym_visitor.visit(child)
 
     def visit_CallBlock(self, node):
@@ -215,6 +215,7 @@ class FrameSymbolVisitor(NodeVisitor):
 
     def visit_AssignBlock(self, node, **kwargs):
         """Stop visiting at block assigns."""
+        self.visit(node.target, **kwargs)
 
     def visit_Scope(self, node, **kwargs):
         """Stop visiting at scopes."""

--- a/jinja2/meta.py
+++ b/jinja2/meta.py
@@ -11,7 +11,7 @@
 """
 from jinja2 import nodes
 from jinja2.compiler import CodeGenerator
-from jinja2._compat import string_types
+from jinja2._compat import string_types, iteritems
 
 
 class TrackingCodeGenerator(CodeGenerator):
@@ -25,9 +25,12 @@ class TrackingCodeGenerator(CodeGenerator):
     def write(self, x):
         """Don't write."""
 
-    def pull_locals(self, frame):
+    def enter_frame(self, frame):
         """Remember all undeclared identifiers."""
-        self.undeclared_identifiers.update(frame.identifiers.undeclared)
+        CodeGenerator.enter_frame(self, frame)
+        for _, (action, param) in iteritems(frame.symbols.loads):
+            if action == 'resolve':
+                self.undeclared_identifiers.add(param)
 
 
 def find_undeclared_variables(ast):

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -242,6 +242,35 @@ class Node(with_metaclass(NodeType, object)):
                       arg in self.fields)
         )
 
+    def dump(self):
+        def _dump(node):
+            if not isinstance(node, Node):
+                buf.append(repr(node))
+                return
+
+            buf.append('nodes.%s(' % node.__class__.__name__)
+            if not node.fields:
+                buf.append(')')
+                return
+            for idx, field in enumerate(node.fields):
+                if idx:
+                    buf.append(', ')
+                value = getattr(node, field)
+                if isinstance(value, list):
+                    buf.append('[')
+                    for idx, item in enumerate(value):
+                        if idx:
+                            buf.append(', ')
+                        _dump(item)
+                    buf.append(']')
+                else:
+                    _dump(value)
+            buf.append(')')
+        buf = []
+        _dump(self)
+        return ''.join(buf)
+
+
 
 class Stmt(Node):
     """Base node for all statements."""

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -24,7 +24,7 @@ from jinja2._compat import imap, text_type, iteritems, \
 __all__ = ['LoopContext', 'TemplateReference', 'Macro', 'Markup',
            'TemplateRuntimeError', 'missing', 'concat', 'escape',
            'markup_join', 'unicode_join', 'to_string', 'identity',
-           'TemplateNotFound', 'make_logging_undefined']
+           'TemplateNotFound']
 
 #: the name of the function that is used to convert something into
 #: a string.  We can just use the text type here.

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -397,14 +397,13 @@ class LoopContextIterator(object):
 class Macro(object):
     """Wraps a macro function."""
 
-    def __init__(self, environment, func, name, arguments, defaults,
+    def __init__(self, environment, func, name, arguments,
                  catch_kwargs, catch_varargs, caller):
         self._environment = environment
         self._func = func
         self._argument_count = len(arguments)
         self.name = name
         self.arguments = arguments
-        self.defaults = defaults
         self.catch_kwargs = catch_kwargs
         self.catch_varargs = catch_varargs
         self.caller = caller
@@ -423,11 +422,7 @@ class Macro(object):
                 try:
                     value = kwargs.pop(name)
                 except KeyError:
-                    try:
-                        value = self.defaults[idx - self._argument_count + off]
-                    except IndexError:
-                        value = self._environment.undefined(
-                            'parameter %r was not provided' % name, name=name)
+                    value = missing
                 arguments.append(value)
 
         # it's important that the order of these arguments does not change

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -329,7 +329,7 @@ class TestLowLevel():
 
     def test_custom_context(self):
         class CustomContext(Context):
-            def resolve(self, key):
+            def resolve_or_missing(self, key):
                 return 'resolve-' + key
 
         class CustomEnvironment(Environment):

--- a/tests/test_core_tags.py
+++ b/tests/test_core_tags.py
@@ -308,13 +308,11 @@ class TestMacros():
             '{% macro bar() %}{{ varargs }}{{ kwargs }}{% endmacro %}'
             '{% macro baz() %}{{ caller() }}{% endmacro %}')
         assert tmpl.module.foo.arguments == ('a', 'b')
-        assert tmpl.module.foo.defaults == ()
         assert tmpl.module.foo.name == 'foo'
         assert not tmpl.module.foo.caller
         assert not tmpl.module.foo.catch_kwargs
         assert not tmpl.module.foo.catch_varargs
         assert tmpl.module.bar.arguments == ()
-        assert tmpl.module.bar.defaults == ()
         assert not tmpl.module.bar.caller
         assert tmpl.module.bar.catch_kwargs
         assert tmpl.module.bar.catch_varargs

--- a/tests/test_core_tags.py
+++ b/tests/test_core_tags.py
@@ -20,7 +20,7 @@ def env_trim():
 
 @pytest.mark.core_tags
 @pytest.mark.for_loop
-class TestForLoop():
+class TestForLoop(object):
 
     def test_simple(self, env):
         tmpl = env.from_string('{% for item in seq %}{{ item }}{% endfor %}')
@@ -30,6 +30,11 @@ class TestForLoop():
         tmpl = env.from_string(
             '{% for item in seq %}XXX{% else %}...{% endfor %}')
         assert tmpl.render() == '...'
+
+    def test_else_scoping_item(self, env):
+        tmpl = env.from_string(
+            '{% for item in [] %}{% else %}{{ item }}{% endfor %}')
+        assert tmpl.render(item=42) == '42'
 
     def test_empty_blocks(self, env):
         tmpl = env.from_string('<{% for item in seq %}{% else %}{% endfor %}>')

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -80,6 +80,7 @@ ZeroDivisionError: (int(eger)? )?division (or modulo )?by zero
             'l_1_foo': 23,
             'l_2_foo': 13,
             'l_0_bar': 99,
-            'l_1_bar': missing
+            'l_1_bar': missing,
+            'l_0_baz': missing,
         })
-        assert locals == {'foo': 13}
+        assert locals == {'foo': 13, 'bar': 99}

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -27,7 +27,7 @@ def fs_env(filesystem_loader):
 
 
 @pytest.mark.debug
-class TestDebug():
+class TestDebug(object):
 
     def assert_traceback_matches(self, callback, expected_tb):
         try:
@@ -71,3 +71,15 @@ ZeroDivisionError: (int(eger)? )?division (or modulo )?by zero
     raise TemplateSyntaxError\('wtf', 42\)
 (jinja2\.exceptions\.)?TemplateSyntaxError: wtf
   line 42''')
+
+    def test_local_extraction(self):
+        from jinja2.debug import get_jinja_locals
+        from jinja2.runtime import missing
+        locals = get_jinja_locals({
+            'l_0_foo': 42,
+            'l_1_foo': 23,
+            'l_2_foo': 13,
+            'l_0_bar': 99,
+            'l_1_bar': missing
+        })
+        assert locals == {'foo': 13}

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -368,7 +368,7 @@ class TestNewstyleInternationalization():
         # that the generated code does not pass num twice (although that
         # would work) for better performance.  This only works on the
         # newstyle gettext of course
-        assert re.search(r"l_ngettext, u?'\%\(num\)s apple', u?'\%\(num\)s "
+        assert re.search(r"u?'\%\(num\)s apple', u?'\%\(num\)s "
                          r"apples', 3", source) is not None
 
     def test_trans_vars(self):

--- a/tests/test_idtracking.py
+++ b/tests/test_idtracking.py
@@ -1,0 +1,218 @@
+import pytest
+
+from jinja2 import nodes
+from jinja2.idtracking import symbols_for_node
+
+
+def test_basics():
+    for_loop = nodes.For(
+        nodes.Name('foo', 'store'),
+        nodes.Name('seq', 'load'),
+        [nodes.Output([nodes.Name('foo', 'load')])],
+        [], None, False)
+    tmpl = nodes.Template([
+        nodes.Assign(
+            nodes.Name('foo', 'store'),
+            nodes.Name('bar', 'load')),
+        for_loop])
+
+    sym = symbols_for_node(tmpl)
+    assert sym.refs == {
+        'foo': 'l_0_foo',
+        'bar': 'l_0_bar',
+        'seq': 'l_0_seq',
+    }
+    assert sym.loads == {
+        'l_0_foo': ('undefined', None),
+        'l_0_bar': ('resolve', 'bar'),
+        'l_0_seq': ('resolve', 'seq'),
+    }
+
+    sym = symbols_for_node(for_loop, sym)
+    assert sym.refs == {
+        'foo': 'l_1_foo',
+    }
+    assert sym.loads == {
+        'l_1_foo': ('undefined', None),
+    }
+
+
+def test_complex():
+    title_block = nodes.Block('title', [
+        nodes.Output([nodes.TemplateData(u'Page Title')])
+    ], False)
+
+    render_title_macro = nodes.Macro('render_title', [nodes.Name('title', 'param')], [], [
+        nodes.Output([
+            nodes.TemplateData(u'\n  <div class="title">\n    <h1>'),
+            nodes.Name('title', 'load'),
+            nodes.TemplateData(u'</h1>\n    <p>'),
+            nodes.Name('subtitle', 'load'),
+            nodes.TemplateData(u'</p>\n    ')]),
+        nodes.Assign(
+            nodes.Name('subtitle', 'store'), nodes.Const('something else')),
+        nodes.Output([
+            nodes.TemplateData(u'\n    <p>'),
+            nodes.Name('subtitle', 'load'),
+            nodes.TemplateData(u'</p>\n  </div>\n'),
+            nodes.If(
+                nodes.Name('something', 'load'), [
+                    nodes.Assign(nodes.Name('title_upper', 'store'),
+                                 nodes.Filter(nodes.Name('title', 'load'),
+                                              'upper', [], [], None, None)),
+                    nodes.Output([
+                        nodes.Name('title_upper', 'load'),
+                        nodes.Call(nodes.Name('render_title', 'load'), [
+                            nodes.Const('Aha')], [], None, None)])], [])])])
+
+    for_loop = nodes.For(
+        nodes.Name('item', 'store'),
+        nodes.Name('seq', 'load'), [
+            nodes.Output([
+                nodes.TemplateData(u'\n    <li>'),
+                nodes.Name('item', 'load'),
+                nodes.TemplateData(u'</li>\n    <span>')]),
+            nodes.Include(nodes.Const('helper.html'), True, False),
+            nodes.Output([
+                nodes.TemplateData(u'</span>\n  ')])], [], None, False)
+
+    body_block = nodes.Block('body', [
+        nodes.Output([
+            nodes.TemplateData(u'\n  '),
+            nodes.Call(nodes.Name('render_title', 'load'), [
+                nodes.Name('item', 'load')], [], None, None),
+            nodes.TemplateData(u'\n  <ul>\n  ')]),
+        for_loop,
+        nodes.Output([nodes.TemplateData(u'\n  </ul>\n')])],
+        False)
+
+    tmpl = nodes.Template([
+        nodes.Extends(nodes.Const('layout.html')),
+        title_block,
+        render_title_macro,
+        body_block,
+    ])
+
+    tmpl_sym = symbols_for_node(tmpl)
+    assert tmpl_sym.refs == {
+        'render_title': 'l_0_render_title',
+    }
+    assert tmpl_sym.loads == {
+        'l_0_render_title': ('undefined', None),
+    }
+    assert tmpl_sym.stores == set(['render_title'])
+    assert tmpl_sym.dump_stores() == {
+        'render_title': 'l_0_render_title',
+    }
+
+    macro_sym = symbols_for_node(render_title_macro, tmpl_sym)
+    assert macro_sym.refs == {
+        'subtitle': 'l_1_subtitle',
+        'something': 'l_1_something',
+        'title': 'l_1_title',
+        'title_upper': 'l_1_title_upper',
+    }
+    assert macro_sym.loads == {
+        'l_1_subtitle': ('resolve', 'subtitle'),
+        'l_1_something': ('resolve','something'),
+        'l_1_title': ('param', None),
+        'l_1_title_upper': ('resolve', 'title_upper'),
+    }
+    assert macro_sym.stores == set(['title', 'title_upper', 'subtitle'])
+    assert macro_sym.find_ref('render_title') == 'l_0_render_title'
+    assert macro_sym.dump_stores() == {
+        'title': 'l_1_title',
+        'title_upper': 'l_1_title_upper',
+        'subtitle': 'l_1_subtitle',
+        'render_title': 'l_0_render_title',
+    }
+
+    body_sym = symbols_for_node(body_block)
+    assert body_sym.refs == {
+        'item': 'l_0_item',
+        'seq': 'l_0_seq',
+        'render_title': 'l_0_render_title',
+    }
+    assert body_sym.loads == {
+        'l_0_item': ('resolve', 'item'),
+        'l_0_seq': ('resolve', 'seq'),
+        'l_0_render_title': ('resolve', 'render_title'),
+    }
+    assert body_sym.stores == set([])
+
+    for_sym = symbols_for_node(for_loop, body_sym)
+    assert for_sym.refs == {
+        'item': 'l_1_item',
+    }
+    assert for_sym.loads == {
+        'l_1_item': ('undefined', None),
+    }
+    assert for_sym.stores == set(['item'])
+    assert for_sym.dump_stores() == {
+        'item': 'l_1_item',
+    }
+
+
+def test_if_branching_stores():
+    tmpl = nodes.Template([
+        nodes.If(nodes.Name('expression', 'load'), [
+            nodes.Assign(nodes.Name('variable', 'store'),
+                         nodes.Const(42))], [])])
+
+    sym = symbols_for_node(tmpl)
+    assert sym.refs == {
+        'variable': 'l_0_variable',
+        'expression': 'l_0_expression'
+    }
+    assert sym.stores == set(['variable'])
+    assert sym.loads == {
+        'l_0_variable': ('resolve', 'variable'),
+        'l_0_expression': ('resolve', 'expression')
+    }
+    assert sym.dump_stores() == {
+        'variable': 'l_0_variable',
+    }
+
+
+def test_if_branching_stores_undefined():
+    tmpl = nodes.Template([
+        nodes.Assign(nodes.Name('variable', 'store'), nodes.Const(23)),
+        nodes.If(nodes.Name('expression', 'load'), [
+            nodes.Assign(nodes.Name('variable', 'store'),
+                         nodes.Const(42))], [])])
+
+    sym = symbols_for_node(tmpl)
+    assert sym.refs == {
+        'variable': 'l_0_variable',
+        'expression': 'l_0_expression'
+    }
+    assert sym.stores == set(['variable'])
+    assert sym.loads == {
+        'l_0_variable': ('undefined', None),
+        'l_0_expression': ('resolve', 'expression')
+    }
+    assert sym.dump_stores() == {
+        'variable': 'l_0_variable',
+    }
+
+
+def test_if_branching_multi_scope():
+    for_loop = nodes.For(nodes.Name('item', 'store'), nodes.Name('seq', 'load'), [
+        nodes.If(nodes.Name('expression', 'load'), [
+            nodes.Assign(nodes.Name('x', 'store'), nodes.Const(42))], []),
+        nodes.Include(nodes.Const('helper.html'), True, False)
+    ], [], None, False)
+
+    tmpl = nodes.Template([
+        nodes.Assign(nodes.Name('x', 'store'), nodes.Const(23)),
+        for_loop
+    ])
+
+    tmpl_sym = symbols_for_node(tmpl)
+    for_sym = symbols_for_node(for_loop, tmpl_sym)
+    assert for_sym.stores == set(['item', 'x'])
+    assert for_sym.loads == {
+        'l_1_x': ('alias', 'l_0_x'),
+        'l_1_item': ('undefined', None),
+        'l_1_expression': ('resolve', 'expression'),
+    }

--- a/tests/test_idtracking.py
+++ b/tests/test_idtracking.py
@@ -33,7 +33,7 @@ def test_basics():
         'foo': 'l_1_foo',
     }
     assert sym.loads == {
-        'l_1_foo': ('undefined', None),
+        'l_1_foo': ('param', None),
     }
 
 
@@ -145,7 +145,7 @@ def test_complex():
         'item': 'l_1_item',
     }
     assert for_sym.loads == {
-        'l_1_item': ('undefined', None),
+        'l_1_item': ('param', None),
     }
     assert for_sym.stores == set(['item'])
     assert for_sym.dump_stores() == {
@@ -213,6 +213,6 @@ def test_if_branching_multi_scope():
     assert for_sym.stores == set(['item', 'x'])
     assert for_sym.loads == {
         'l_1_x': ('alias', 'l_0_x'),
-        'l_1_item': ('undefined', None),
+        'l_1_item': ('param', None),
         'l_1_expression': ('resolve', 'expression'),
     }

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -146,3 +146,11 @@ class TestIncludes():
             {{ outer("FOO") }}
         """)
         assert t.render().strip() == '(FOO)'
+
+    def test_import_from_with_context(self):
+        env = Environment(loader=DictLoader({
+            'a': '{% macro x() %}{{ foobar }}{% endmacro %}',
+        }))
+        t = env.from_string('{% set foobar = 42 %}{% from "a" '
+                            'import x with context %}{{ x() }}')
+        assert t.render() == '42'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -306,3 +306,14 @@ class TestBug():
         {% endmacro %}{{ test() }}
         ''')
         assert tmpl.render().strip() == '0123456789'
+
+    def test_macro_var_bug_advanced(self, env):
+        tmpl = env.from_string('''
+        {% macro outer() %}
+            {% set i = 1 %}
+            {% macro test() %}
+                {% for i in range(0, 10) %}{{ i }}{% endfor %}
+            {% endmacro %}{{ test() }}
+        {% endmacro %}{{ outer() }}
+        ''')
+        assert tmpl.render().strip() == '0123456789'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -322,9 +322,9 @@ class TestBug():
         env = Environment()
         env.globals['get_int'] = lambda: 42
         t = env.from_string('''
-         {% macro test(arg1=get_int()) %}
-             {{ arg1 }}
-        {% endmacro %}
-        {{ test(1) }}|{{ test() }}
+        {% macro test(a, b, c=get_int()) -%}
+             {{ a + b + c }}
+        {%- endmacro %}
+        {{ test(1, 2) }}|{{ test(1, 2, 3) }}
         ''')
-        assert t.render().strip() == '1|42'
+        assert t.render().strip() == '45|6'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -317,3 +317,14 @@ class TestBug():
         {% endmacro %}{{ outer() }}
         ''')
         assert tmpl.render().strip() == '0123456789'
+
+    def test_callable_defaults(self):
+        env = Environment()
+        env.globals['get_int'] = lambda: 42
+        t = env.from_string('''
+         {% macro test(arg1=get_int()) %}
+             {{ arg1 }}
+        {% endmacro %}
+        {{ test(1) }}|{{ test() }}
+        ''')
+        assert t.render().strip() == '1|42'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -297,3 +297,12 @@ class TestBug():
                                '{% for i in range(3) %}{{ i }}{% endfor %}'
                                '{% endfor %}')
         assert tmpl.render() == '012'
+
+    def test_macro_var_bug(self, env):
+        tmpl = env.from_string('''
+        {% set i = 1 %}
+        {% macro test() %}
+            {% for i in range(0, 10) %}{{ i }}{% endfor %}
+        {% endmacro %}{{ test() }}
+        ''')
+        assert tmpl.render().strip() == '0123456789'

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -291,3 +291,9 @@ class TestBug():
         }))
         t = env.from_string('{% extends "main" %}{% set x %}42{% endset %}')
         assert t.render() == '[42]'
+
+    def test_nested_for_else(self, env):
+        tmpl = env.from_string('{% for x in y %}{{ loop.index0 }}{% else %}'
+                               '{% for i in range(3) %}{{ i }}{% endfor %}'
+                               '{% endfor %}')
+        assert tmpl.render() == '012'


### PR DESCRIPTION
This branch implements correct identifier tracking through aliasing. This basically solves Jinja's oldest bug which is that it tries to trivially map identifiers onto Python scoping which cannot work because Python scoping is not expressive enough to support all of Jinja's features.

This will also fix a ton of other issues and open up heavily improved includes.

The main breakage this causes which is known is that code that overrides Context now needs to override `resolve_or_missing` instead of `resolve` if it wants custom resolve support.