### PR TITLE
temporarily pin pytest to avoid test bug

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 passenv = LANG
 usedevelop = true
 deps =
-    pytest>=3
+    pytest>=3,<3.7
     coverage
 
 commands = coverage run -p -m pytest {posargs}


### PR DESCRIPTION
pytest-dev/pytest#3771

Pytest 3.7.0 and 3.7.1 had some issues with test collection causing a recursion error. 3.7.2 should fix that, then this can be reverted.