### PR TITLE
Fix Travis CI argparse import error on Python 2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ usedevelop = true
 deps =
     pytest>=3
     coverage
+    argparse
 
 commands = coverage run -p -m pytest {posargs}
 


### PR DESCRIPTION
```
codecov runtests: commands[2] | codecov
Traceback (most recent call last):
  File "/home/travis/build/pallets/jinja/.tox/codecov/bin/codecov", line 7, in <module>
    from codecov import main
  File "/home/travis/build/pallets/jinja/.tox/codecov/lib/python2.6/site-packages/codecov/__init__.py", line 8, in <module>
    import argparse
ImportError: No module named argparse
ERROR: InvocationError: '/home/travis/build/pallets/jinja/.tox/codecov/bin/codecov'
___________________________________ summary ____________________________________
  py: commands succeeded
ERROR:   codecov: commands failed
The command "tox" exited with 1.
```
https://travis-ci.org/pallets/jinja/jobs/276874396

Same thing as https://github.com/pallets/flask/pull/2476.