### PR TITLE
Add a flip filter

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -941,6 +941,29 @@ def do_attr(environment, obj, name):
 
 
 @contextfilter
+def do_flip(context, value, name, *args, **kwargs):
+    """Applies a filter with arguments flipped in reverse order.
+    This becomes useful with filters like map where you can't easily re-order
+    the arguments yourself.
+
+    Say you want to find all numbers in a list that divides 10 you'd do it like
+    this_
+
+    .. sourcecode:: jinja
+
+        {{ [1,2,3,4,5,6,7,8,9] | select('flip', 'divisibleby', 10) | list }}
+
+
+    This would give you back `[1, 2, 4, 5]`.
+
+    .. versionadded:: 2.11
+    """
+    args = args[::-1] + (value,)
+    return context.environment.call_filter(
+        name, args[0], args[1:], kwargs=kwargs, context=context)
+
+
+@contextfilter
 def do_map(*args, **kwargs):
     """Applies a filter on a sequence of objects or looks up an attribute.
     This is useful when dealing with lists of objects but you are really
@@ -1153,6 +1176,7 @@ FILTERS = {
     'escape':               escape,
     'filesizeformat':       do_filesizeformat,
     'first':                do_first,
+    'flip':                 do_flip,
     'float':                do_float,
     'forceescape':          do_forceescape,
     'format':               do_format,

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -946,17 +946,51 @@ def do_flip(context, value, name, *args, **kwargs):
     This becomes useful with filters like map where you can't easily re-order
     the arguments yourself.
 
-    Say you want to find all numbers in a list that divides 10 you'd do it like
-    this_
+    Example 1:
+
+    Say you have a list of names and you want to prefix them all with "Name: "
+    you could do it like this:
 
     .. sourcecode:: jinja
 
-        {{ [1,2,3,4,5,6,7,8,9] | select('flip', 'divisibleby', 10) | list }}
+        {{ ["Carl", "Jane"] | map("flip", "format", "Name: %s") | join(",") }}
 
+    This would give you back:
 
-    This would give you back `[1, 2, 4, 5]`.
+        Name: Carl, Name: Jane
+
+    Example 2:
+
+    Say you have a User object like below:
+
+    .. sourcecode:: python
+
+        class User(object):
+            def __init__(self, name, surname, age):
+                self.name = name
+                self.surname = surname
+                self.age = age
+        user = User('john', 'doe', 31)
+
+    ... and you want to extract a couple of attribute values from it as a list
+    and process that.
+
+    This is one way to do that:
+
+    .. sourcecode:: jinja
+
+        {{ ['surname', 'name']
+         | map("flip", "attr", user)
+         | map("capitalize")
+         | join(", ")
+        }}
+
+    This would give you back
+
+        Doe, John
 
     .. versionadded:: 2.11
+
     """
     args = args[::-1] + (value,)
     return context.environment.call_filter(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -562,14 +562,44 @@ class TestFilter(object):
         tmpl = env.from_string('{{ none|map("upper")|list }}')
         assert tmpl.render() == '[]'
 
-    def test_flip_map(self, env):
+    def test_flip_with_map(self, env):
+        class User(object):
+            def __init__(self, name, surname, age):
+                self.name = name
+                self.surname = surname
+                self.age = age
         env = Environment()
-        tmpl = env.from_string(
-            '{{ ["Carl", "Sigmund"]'
-            ' | map("flip", "format", "Name: %s")'
-            ' | join("\n")'
-            '}}')
-        assert tmpl.render() == 'Name: Carl\nName: Sigmund'
+        user = User('john', 'doe', 31)
+        fields = ["surname", "name"]
+
+        tmpl = env.from_string('{{ fields'
+                               ' | map("flip", "attr", user)'
+                               ' | map("capitalize")'
+                               ' | join(", ")'
+                               '}}')
+        assert tmpl.render(user=user, fields=fields) == 'Doe, John'
+
+    def test_flip_with_map_complex(self, env):
+        class User(object):
+            def __init__(self, name, surname, age):
+                self.name = name
+                self.surname = surname
+                self.age = age
+        env = Environment()
+        users = [
+            User('john', 'doe', 31),
+            User('jane', 'dee', 27),
+            User('jill', 'due', 47),
+        ]
+        fields = ["surname", "name"]
+        tmpl = env.from_string('{{ users'
+                               ' | map("flip", "map", "attr", "flip", fields)'
+                               ' | map("map", "capitalize")'
+                               ' | map("join", ", ")'
+                               ' | join(" | ")'
+                               '}}')
+        assert tmpl.render(users=users, fields=fields) == \
+            'Doe, John | Dee, Jane | Due, Jill'
 
     def test_simple_select(self, env):
         env = Environment()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -562,6 +562,15 @@ class TestFilter(object):
         tmpl = env.from_string('{{ none|map("upper")|list }}')
         assert tmpl.render() == '[]'
 
+    def test_flip_map(self, env):
+        env = Environment()
+        tmpl = env.from_string(
+            '{{ ["Carl", "Sigmund"]'
+            ' | map("flip", "format", "Name: %s")'
+            ' | join("\n")'
+            '}}')
+        assert tmpl.render() == 'Name: Carl\nName: Sigmund'
+
     def test_simple_select(self, env):
         env = Environment()
         tmpl = env.from_string('{{ [1, 2, 3, 4, 5]|select("odd")|join("|") }}')


### PR DESCRIPTION
The flip filter applies a filter with arguments flipped in reverse order. This
becomes useful with filters like map where you can't easily re-order the
arguments yourself.

See these Ansible issues and PR's for context:
[Ansible Issue #46215](https://github.com/ansible/ansible/issues/46215)
[Ansible PR #46255](https://github.com/ansible/ansible/pull/46255)
[Ansible PR #46340](https://github.com/ansible/ansible/pull/46340)
