### PR TITLE
Remove unneed tpye test for get_template method.

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -823,8 +823,6 @@ class Environment(object):
            If `name` is a :class:`Template` object it is returned from the
            function unchanged.
         """
-        if isinstance(name, Template):
-            return name
         if parent is not None:
             name = self.join_path(name, parent)
         return self._load_template(name, self.make_globals(globals))


### PR DESCRIPTION
  get_template method is only used by get_or_select_template method. As the later just call get_template when the argument template_name_or_list is instance of str or Unicode, there is no need type test in get_template method.