### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -15,6 +15,6 @@
 <h3>Useful Links</h3>
 <ul>
   <li><a href="http://jinja.pocoo.org/">The Jinja2 Website</a></li>
-  <li><a href="https://pypi.python.org/pypi/Jinja2">Jinja2 @ PyPI</a></li>
+  <li><a href="https://pypi.org/project/Jinja2/">Jinja2 @ PyPI</a></li>
   <li><a href="https://github.com/pallets/jinja">Jinja2 @ github</a></li>
 </ul>

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,11 +60,11 @@ As an alternative to steps 4 you can also do ``python setup.py develop``
 which will install the package via `distribute` in development mode.  This also
 has the advantage that the C extensions are compiled.
 
-.. _download page: https://pypi.python.org/pypi/Jinja2
-.. _distribute: https://pypi.python.org/pypi/distribute 
+.. _download page: https://pypi.org/project/Jinja2/
+.. _distribute: https://pypi.org/project/distribute/ 
 .. _setuptools: http://peak.telecommunity.com/DevCenter/setuptools
 .. _easy_install: http://peak.telecommunity.com/DevCenter/EasyInstall
-.. _pip: https://pypi.python.org/pypi/pip
+.. _pip: https://pypi.org/project/pip/
 .. _git: https://git-scm.org/
 
 
@@ -75,7 +75,7 @@ As of version 2.7 Jinja2 depends on the `MarkupSafe`_ module.  If you
 install Jinja2 via `pip` or `easy_install` it will be installed
 automatically for you.
 
-.. _MarkupSafe: https://pypi.python.org/pypi/MarkupSafe
+.. _MarkupSafe: https://pypi.org/project/MarkupSafe/
 
 Basic API Usage
 ---------------


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html