### PR TITLE
Add support for auto-indented blocks

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -630,6 +630,26 @@ def do_indent(
     return rv
 
 
+def do_lineprefix(s, prefix):
+    """Return a copy of the string with each line prepended by the given string.
+
+    :param prefix: String to prepend each line with
+
+    .. versionadded:: 2.11
+        Add block auto-indent feature
+    """
+    newline = u'\n'
+
+    if isinstance(s, Markup):
+        prefix = Markup(prefix)
+        newline = Markup(newline)
+
+    lines = s.splitlines()
+    rv = newline.join(prefix + line if line else line for line in lines)
+
+    return rv
+
+
 @environmentfilter
 def do_truncate(env, s, length=255, killwords=False, end='...', leeway=None):
     """Return a truncated copy of the string. The length is specified
@@ -1208,6 +1228,7 @@ FILTERS = {
     'format':               do_format,
     'groupby':              do_groupby,
     'indent':               do_indent,
+    'lineprefix':           do_lineprefix,
     'int':                  do_int,
     'join':                 do_join,
     'last':                 do_last,

--- a/jinja2/lexer.py
+++ b/jinja2/lexer.py
@@ -487,13 +487,14 @@ class Lexer(object):
             'root': [
                 # directives
                 (c('(.*?)(?:%s)' % '|'.join(
-                    [r'(?P<raw_begin>(?:\s*%s\-|%s)\s*raw\s*(?:\-%s\s*|%s))' % (
+                    [r'(?P<raw_begin>(?:\s*%s\-|[ \t]*%s\*|%s)\s*raw\s*(?:\-%s\s*|%s))' % (
+                        e(environment.block_start_string),
                         e(environment.block_start_string),
                         block_prefix_re,
                         e(environment.block_end_string),
                         e(environment.block_end_string)
                     )] + [
-                        r'(?P<%s_begin>\s*%s\-|%s)' % (n, r, prefix_re.get(n,r))
+                        r'(?P<%s_begin>\s*%s\-|[ \t]*%s\*|%s)' % (n, r, r, prefix_re.get(n,r))
                         for n, r in root_tag_rules
                     ])), (TOKEN_DATA, '#bygroup'), '#bygroup'),
                 # data


### PR DESCRIPTION
Fixes #178

Blocks now support a new syntax `{%* ... %}` that aligns the indentation of
multiline string with the block statement itself. This is especially
useful when templating YAML or other languages where indentation matters. Example:

labels.j2:
```
tla: webtool
env: {{ env }}
```

deployment.yaml.j2:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    {% include 'labels.j2' %}
  name: webtool
spec:
  selector:
    matchLabels:
      {% include 'labels.j2' %}
  strategy:
    type: Recreate
```
...renders to broken YAML:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    tla: webtool
env: qa
  name: webtool
spec:
  selector:
    matchLabels:
      tla: webtool
env: qa
  strategy:
    type: Recreate
```

deployment_new_syntax.yaml.j2:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    {%* include 'labels.j2' %}
  name: webtool
spec:
  selector:
    matchLabels:
      {%* include 'labels.j2' %}
  strategy:
    type: Recreate
```
...renders correctly:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    tla: webtool
    env: qa
  name: webtool
spec:
  selector:
    matchLabels:
      tla: webtool
      env: qa
  strategy:
    type: Recreate
```