### PR TITLE
Let wordwrap filter respect existing newlines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,9 @@ Unreleased
     the correct queue. :issue:`843`
 -   Compiling templates always writes UTF-8 instead of defaulting to the
     system encoding. :issue:`889`
+-   ``|wordwrap`` filter treats existing newlines as separate paragraphs
+    to be wrapped individually, rather than creating short intermediate
+    lines. :issue:`175`
 
 
 Version 2.10.3

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -700,9 +700,23 @@ def do_wordwrap(environment, s, width=79, break_long_words=True,
     if not wrapstring:
         wrapstring = environment.newline_sequence
     import textwrap
-    return wrapstring.join(textwrap.wrap(s, width=width, expand_tabs=False,
-                                   replace_whitespace=False,
-                                   break_long_words=break_long_words))
+    # Work around textwrap.wrap()'s unexpected behaviour when wrapping multiple
+    # paragraphs. I.e. if your first paragraph ends on col 75, the next
+    # next paragraph would be wrapped on col 5 already, so we're going to wrap
+    # each paragraph individually.
+    paragraphs = str.splitlines(s)
+    paragraphs_wrapped = []
+    for paragraph in paragraphs:
+        paragraph_wrapped = wrapstring.join(
+            textwrap.wrap(paragraph,
+                          width=width,
+                          expand_tabs=False,
+                          replace_whitespace=False,
+                          break_long_words=break_long_words
+                          )
+            )
+        paragraphs_wrapped.append(paragraph_wrapped)
+    return wrapstring.join(paragraphs_wrapped)
 
 
 def do_wordcount(s):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -757,3 +757,9 @@ class TestFilter(object):
         env.policies['json.dumps_function'] = my_dumps
         env.policies['json.dumps_kwargs'] = {'foo': 'bar'}
         assert t.render(x=23) == '42'
+
+    def test_wordwrap(self, env):
+        env.newline_sequence = "\n"
+        t = env.from_string("{{ s|wordwrap(20) }}")
+        result = t.render(s="Hello!\nThis is Jinja saying something.")
+        assert result == "Hello!\nThis is Jinja saying\nsomething."


### PR DESCRIPTION
`textwrap.wrap()` from stdlib has unexpected behaviour where when
wrapping multiple paragraphs it will not consider existing newlines.

I.e. when your first paragraph ends on col 75, the next paragraph
will be wrapped on col 5 already.

This patch is wrapping each line individually and combining it back
together.

Fixes #175.