### PR TITLE
Fix issue with async's do_map which wasn't awaiting any func's that are coroutines

### DIFF
--- a/jinja2/asyncfilters.py
+++ b/jinja2/asyncfilters.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from jinja2.asyncsupport import auto_aiter
+from jinja2.asyncsupport import auto_aiter, auto_await
 from jinja2 import filters
 
 
@@ -109,7 +109,7 @@ async def do_map(*args, **kwargs):
     seq, func = filters.prepare_map(args, kwargs)
     if seq:
         async for item in auto_aiter(seq):
-            yield func(item)
+            yield await auto_await(func(item))
 
 
 @asyncfiltervariant(filters.do_sum)

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -173,6 +173,11 @@ def test_simple_map(env_async, items):
     assert tmpl.render(items=items) == '6'
 
 
+def test_map_sum(env_async):  # async map + async filter
+    tmpl = env_async.from_string('{{ [[1,2], [3], [4,5,6]]|map("sum")|list }}')
+    assert tmpl.render() == '[3, 3, 15]'
+
+
 @mark_dualiter('users', make_users)
 def test_attribute_map(env_async, users):
     tmpl = env_async.from_string('{{ users()|map(attribute="name")|join("|") }}')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -544,6 +544,10 @@ class TestFilter(object):
         tmpl = env.from_string('{{ ["1", "2", "3"]|map("int")|sum }}')
         assert tmpl.render() == '6'
 
+    def test_map_sum(self, env):
+        tmpl = env.from_string('{{ [[1,2], [3], [4,5,6]]|map("sum")|list }}')
+        assert tmpl.render() == '[3, 3, 15]'
+
     def test_attribute_map(self, env):
         class User(object):
             def __init__(self, name):


### PR DESCRIPTION
While working on the async version of a new applymacro filter, I noticed an underlying issue with map, applying other async filters.  In its iteration, it needed to check whether the return value is a coroutine, and if so wait for it.

The added test, test_map_sum passes when in non-async mode, but without this fix, fails in the async tests.