### PR TITLE
Update integration docs for Vim syntax highlighting

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -81,21 +81,26 @@ snippet and add it into your `config/environment.py`::
 TextMate
 --------
 
-There is a `bundle for TextMate`_ that supports syntax highlighting for Jinja1 and Jinja2 for text based
-templates as well as HTML.  It also contains a few often used snippets.
+There is a `bundle for TextMate`_ that supports syntax highlighting for Jinja1
+and Jinja2 for text based templates as well as HTML. It also contains a few
+often used snippets.
 
 .. _bundle for TextMate: https://github.com/mitsuhiko/jinja2-tmbundle
 
 Vim
 ---
 
-A syntax plugin for `Vim`_ exists in the Vim-scripts directory as well as the
-`ext` folder at the root of the Jinja2 project.  `The script
-<http://www.vim.org/scripts/script.php?script_id=1856>`_ supports Jinja1 and
-Jinja2.  Once installed two file types are available `jinja` and `htmljinja`.
-The first one for text based templates, the latter for HTML templates.
+A syntax plugin for `Vim`_ is available `from the jinja repository
+<https://github.com/pallets/jinja/blob/master/ext/Vim/jinja.vim>`_. The script
+supports Jinja1 and Jinja2. Once installed, two file types are available
+(``jinja`` and ``htmljinja``). The first one is for text-based templates and the
+second is for HTML templates. For HTML documents, the plugin attempts to
+automatically detect Jinja syntax inside of existing HTML documents.
 
-Copy the files into your `syntax` folder.
+If you are using a plugin manager like `Pathogen`_, see the `vim-jinja
+<https://github.com/mitsuhiko/vim-jinja>`_ repository for installing in the
+``bundle/`` directory.
 
 .. _Babel: http://babel.pocoo.org/
 .. _Vim: http://www.vim.org/
+.. _Pathogen: https://github.com/tpope/vim-pathogen


### PR DESCRIPTION
I spent a while battling to get Jinja syntax highlighting working correctly with Vim, so I made some quick changes to hopefully make it easier for others to get started working with the syntax highlighting.

Notably, I removed the link to the hosted Vim script since it is ten years out of date from the one in this repository, and the original author maintains the script elsewhere (in the GitHub repo I explained at the end section for Pathogen users).

I tested and built this locally before submitting the PR, seen below:

![Rendered preview of updated Vim integration docs page](https://user-images.githubusercontent.com/4721034/41993056-d731f3bc-7a0f-11e8-8b66-3a3452933340.png)