### PR TITLE
Enhanced Test Reporting for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,33 @@ matrix:
     - python: 3.6
       env: TOXENV=docs-html
 
+before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+
 install:
   - pip install tox
 
 script:
-  - tox
+  - if [[ "${TOXENV}" =~ ^py ]] ; then
+      tox -- --junit-xml=testresults.xml;
+    else
+      tox;
+    fi
 
+after_script:
+  - if [[ "${TOXENV}" =~ ^py ]] ; then
+      testspace [python_${TRAVIS_PYTHON_VERSION}]testresults.xml{tests};
+    fi
+ 
 cache:
   - pip
 
 branches:
   only:
     - master
+    - add-test-reporting
     - /^.*-maintenance$/
 
 notifications:


### PR DESCRIPTION
We’ve made a few minor changes to demonstrate how [Testspace.com](https://www.testspace.com/) could be used by your team to better represent your testing. You could even capture the testing of all of your **Pallets Projects** in a single dashboard. It is very obviously your team is very well organized. Nice job. 

Note that there is **no** impact on the workflow. 

YOUR TEST RESULTS, from `our fork`, at https://open.testspace.com/projects/TryTestspace:jinja.

#### Some of the benefits for your team and contributors 

* Represent all of your tests in an organized fashion controlled by your source repo 
* Detailed timing, stdout/stderr output, etc., even when not failing
* Test Failures can be filtering on, speeding up the resolution process; versus using a Travis Log
    * Example filtering on failures [here](https://open.testspace.com/spaces/75174) - Hit the `36 Failures` button 
* Can push other content such as code coverage, static analysis, HTML, log files, etc.

----

If there is interest we can enable your other projects (i.e. flask, werkzeug, etc.). Also, note we are going to support other 3rd Party code coverage soon (i.e. Codecov) and _merging_ test results from multiple CIs (Travis and AppVeyor).

