### PR TITLE
Add support for `{% trans trimmed ... %}`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,9 @@ Version 2.10
 - Added a `namespace` function that creates a special object which allows
   attribute assignment using the `set` tag.  This can be used to carry data
   across scopes, e.g. from a loop body to code that comes after the loop.
+- Added a `trimmed` modifier to `{% trans %}` to strip linebreaks and
+  surrounding whitespace. Also added a new policy to enable this for all
+  `trans` blocks.
 
 Version 2.9.6
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -611,6 +611,13 @@ Example::
     Keyword arguments to be passed to the dump function.  The default is
     ``{'sort_keys': True}``.
 
+.. _ext-i18n-trimmed:
+
+``ext.i18n.trimmed``:
+    If this is set to `True`, ``{% trans %}`` blocks of the
+    :ref:`i18n-extension` will always unify linebreaks and surrounding
+    whitespace as if the `trimmed` modifier was used.
+
 
 Utilities
 ---------

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -111,6 +111,15 @@ The usage of the `i18n` extension for template designers is covered as part
 
 .. _newstyle-gettext:
 
+Whitespace Trimming
+~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.10
+
+Linebreaks and surrounding whitespace can be automatically trimmed by enabling
+the ``ext.i18n.trimmed`` :ref:`policy <ext-i18n-trimmed>`.
+
+
 Newstyle Gettext
 ~~~~~~~~~~~~~~~~
 

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1492,6 +1492,22 @@ which should be used for pluralizing by adding it as parameter to `pluralize`::
     {% trans ..., user_count=users|length %}...
     {% pluralize user_count %}...{% endtrans %}
 
+When translating longer blocks of text, whitespace and linebreaks result in
+rather ugly and error-prone translation strings.  To avoid this, a trans block
+can be marked as trimmed which will replace all linebreaks and the whitespace
+surrounding them with a single space and remove leading/trailing whitespace::
+
+    {% trans trimmed book_title=book.title %}
+        This is {{ book_title }}.
+        You should read it!
+    {% endtrans %}
+
+If trimming is enabled globally, the `notrimmed` modifier can be used to
+disable it for a `trans` block.
+
+.. versionadded:: 2.10
+   The `trimmed` and `notrimmed` modifiers have been added.
+
 It's also possible to translate strings in expressions.  For that purpose,
 three functions exist:
 

--- a/jinja2/defaults.py
+++ b/jinja2/defaults.py
@@ -48,6 +48,7 @@ DEFAULT_POLICIES = {
     'truncate.leeway':      5,
     'json.dumps_function':  None,
     'json.dumps_kwargs':    {'sort_keys': True},
+    'ext.i18n.trimmed':     False,
 }
 
 

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -10,6 +10,8 @@
     :copyright: (c) 2017 by the Jinja Team.
     :license: BSD.
 """
+import re
+
 from jinja2 import nodes
 from jinja2.defaults import BLOCK_START_STRING, \
      BLOCK_END_STRING, VARIABLE_START_STRING, VARIABLE_END_STRING, \
@@ -223,6 +225,7 @@ class InternationalizationExtension(Extension):
         plural_expr = None
         plural_expr_assignment = None
         variables = {}
+        trimmed = None
         while parser.stream.current.type != 'block_end':
             if variables:
                 parser.stream.expect('comma')
@@ -241,6 +244,9 @@ class InternationalizationExtension(Extension):
             if parser.stream.current.type == 'assign':
                 next(parser.stream)
                 variables[name.value] = var = parser.parse_expression()
+            elif trimmed is None and name.value in ('trimmed', 'notrimmed'):
+                trimmed = name.value == 'trimmed'
+                continue
             else:
                 variables[name.value] = var = nodes.Name(name.value, 'load')
 
@@ -256,7 +262,7 @@ class InternationalizationExtension(Extension):
 
         parser.stream.expect('block_end')
 
-        plural = plural_names = None
+        plural = None
         have_plural = False
         referenced = set()
 
@@ -297,6 +303,13 @@ class InternationalizationExtension(Extension):
         elif plural_expr is None:
             parser.fail('pluralize without variables', lineno)
 
+        if trimmed is None:
+            trimmed = self.environment.policies['ext.i18n.trimmed']
+        if trimmed:
+            singular = self._trim_whitespace(singular)
+            if plural:
+                plural = self._trim_whitespace(plural)
+
         node = self._make_node(singular, plural, variables, plural_expr,
                                bool(referenced),
                                num_called_num and have_plural)
@@ -305,6 +318,9 @@ class InternationalizationExtension(Extension):
             return [plural_expr_assignment, node]
         else:
             return node
+
+    def _trim_whitespace(self, string, _ws_re=re.compile(r'\s*\n\s*')):
+        return _ws_re.sub(' ', string.strip())
 
     def _parse_block(self, parser, allow_pluralize):
         """Parse until the next block tag with a given name."""
@@ -583,6 +599,8 @@ def babel_extract(fileobj, keywords, comment_tags, options):
         auto_reload=False
     )
 
+    if getbool(options, 'trimmed'):
+        environment.policies['ext.i18n.trimmed'] = True
     if getbool(options, 'newstyle_gettext'):
         environment.newstyle_gettext = True
 


### PR DESCRIPTION
Same behavior as in Django: All linebreaks and the whitespace surrounding them are replaced with a single space. Also added a policy `ext.i18n.trimmed` to enable this globally (can be overridden using the `notrimmed` modifier).

closes #504

---

Note: There is one minor case of backwards incompatibility which has no real-world implications. This was already valid Jinja code: `{% trans somevar %}...{% endtrans %}`, making the following ambiguous:

    {% trans trimmed %}
        hello world
    {% endtrans %}

However, `trimmed` is a somewhat unlikely variable name, especially in the context of a `trans` block and the fact that you can specify variables without an assignment there is undocumented. So I don't think anyone is using the combination of these two things. When using a variable assignment the behavior does not change - the modifier only applies if it is not followed by a `=`.