### PR TITLE
Misc. source comment typos

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1076,7 +1076,7 @@ class Template(object):
 
     def make_module_async(self, vars=None, shared=False, locals=None):
         """As template module creation can invoke template code for
-        asynchronous exections this method must be used instead of the
+        asynchronous executions this method must be used instead of the
         normal :meth:`make_module` one.  Likewise the module attribute
         becomes unavailable in async mode.
         """

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -400,7 +400,7 @@ def do_join(eval_ctx, value, d=u'', attribute=None):
     if attribute is not None:
         value = imap(make_attrgetter(eval_ctx.environment, attribute), value)
 
-    # no automatic escaping?  joining is a lot eaiser then
+    # no automatic escaping?  joining is a lot easier then
     if not eval_ctx.autoescape:
         return text_type(d).join(imap(text_type, value))
 

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -636,7 +636,7 @@ class Filter(Expr):
 
         # we have to be careful here because we call filter_ below.
         # if this variable would be called filter, 2to3 would wrap the
-        # call in a list beause it is assuming we are talking about the
+        # call in a list because it is assuming we are talking about the
         # builtin filter function here which no longer returns a list in
         # python 3.  because of that, do not rename filter_ to filter!
         filter_ = self.environment.filters.get(self.name)

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -40,7 +40,7 @@ else:
 #: unsafe method attributes.  function attributes are unsafe for methods too
 UNSAFE_METHOD_ATTRIBUTES = set(['im_class', 'im_func', 'im_self'])
 
-#: unsafe generator attirbutes.
+#: unsafe generator attributes.
 UNSAFE_GENERATOR_ATTRIBUTES = set(['gi_frame', 'gi_code'])
 
 #: unsafe attributes on coroutines
@@ -299,7 +299,7 @@ class SandboxedEnvironment(Environment):
     def intercept_unop(self, operator):
         """Called during template compilation with the name of a unary
         operator to check if it should be intercepted at runtime.  If this
-        method returns `True`, :meth:`call_unop` is excuted for this unary
+        method returns `True`, :meth:`call_unop` is executed for this unary
         operator.  The default implementation of :meth:`call_unop` will use
         the :attr:`unop_table` dictionary to perform the operator with the
         same logic as the builtin one.

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -614,7 +614,7 @@ class Joiner(object):
 
 class Namespace(object):
     """A namespace object that can hold arbitrary attributes.  It may be
-    initialized from a dictionary or with keyword argments."""
+    initialized from a dictionary or with keyword arguments."""
 
     def __init__(*args, **kwargs):
         self, args = args[0], args[1:]

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -91,7 +91,7 @@ comment=no
 # * unused variables / imports
 # * undefined variables
 # * redefinition of variable from builtins or from an outer scope
-# * use of variable before assigment
+# * use of variable before assignment
 # 
 [VARIABLES]
 
@@ -118,8 +118,8 @@ ignore-mixin-members=yes
 # access to some undefined attributes.
 zope=no
 
-# List of members which are usually get through zope's acquisition mecanism and
-# so shouldn't trigger E0201 when accessed (need zope=yes to be considered).
+# List of members which are usually gotten through zope's acquisition mechanism
+# and so shouldn't trigger E0201 when accessed (need zope=yes to be considered)
 acquired-members=REQUEST,acl_users,aq_parent
 
 


### PR DESCRIPTION
Found via `codespell -q 3` using v1.12.0.dev0