### PR TITLE
Continue on search path if ENOTDIR returned when looking for templates

### DIFF
--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -153,7 +153,7 @@ def open_if_exists(filename, mode='rb'):
     try:
         return open(filename, mode)
     except IOError as e:
-        if e.errno not in (errno.ENOENT, errno.EISDIR, errno.EINVAL):
+        if e.errno not in (errno.ENOENT, errno.EISDIR, errno.EINVAL, errno.ENOTDIR):
             raise
 
 


### PR DESCRIPTION
This became a problem in my build environment where we're running from python packaged into `.jar` files. The code looks for a path of the form `run.jar/templates/my_template.html` which returns `errno.ENOTDIR` breaking out of the whole search loop. This fixes that.