### PR TITLE
Fix regression in 2.9 involving unsafe Context.get_all() usage

### DIFF
--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -198,7 +198,7 @@ def translate_exception(exc_info, initial_skip=0):
 def get_jinja_locals(real_locals):
     ctx = real_locals.get('context')
     if ctx:
-        locals = ctx.get_all()
+        locals = ctx.get_all().copy()
     else:
         locals = {}
 


### PR DESCRIPTION
Since commit d67f0fd4cc2a4af08f51f4466150d49da7798729, callers
of Context.get_all() need to make a copy it they're going to
modify the result.

Fixes: d67f0fd4cc2a ("Generalize scoping.  This fixes #603")
See: https://github.com/ansible/ansible/issues/20494

@mitsuhiko, PTAL