### PR TITLE
Update line statement lexer regexp to stop at the first newline

### DIFF
--- a/jinja2/lexer.py
+++ b/jinja2/lexer.py
@@ -536,7 +536,7 @@ class Lexer(object):
             ],
             # line statements
             TOKEN_LINESTATEMENT_BEGIN: [
-                (c(r'\s*(\n|$)'), TOKEN_LINESTATEMENT_END, '#pop')
+                (c(r'[ \t\r\f\v]*(\n|$)'), TOKEN_LINESTATEMENT_END, '#pop')
             ] + tag_rules,
             # line comments
             TOKEN_LINECOMMENT_BEGIN: [

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -161,7 +161,7 @@ class TestBug(object):
 #   print 'D'
 # endif
     ''')
-        assert t.render(a=0, b=False, c=42, d=42.0) == '1111C'
+        assert t.render(a=0, b=False, c=42, d=42.0) == '1111C    '
 
     def test_stacked_locals_scoping_bug_twoframe(self, env):
         t = Template('''


### PR DESCRIPTION
When using line statement prefix in Jinja2 templates it is impossible to add a blank line after the Jinja2 tag because successive newlines are recognized as TOKEN_LINESTATEMENT_END. 

The following example:
```
# for i in range(2)
#  for j in range(2)
{{i}}_{{j}}
#  endfor

# endfor
```
Will output:
```
0_0
0_1
1_0
1_1
```

A workaround is to add an explicit newline:
```
# for i in range(2)
#  for j in range(2)
{{i}}_{{j}}
#  endfor
{{'\n'}}
# endfor
```

With this simple fix, the lexer will recognize the end of the line statement at the first newline and allow the user to put empty lines as if (s)he is using blocks.

The given example will respect user wish to insert an empty line after each inner loop by generating the following output:
```
0_0
0_1

1_0
1_1

```
