### PR TITLE
Fix escaped characters in indent filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv-*/
 .coverage
 .coverage.*
 htmlcov
+.pytest_cache/

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -567,6 +567,8 @@ def do_indent(
             rv += u'\n' + u'\n'.join(
                 indention + line if line else line for line in lines
             )
+            # Unescape any strings that were escaped due to concatenation
+            rv = Markup(rv.unescape())
 
     if first:
         rv = indention + rv

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -557,8 +557,19 @@ def do_indent(
     s += u'\n'  # this quirk is necessary for splitlines method
     indention = u' ' * width
 
+    def _unescape(val):
+        '''
+        Unescape any strings that were escaped due to concatenation. If the
+        value passed is not a Markup instance, return the original value.
+        '''
+        try:
+            return Markup(val.unescape())
+        except AttributeError:
+            # s was not a Markup instance
+            return val
+
     if blank:
-        rv = (u'\n' + indention).join(s.splitlines())
+        rv = _unescape((u'\n' + indention).join(s.splitlines()))
     else:
         lines = s.splitlines()
         rv = lines.pop(0)
@@ -567,12 +578,7 @@ def do_indent(
             rv += u'\n' + u'\n'.join(
                 indention + line if line else line for line in lines
             )
-            try:
-                # Unescape any strings that were escaped due to concatenation
-                rv = Markup(rv.unescape())
-            except AttributeError:
-                # s was not a Markup instance
-                pass
+            rv = _unescape(rv)
 
     if first:
         rv = indention + rv

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -554,31 +554,25 @@ def do_indent(
         ), stacklevel=2)
         first = indentfirst
 
-    s += u'\n'  # this quirk is necessary for splitlines method
     indention = u' ' * width
+    newline = u'\n'
 
-    def _unescape(val):
-        '''
-        Unescape any strings that were escaped due to concatenation. If the
-        value passed is not a Markup instance, return the original value.
-        '''
-        try:
-            return Markup(val.unescape())
-        except AttributeError:
-            # s was not a Markup instance
-            return val
+    if isinstance(s, Markup):
+        indention = Markup(indention)
+        newline = Markup(newline)
+
+    s += newline  # this quirk is necessary for splitlines method
 
     if blank:
-        rv = _unescape((u'\n' + indention).join(s.splitlines()))
+        rv = (newline + indention).join(s.splitlines())
     else:
         lines = s.splitlines()
         rv = lines.pop(0)
 
         if lines:
-            rv += u'\n' + u'\n'.join(
+            rv += newline + newline.join(
                 indention + line if line else line for line in lines
             )
-            rv = _unescape(rv)
 
     if first:
         rv = indention + rv

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -567,8 +567,12 @@ def do_indent(
             rv += u'\n' + u'\n'.join(
                 indention + line if line else line for line in lines
             )
-            # Unescape any strings that were escaped due to concatenation
-            rv = Markup(rv.unescape())
+            try:
+                # Unescape any strings that were escaped due to concatenation
+                rv = Markup(rv.unescape())
+            except AttributeError:
+                # s was not a Markup instance
+                pass
 
     if first:
         rv = indention + rv

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -135,23 +135,34 @@ class TestFilter(object):
         out = tmpl.render()
         assert out == 'a|b'
 
-    def test_indent(self, env):
-        text = '\n'.join(['', 'foo bar', ''])
+    @staticmethod
+    def _test_indent_multiline_template(env, markup=False):
+        text = '\n'.join(['', 'foo bar', '"baz"', ''])
+        if markup:
+            text = Markup(text)
         t = env.from_string('{{ foo|indent(2, false, false) }}')
-        assert t.render(foo=text) == '\n  foo bar\n'
+        assert t.render(foo=text) == '\n  foo bar\n  "baz"\n'
         t = env.from_string('{{ foo|indent(2, false, true) }}')
-        assert t.render(foo=text) == '\n  foo bar\n  '
+        assert t.render(foo=text) == '\n  foo bar\n  "baz"\n  '
         t = env.from_string('{{ foo|indent(2, true, false) }}')
-        assert t.render(foo=text) == '  \n  foo bar\n'
+        assert t.render(foo=text) == '  \n  foo bar\n  "baz"\n'
         t = env.from_string('{{ foo|indent(2, true, true) }}')
-        assert t.render(foo=text) == '  \n  foo bar\n  '
+        assert t.render(foo=text) == '  \n  foo bar\n  "baz"\n  '
 
+    def test_indent(self, env):
+        self._test_indent_multiline_template(env)
         t = env.from_string('{{ "jinja"|indent }}')
         assert t.render() == 'jinja'
         t = env.from_string('{{ "jinja"|indent(first=true) }}')
         assert t.render() == '    jinja'
         t = env.from_string('{{ "jinja"|indent(blank=true) }}')
         assert t.render() == 'jinja'
+
+    def test_indent_markup_input(self, env):
+        '''
+        Tests casses where the filter input is a Markup type
+        '''
+        self._test_indent_multiline_template(env, markup=True)
 
     def test_indentfirst_deprecated(self, env):
         with pytest.warns(DeprecationWarning):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -160,7 +160,7 @@ class TestFilter(object):
 
     def test_indent_markup_input(self, env):
         '''
-        Tests casses where the filter input is a Markup type
+        Tests cases where the filter input is a Markup type
         '''
         self._test_indent_multiline_template(env, markup=True)
 


### PR DESCRIPTION
This ~~unescapes after concatenating~~ ensures that we only concatenate `Markup` types to other `Markup` types, to fix a bug introduced in Jinja 2.10 where concatenated lines contain escaped versions of quotes and other characters.

Resolves #823.