### PR TITLE
Allow to pass a list to native_concat

### DIFF
--- a/jinja2/nativetypes.py
+++ b/jinja2/nativetypes.py
@@ -21,12 +21,11 @@ def native_concat(nodes):
     if not head:
         return None
 
-    if isinstance(nodes, types.GeneratorType):
-        nodes = chain(head, nodes)
-
     if len(head) == 1:
         out = head[0]
     else:
+        if isinstance(nodes, types.GeneratorType):
+            nodes = chain(head, nodes)
         out = u''.join([text_type(v) for v in nodes])
 
     try:

--- a/jinja2/nativetypes.py
+++ b/jinja2/nativetypes.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from ast import literal_eval
 from itertools import islice, chain
 from jinja2 import nodes
@@ -20,10 +21,13 @@ def native_concat(nodes):
     if not head:
         return None
 
+    if isinstance(nodes, types.GeneratorType):
+        nodes = chain(head, nodes)
+
     if len(head) == 1:
         out = head[0]
     else:
-        out = u''.join([text_type(v) for v in chain(head, nodes)])
+        out = u''.join([text_type(v) for v in nodes])
 
     try:
         return literal_eval(out)

--- a/tests/test_nativetypes.py
+++ b/tests/test_nativetypes.py
@@ -108,3 +108,9 @@ class TestNativeEnvironment(object):
         result = t.render()
         assert not isinstance(result, type)
         assert result in ["<type 'bool'>", "<class 'bool'>"]
+
+    def test_string(self, env):
+        t = env.from_string("[{{ 'all' }}]")
+        result = t.render()
+        assert isinstance(result, text_type)
+        assert result == "[all]"


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/ansible/ansible/pull/32738#issuecomment-358010879:
```
from jinja2 import Environment, BaseLoader
from jinja2.nativetypes import NativeEnvironment

data = "[{{ 'all' }}]"
loader = BaseLoader()
t = Environment(loader=loader).from_string(data)
t_native = NativeEnvironment(loader=loader).from_string(data)
print t.render()
print t_native.render()
```
Before:
```
[all]
[all[all]
```
After:
```
[all]
[all]
```