### PR TITLE
Enable a buffer of size 1 in a template stream

### DIFF
--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -1260,7 +1260,7 @@ class TemplateStream(object):
 
     def enable_buffering(self, size=5):
         """Enable buffering.  Buffer `size` items before yielding them."""
-        if size <= 1:
+        if size < 1:
             raise ValueError('buffer size too small')
 
         self.buffered = True


### PR DESCRIPTION
Currently, a `Template.stream` permits a buffer size of greater than one.  In an applications I need to stream one buffer at a time.  This pull request changes the existing logic in `enable_buffering` to stream from the buffer one at a time.

Additionally, should there be a check added for non-integer values in `enable_buffering`?  