### PR TITLE
[Docs] Fix ambiguity in include section

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -989,7 +989,7 @@ at the same time.  They are documented in detail in the
 Include
 ~~~~~~~
 
-The `include` statement is useful to include a template and return the
+The `include` tag is useful to include a template and return the
 rendered contents of that file into the current namespace::
 
     {% include 'header.html' %}


### PR DESCRIPTION
The extends section was written as:

> The extends **tag** can be used to...

So, this PR change `statement` into `tag` in the include section to follow this format:

> The include **tag** is useful to...