### PR TITLE
add examples showing > 1 argument in filter

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -865,6 +865,9 @@ def do_select(*args, **kwargs):
 
         {{ numbers|select("odd") }}
         {{ numbers|select("odd") }}
+        {{ numbers|select("divisibleby", 3) }}
+        {{ numbers|select("lessthan", 42) }}
+        {{ strings|select("equalto", "mystring") }}
 
     .. versionadded:: 2.7
     """


### PR DESCRIPTION
This is implied but poorly documented. A few examples make it clear.

The first example, "select odd", was already duplicated- I don't know why.