### PR TITLE
Add in test

### DIFF
--- a/jinja2/tests.py
+++ b/jinja2/tests.py
@@ -162,6 +162,11 @@ def test_lessthan(value, other):
     return value < other
 
 
+def test_in(value, seq):
+    """Check if value is in seq."""
+    return value in seq
+
+
 TESTS = {
     'odd':              test_odd,
     'even':             test_even,
@@ -181,5 +186,6 @@ TESTS = {
     'equalto':          test_equalto,
     'escaped':          test_escaped,
     'greaterthan':      test_greaterthan,
-    'lessthan':         test_lessthan
+    'lessthan':         test_lessthan,
+    'in':               test_in
 }

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -126,3 +126,16 @@ class TestTestsCase(object):
         assert tmpl.render() == 'False'
         assert items == [('us-west-1', '(us-east-1|ap-northeast-1)'),
                          ('stage', '(dev|stage)')]
+
+    def test_in(self, env):
+        tmpl = env.from_string('{{ "o" is in "foo" }}|'
+                               '{{ "foo" is in "foo" }}|'
+                               '{{ "b" is in "foo" }}|'
+                               '{{ 1 is in ((1, 2)) }}|'
+                               '{{ 3 is in ((1, 2)) }}|'
+                               '{{ 1 is in [1, 2] }}|'
+                               '{{ 3 is in [1, 2] }}|'
+                               '{{ "foo" is in {"foo": 1}}}|'
+                               '{{ "baz" is in {"bar": 1}}}')
+        assert tmpl.render() \
+            == 'True|True|False|True|False|True|False|True|False'


### PR DESCRIPTION
This PR introduces an implementation for an `in` test. (edit: The test was originally named `elementof`, see discussion below.)

In conjunction with the `selectattr` filter (or `rejectattr` for negation) this test can be used to extract values from one sequence having attributes that match at least one element of another sequence. It is a thin proxy for Python's `in` operator – like `equalto` is for `==`. While it is trivial to implement this using a custom test by Jinja's users i'd argue that the addition of this test to the Jinja core provides feature parity with existing functionality with respect to `equalto`.

#### Use case:
When writing Ansible plays (which uses Jinja2) I hit a wall trying to filter a list of dicts on their name attribute inside of a Jinja2 expression.
When your rendering target is text (e.g. website templates) you can achieve something similar (not interchangable) using `{% for x in seq1 %}{% if x.attr in seq2 %}{# access x or its attributes here #}{% endif %}{% endfor %}`. However you can't use the latter construct when the consuming environment calls for an actual sequence being returned from Jinja.

#### Side notes (not related to Jinja, but the concrete use case inside Ansible playbooks):
It is possible to resort to external logic as a workaround (e.g. Ansible's when statement or dynamically create restructured, intermediate data representations).
Ansible can use a variation of the aforementioned for-if-template by incorporating the joiner() helper to create a YAML flow-style list but this creates a somewhat awkward contraption:

```yaml
# […]
  - debug: "msg={{item}}"
    with_items: "[{% set j = joiner(',') %}{% for x in s1 %}{% if x.name in s2 %}{{ j() }}{{ x }}{% endif %}{% endfor %}]"
```

#### Example code (using this PR):
```python
>>> import jinja2
>>>
>>> t = e.from_string("""\
... {{ list_of_dicts|selectattr("name", "in", selection_seq)|list }}
... """)
>>>
>>> t.render(list_of_dicts=[dict(name="foo", x=1), dict(name="bar", y=2), dict(name="baz", z=3)],
...          selection_seq=dict(foo=1, bar=42))
"[{'name': 'foo', 'x': 1}, {'name': 'bar', 'y': 2}]"
```

I hope this hasn't been discussed here previously. I'd like any opinions and criticism on this PR and alternative approaches for achieving the presented behavior using existing features in Jinja2.