### PR TITLE
Add a DerivedContextReference node type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,9 @@ Unreleased
     and source for Python >= 3.7. :issue:`1104`
 -   Tracebacks for template syntax errors in Python 3 no longer show
     internal compiler frames. :issue:`763`
+-   Add a ``DerivedContextReference`` node that can be used by
+    extensions to get the current context and local variables such as
+    ``loop``. :issue:`860`
 
 
 Version 2.10.3

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1720,6 +1720,9 @@ class CodeGenerator(NodeVisitor):
     def visit_ContextReference(self, node, frame):
         self.write('context')
 
+    def visit_DerivedContextReference(self, node, frame):
+        self.write(self.derive_context(frame))
+
     def visit_Continue(self, node, frame):
         self.writeline('continue', node)
 

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -952,6 +952,15 @@ class ContextReference(Expr):
     """
 
 
+class DerivedContextReference(Expr):
+    """Return the current template context including locals. Behaves
+    exactly like :class:`ContextReference`, but includes local
+    variables, such as from a ``for`` loop.
+
+    .. versionadded:: 2.11
+    """
+
+
 class Continue(Stmt):
     """Continue a loop."""
 


### PR DESCRIPTION
This allows extensions to access locals in the scope from which they were called. Fixes #860