### PR TITLE
handle template.get_corresponding_lineno() for lines without debug info

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1124,8 +1124,10 @@ class Template(object):
     @property
     def debug_info(self):
         """The debug info mapping."""
-        return [tuple(imap(int, x.split('='))) for x in
-                self._debug_info.split('&')]
+        if self._debug_info:
+            return [tuple(imap(int, x.split('='))) for x in
+                    self._debug_info.split('&')]
+        return []
 
     def __repr__(self):
         if self.name is None:

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -82,3 +82,7 @@ ZeroDivisionError: (int(eger)? )?division (or modulo )?by zero
             'l_0_baz': missing,
         })
         assert locals == {'foo': 13, 'bar': 99}
+
+    def test_get_corresponding_lineno_traceback(self, fs_env):
+        tmpl = fs_env.get_template('test.html')
+        assert tmpl.get_corresponding_lineno(1) == 1


### PR DESCRIPTION
When I have a template with the following contents:

```
Hello World
```

and execute `Template.get_corresponding_lineno()` on it Jinja produces the exception below:

```
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/senko/coverage-jinja-plugin/tests/test_simple.py", line 51, in test_one_line
    text, line_data = self.do_jinja_coverage('hello.html')
  File "/home/senko/coverage-jinja-plugin/tests/test_simple.py", line 40, in do_jinja_coverage
    text = self._render(template, context)
  File "/home/senko/coverage-jinja-plugin/tests/test_simple.py", line 18, in _render
    template = env.get_template(template_filename)
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/environment.py", line 849, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/environment.py", line 823, in _load_template
    template = self.loader.load(self, name, globals)
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/loaders.py", line 135, in load
    globals, uptodate)
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/environment.py", line 975, in from_code
    exec(code, namespace)
  File "/home/senko/coverage-jinja-plugin/tests/templates/hello.html", line 1, in <module>
    BAR
  File "/home/senko/coverage-jinja-plugin/jinja_coverage/plugin.py", line 44, in line_number_range
    lineno = template.get_corresponding_lineno(frame.f_lineno)
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/environment.py", line 1131, in get_corresponding_lineno
    for template_line, code_line in reversed(self.debug_info):
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/environment.py", line 1147, in debug_info
    self._debug_info.split('&')]
  File "/home/senko/.virtualenvs/Jinja2Coverage/lib/python3.5/site-packages/jinja2/environment.py", line 1146, in <listcomp>
    return [tuple(imap(int, x.split('='))) for x in
ValueError: invalid literal for int() with base 10: ''
```

Note: the above traceback is from a coverage.py plugin for Jinja templates I have been working on. The test added in this PR yields similar results.

The original template is translated to the following Python code:

```
from __future__ import division, generator_stop
from jinja2.runtime import LoopContext, TemplateReference, Macro, Markup, TemplateRuntimeError, missing, concat, escape, markup_join, unicode_join, to_string, identity, TemplateNotFound
name = 'hello.html'

def root(context, missing=missing, environment=environment):
    resolve = context.resolve_or_missing
    undefined = environment.undefined
    if 0: yield None
    pass
    yield 'Hello World'

blocks = {}
debug_info = ''
```

As you can see `debug_info` is an empty string. If I add `{% block %}`, `{% endblock %}` tags around the text everything works fine.

