### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/docs/_themes/jinja/static/jinja.css_t
+++ b/docs/_themes/jinja/static/jinja.css_t
@@ -12,11 +12,11 @@
 {% set sidebar_width = '220px' %}
 {% set font_family = 'Georgia, serif' %}
 {% set header_font_family = 'Crimson Text, ' ~ font_family %}
- 
+
 @import url("basic.css");
- 
+
 /* -- page layout ----------------------------------------------------------- */
- 
+
 body {
     font-family: {{ font_family }};
     font-size: 17px;
@@ -47,7 +47,7 @@ div.sphinxsidebar {
 hr {
     border: 1px solid #B1B4B6;
 }
- 
+
 div.body {
     background-color: #ffffff;
     color: #3E4349;
@@ -58,7 +58,7 @@ img.floatingflask {
     padding: 0 0 10px 10px;
     float: right;
 }
- 
+
 div.footer {
     width: {{ page_width }};
     margin: 20px auto 30px auto;
@@ -74,7 +74,7 @@ div.footer a {
 div.related {
     display: none;
 }
- 
+
 div.sphinxsidebar a {
     color: #444;
     text-decoration: none;
@@ -84,7 +84,7 @@ div.sphinxsidebar a {
 div.sphinxsidebar a:hover {
     border-bottom: 1px solid #999;
 }
- 
+
 div.sphinxsidebar {
     font-size: 15px;
     line-height: 1.5;
@@ -99,7 +99,7 @@ div.sphinxsidebarwrapper p.logo {
     margin: 0;
     text-align: center;
 }
- 
+
 div.sphinxsidebar h3,
 div.sphinxsidebar h4 {
     font-family: {{ font_family }};
@@ -113,7 +113,7 @@ div.sphinxsidebar h4 {
 div.sphinxsidebar h4 {
     font-size: 20px;
 }
- 
+
 div.sphinxsidebar h3 a {
     color: #444;
 }
@@ -124,7 +124,7 @@ div.sphinxsidebar p.logo a:hover,
 div.sphinxsidebar h3 a:hover {
     border: none;
 }
- 
+
 div.sphinxsidebar p {
     color: #555;
     margin: 10px 0;
@@ -135,7 +135,7 @@ div.sphinxsidebar ul {
     padding: 0;
     color: #000;
 }
- 
+
 div.sphinxsidebar input {
     border: 1px solid #ccc;
     font-family: {{ font_family }};
@@ -145,19 +145,19 @@ div.sphinxsidebar input {
 div.sphinxsidebar form.search input[name="q"] {
     width: 130px;
 }
- 
+
 /* -- body styles ----------------------------------------------------------- */
- 
+
 a {
     color: #aa0000;
     text-decoration: underline;
 }
- 
+
 a:hover {
     color: #dd0000;
     text-decoration: underline;
 }
- 
+
 div.body h1,
 div.body h2,
 div.body h3,
@@ -170,25 +170,25 @@ div.body h6 {
     padding: 0;
     color: black;
 }
- 
+
 div.body h1 { margin-top: 0; padding-top: 0; font-size: 240%; }
 div.body h2 { font-size: 180%; }
 div.body h3 { font-size: 150%; }
 div.body h4 { font-size: 130%; }
 div.body h5 { font-size: 100%; }
 div.body h6 { font-size: 100%; }
- 
+
 a.headerlink {
     color: #ddd;
     padding: 0 4px;
     text-decoration: none;
 }
- 
+
 a.headerlink:hover {
     color: #444;
     background: #eaeaea;
 }
- 
+
 div.body p, div.body dd, div.body li {
     line-height: 1.4em;
 }
@@ -235,20 +235,20 @@ div.note {
     background-color: #eee;
     border: 1px solid #ccc;
 }
- 
+
 div.seealso {
     background-color: #ffc;
     border: 1px solid #ff6;
 }
- 
+
 div.topic {
     background-color: #eee;
 }
- 
+
 p.admonition-title {
     display: inline;
 }
- 
+
 p.admonition-title:after {
     content: ":";
 }
@@ -342,7 +342,7 @@ ul, ol {
     margin: 10px 0 10px 30px;
     padding: 0;
 }
- 
+
 pre {
     background: #eee;
     padding: 7px 30px;
@@ -359,7 +359,7 @@ dl dl pre {
     margin-left: -90px;
     padding-left: 90px;
 }
- 
+
 tt {
     background-color: #E8EFF0;
     color: #222;

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,7 +19,7 @@ Even if you are creating templates from strings by using the constructor of
 albeit a shared one.
 
 Most applications will create one :class:`Environment` object on application
-initialization and use that to load templates.  In some cases however, it's 
+initialization and use that to load templates.  In some cases however, it's
 useful to have multiple environments side by side, if different configurations
 are in use.
 
@@ -213,7 +213,7 @@ useful if you want to dig deeper into Jinja2 or :ref:`develop extensions
         For a more complex example you can provide a hint.  For example
         the :func:`first` filter creates an undefined object that way::
 
-            return environment.undefined('no first item, sequence was empty')            
+            return environment.undefined('no first item, sequence was empty')
 
         If it the `name` or `obj` is known (for example because an attribute
         was accessed) it should be passed to the undefined object, even if
@@ -838,7 +838,7 @@ Here a simple test that checks if a variable is a prime number::
             if n % i == 0:
                 return False
         return True
-        
+
 
 You can register it on the template environment by updating the
 :attr:`~Environment.tests` dict on the environment::

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -62,7 +62,7 @@ which will install the package via `distribute` in development mode.  This also
 has the advantage that the C extensions are compiled.
 
 .. _download page: https://pypi.org/project/Jinja2/
-.. _distribute: https://pypi.org/project/distribute/ 
+.. _distribute: https://pypi.org/project/distribute/
 .. _setuptools: http://peak.telecommunity.com/DevCenter/setuptools
 .. _easy_install: http://peak.telecommunity.com/DevCenter/EasyInstall
 .. _pip: https://pypi.org/project/pip/

--- a/ext/django2jinja/django2jinja.py
+++ b/ext/django2jinja/django2jinja.py
@@ -33,13 +33,13 @@
         writer = Writer()
         writer.node_handlers[MyNode] = write_my_node
         convert_templates('/path/to/output/folder', writer=writer)
-    
+
     Here is an example hos to automatically translate your django
     variables to jinja2::
-        
+
         import re
         # List of tuple (Match pattern, Replace pattern, Exclusion pattern)
-        
+
         var_re  = ((re.compile(r"(u|user)\.is_authenticated"), r"\1.is_authenticated()", None),
                   (re.compile(r"\.non_field_errors"), r".non_field_errors()", None),
                   (re.compile(r"\.label_tag"), r".label_tag()", None),
@@ -47,7 +47,7 @@
                   (re.compile(r"\.as_table"), r".as_table()", None),
                   (re.compile(r"\.as_widget"), r".as_widget()", None),
                   (re.compile(r"\.as_hidden"), r".as_hidden()", None),
-                  
+
                   (re.compile(r"\.get_([0-9_\w]+)_url"), r".get_\1_url()", None),
                   (re.compile(r"\.url"), r".url()", re.compile(r"(form|calendar).url")),
                   (re.compile(r"\.get_([0-9_\w]+)_display"), r".get_\1_display()", None),
@@ -55,14 +55,14 @@
                   (re.compile(r"loop\.revcounter"), r"loop.revindex", None),
                   (re.compile(r"request\.GET\.([0-9_\w]+)"), r"request.GET.get('\1', '')", None),
                   (re.compile(r"request\.get_host"), r"request.get_host()", None),
-                  
+
                   (re.compile(r"\.all(?!_)"), r".all()", None),
                   (re.compile(r"\.all\.0"), r".all()[0]", None),
                   (re.compile(r"\.([0-9])($|\s+)"), r"[\1]\2", None),
                   (re.compile(r"\.items"), r".items()", None),
         )
         writer = Writer(var_re=var_re)
-        
+
     For details about the writing process have a look at the module code.
 
     :copyright: (c) 2009 by the Jinja Team.
@@ -314,7 +314,7 @@ class Writer(object):
         """Performs variable name translation."""
         if self.in_loop and var == 'forloop' or var.startswith('forloop.'):
             var = var[3:]
-        
+
         for reg, rep, unless in self.var_re:
             no_unless = unless and unless.search(var) or True
             if reg.search(var) and no_unless:
@@ -425,7 +425,7 @@ def if_condition(writer, node):
     join_with = 'and'
     if node.link_type == core_tags.IfNode.LinkTypes.or_:
         join_with = 'or'
-    
+
     for idx, (ifnot, expr) in enumerate(node.bool_exprs):
         if idx:
             writer.write(' %s ' % join_with)
@@ -734,22 +734,22 @@ def simple_tag(writer, node):
         writer._filters_warned.add(name)
         writer.warn('Filter %s probably doesn\'t exist in Jinja' %
                     name)
-        
+
     if not node.vars_to_resolve:
         # No argument, pass the request
         writer.start_variable()
         writer.write('request|')
         writer.write(name)
         writer.end_variable()
-        return 
-    
+        return
+
     first_var =  node.vars_to_resolve[0]
     args = node.vars_to_resolve[1:]
     writer.start_variable()
-    
+
     # Copied from Writer.filters()
     writer.node(first_var)
-    
+
     writer.write('|')
     writer.write(name)
     if args:
@@ -762,7 +762,7 @@ def simple_tag(writer, node):
             else:
                 writer.literal(var.literal)
         writer.write(')')
-    writer.end_variable()   
+    writer.end_variable()
 
 # get rid of node now, it shouldn't be used normally
 del node

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -1,11 +1,11 @@
 # lint Python modules using external checkers.
-# 
+#
 # This is the main checker controlling the other ones and the reports
 # generation. It is itself both a raw checker and an astng checker in order
 # to:
 # * handle message activation / deactivation at the module level
 # * handle some basic but necessary stats'data (number of classes, methods...)
-# 
+#
 [MASTER]
 
 # Specify a configuration file.
@@ -92,7 +92,7 @@ comment=no
 # * undefined variables
 # * redefinition of variable from builtins or from an outer scope
 # * use of variable before assignment
-# 
+#
 [VARIABLES]
 
 # Tells whether we should check for unused import in __init__ files.
@@ -107,7 +107,7 @@ additional-builtins=
 
 
 # try to find bugs in the code using type inference
-# 
+#
 [TYPECHECK]
 
 # Tells whether missing members accessed in mixin class should be ignored. A
@@ -132,7 +132,7 @@ acquired-members=REQUEST,acl_users,aq_parent
 # * dangerous default values as arguments
 # * redefinition of function / method / class
 # * uses of the global statement
-# 
+#
 [BASIC]
 
 # Required attributes for module, separated by a comma
@@ -183,7 +183,7 @@ bad-functions=apply,input
 # checks for sign of poor/misdesign:
 # * number of methods, attributes, local variables...
 # * size, complexity of functions, methods
-# 
+#
 [DESIGN]
 
 # Maximum number of arguments for function / method
@@ -219,7 +219,7 @@ max-public-methods=20
 # * relative / wildcard imports
 # * cyclic imports
 # * uses of deprecated modules
-# 
+#
 [IMPORTS]
 
 # Deprecated modules which should not be used, separated by a comma
@@ -245,7 +245,7 @@ int-import-graph=
 # * attributes not defined in the __init__ method
 # * supported interfaces implementation
 # * unreachable code
-# 
+#
 [CLASSES]
 
 # List of interface methods to ignore, separated by a comma. This is used for
@@ -259,7 +259,7 @@ defining-attr-methods=__init__,__new__,setUp
 # checks for similarities and duplicated code. This computation may be
 # memory / CPU intensive, so you should disable it if you experiments some
 # problems.
-# 
+#
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
@@ -275,7 +275,7 @@ ignore-docstrings=yes
 # checks for:
 # * warning notes in the code like FIXME, XXX
 # * PEP 263: source code with non ascii character but no encoding declaration
-# 
+#
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
@@ -287,7 +287,7 @@ notes=FIXME,XXX,TODO
 # * strict indentation
 # * line length
 # * use of <> instead of !=
-# 
+#
 [FORMAT]
 
 # Maximum number of characters on a single line.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,7 +68,7 @@ class TestExtendedAPI(object):
         c.next()
         assert c.current == 2
         c.reset()
-        assert c.current == 1        
+        assert c.current == 1
 
     def test_expressions(self, env):
         expr = env.compile_expression("foo")


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.