### PR TITLE
Add more strict type tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Unreleased
 -   Parentheses around comparisons are preserved, so
     ``{{ 2 * (3 < 5) }}`` outputs "2" instead of "False".
     :issue:`755`, :pr:`938`
+-   Add new ``boolean``, ``false``, ``true``, ``integer`` and ``float``
+    tests. :pr:`824`
 
 
 Version 2.10.3

--- a/jinja2/tests.py
+++ b/jinja2/tests.py
@@ -63,6 +63,48 @@ def test_none(value):
     return value is None
 
 
+def test_boolean(value):
+    """Return true if the object is a boolean value.
+
+    .. versionadded:: 2.11
+    """
+    return value is True or value is False
+
+
+def test_false(value):
+    """Return true if the object is False.
+
+    .. versionadded:: 2.11
+    """
+    return value is False
+
+
+def test_true(value):
+    """Return true if the object is True.
+
+    .. versionadded:: 2.11
+    """
+    return value is True
+
+
+# NOTE: The existing Jinja2 'number' test matches booleans and floats
+def test_integer(value):
+    """Return true if the object is an integer.
+
+    .. versionadded:: 2.11
+    """
+    return isinstance(value, integer_types) and value is not True and value is not False
+
+
+# NOTE: The existing Jinja2 'number' test matches booleans and integers
+def test_float(value):
+    """Return true if the object is a float.
+
+    .. versionadded:: 2.11
+    """
+    return isinstance(value, float)
+
+
 def test_lower(value):
     """Return true if the variable is lowercased."""
     return text_type(value).islower()
@@ -145,6 +187,11 @@ TESTS = {
     'defined':          test_defined,
     'undefined':        test_undefined,
     'none':             test_none,
+    'boolean':          test_boolean,
+    'false':            test_false,
+    'true':             test_true,
+    'integer':          test_integer,
+    'float':            test_float,
     'lower':            test_lower,
     'upper':            test_upper,
     'string':           test_string,


### PR DESCRIPTION
This PR adds a few more type-related tests.

- **boolean**
    Testing if an object is a boolean required 2 tests.

        {% if result.value is boolean %}

- **false**
    Make this similar to testing none value, not requiring sameas

        {% if result.value is false %}

- **true**
    Make this similar to testing none value, not requiring sameas

        {% if result.value is true %}

- **integer**
    The existing 'number' test does not make a distinction between
    integer, float or even booleans

        {% if result.value is integer %}

- **float**
    The existing 'number' test does not make a distinction between
    integer, float or even booleans

        {% if result.value is float %}

- ~**list**~
    ~The existing 'sequence' or 'iterable test does not make a distinction
    between strings, lists or mappings. Even 'iterable' does not help here.~

        {% if result.value is list %}

This brings the same convenience as:

- **none**

        {% if result.value is none %}

- **string**

        {% if result.value is string %}

- **mapping**

        {% if result.value is mapping %}

For the original Jinja2 use-case where values eventually turn into strings anyway, type-checking is less of an issue, however in Ansible or other projects that use Jinja2 for more than web-templating this is more important.

We see people turning booleans into strings to compare with 'True' or 'False'. Or doing very weird things to determine what is a string, or a list. If you're not careful you end up with a character, instead of the first element.

You can see the effect of testing different types in Jinja including these new tests:
https://github.com/dagwieers/ansible/blob/jinja2-type-tests/test/integration/targets/jinja2_tests/tasks/main.yml

PS This PR also has a workaround for a small doc issue breaking Travis testing.