### PR TITLE
fix failing tests: removed some broken code

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -696,8 +696,6 @@ def do_round(value, precision=0, method='common'):
 _GroupTuple = namedtuple('_GroupTuple', ['grouper', 'list'])
 _GroupTuple.__repr__ = tuple.__repr__
 _GroupTuple.__str__ = tuple.__str__
-if not PY2:
-    _GroupTuple.__unicode__ = tuple.__unicode__
 
 @environmentfilter
 def do_groupby(environment, value, attribute):


### PR DESCRIPTION
This is the cause of failing tests. Attempt to overload methods on namedtuple with that of builtin tuple with attribute \_\_unicode__ is not needed. tuple and namedtuple do not have a \_\_unicode__ method