### PR TITLE
Loader for Python modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,3 +75,9 @@ def prefix_loader(filesystem_loader, dict_loader):
         'a':        filesystem_loader,
         'b':        dict_loader
     })
+
+@pytest.fixture
+def pymodule_loader():
+    '''returns a PyModuleLoader
+    '''
+    return loaders.PyModuleLoader()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -66,6 +66,14 @@ class TestLoaders(object):
         assert tmpl.render().strip() == 'FOO'
         pytest.raises(TemplateNotFound, env.get_template, 'missing')
 
+    def test_pymodule_loader(self, pymodule_loader):
+        env = Environment(loader=pymodule_loader)
+        tmpl = env.get_template('__python__.__builtin__')
+        tdict = tmpl.module.__dict__
+        mdict = __builtin__.__dict__
+        assert all(mdict[k] == tdict[k] for k in mdict)
+        pytest.raises(TemplateNotFound, env.get_template, 'missing')
+
     def test_caching(self):
         changed = False
 


### PR DESCRIPTION
Load Python modules as Jinja2 templates.
```
        >>> loader = PyModuleLoader()
```
This loader returns an empty template exporting Python module's namespace. It piggybacks on the Jinja2 import mechanism to provide a convienient way to access functionality from any Python module in ``sys.path``.
