### PR TITLE
Import abstract base classes from collections.abc

### DIFF
--- a/docs/jinjaext.py
+++ b/docs/jinjaext.py
@@ -8,7 +8,6 @@
     :copyright: Copyright 2008 by Armin Ronacher.
     :license: BSD.
 """
-import collections
 import os
 import re
 import inspect
@@ -26,6 +25,7 @@ from pygments.style import Style
 from pygments.token import Keyword, Name, Comment, String, Error, \
      Number, Operator, Generic
 from jinja2 import Environment, FileSystemLoader
+from jinja2._compat import abc
 
 
 def parse_rst(state, content_offset, doc):
@@ -160,7 +160,7 @@ def jinja_nodes(dirname, arguments, options, content, lineno,
             members = []
             for key, name in node.__dict__.items():
                 if not key.startswith('_') and \
-                   not hasattr(node.__base__, key) and isinstance(name, collections.Callable):
+                   not hasattr(node.__base__, key) and isinstance(name, abc.Callable):
                     members.append(key)
             if members:
                 members.sort()

--- a/jinja2/_compat.py
+++ b/jinja2/_compat.py
@@ -97,3 +97,9 @@ try:
     from urllib.parse import quote_from_bytes as url_quote
 except ImportError:
     from urllib import quote as url_quote
+
+
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -20,7 +20,7 @@ from jinja2.exceptions import UndefinedError, TemplateRuntimeError, \
      TemplateNotFound
 from jinja2._compat import imap, text_type, iteritems, \
      implements_iterator, implements_to_string, string_types, PY2, \
-     with_metaclass
+     with_metaclass, abc
 
 
 # these variables are exported to the template runtime
@@ -313,12 +313,7 @@ class Context(with_metaclass(ContextMeta)):
         )
 
 
-# register the context as mapping if possible
-try:
-    from collections import Mapping
-    Mapping.register(Context)
-except ImportError:
-    pass
+abc.Mapping.register(Context)
 
 
 class BlockReference(object):

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -14,10 +14,9 @@
 """
 import types
 import operator
-from collections import Mapping
 from jinja2.environment import Environment
 from jinja2.exceptions import SecurityError
-from jinja2._compat import string_types, PY2
+from jinja2._compat import string_types, PY2, abc
 from jinja2.utils import Markup
 
 from markupsafe import EscapeFormatter
@@ -79,10 +78,9 @@ except ImportError:
     pass
 
 #: register Python 2.6 abstract base classes
-from collections import MutableSet, MutableMapping, MutableSequence
-_mutable_set_types += (MutableSet,)
-_mutable_mapping_types += (MutableMapping,)
-_mutable_sequence_types += (MutableSequence,)
+_mutable_set_types += (abc.MutableSet,)
+_mutable_mapping_types += (abc.MutableMapping,)
+_mutable_sequence_types += (abc.MutableSequence,)
 
 
 _mutable_spec = (
@@ -103,7 +101,7 @@ _mutable_spec = (
 )
 
 
-class _MagicFormatMapping(Mapping):
+class _MagicFormatMapping(abc.Mapping):
     """This class implements a dummy wrapper to fix a bug in the Python
     standard library for string formatting.
 

--- a/jinja2/tests.py
+++ b/jinja2/tests.py
@@ -10,9 +10,8 @@
 """
 import operator
 import re
-from collections import Mapping
 from jinja2.runtime import Undefined
-from jinja2._compat import text_type, string_types, integer_types
+from jinja2._compat import text_type, string_types, integer_types, abc
 import decimal
 
 number_re = re.compile(r'^-?\d+(\.\d+)?$')
@@ -84,7 +83,7 @@ def test_mapping(value):
 
     .. versionadded:: 2.6
     """
-    return isinstance(value, Mapping)
+    return isinstance(value, abc.Mapping)
 
 
 def test_number(value):

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -14,7 +14,7 @@ import errno
 from collections import deque
 from threading import Lock
 from jinja2._compat import text_type, string_types, implements_iterator, \
-     url_quote
+     url_quote, abc
 
 
 _word_split_re = re.compile(r'(\s+)')
@@ -480,12 +480,7 @@ class LRUCache(object):
     __copy__ = copy
 
 
-# register the LRU cache as mutable mapping if possible
-try:
-    from collections import MutableMapping
-    MutableMapping.register(LRUCache)
-except ImportError:
-    pass
+abc.MutableMapping.register(LRUCache)
 
 
 def select_autoescape(enabled_extensions=('html', 'htm', 'xml'),


### PR DESCRIPTION
In Python 3.7, importing ABCs directly from the `collections` module shows a
warning (and in Python 3.8 it will stop working) - see
https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320

This fixes various DeprecationWarnings such as those:

```
.../jinja2/utils.py:485: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import MutableMapping

.../jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping
```