### PR TITLE
Fix broken nl2br filter example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -740,7 +740,7 @@ enabled::
     import re
     from jinja2 import evalcontextfilter, Markup, escape
 
-    _paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
+    _paragraph_re = re.compile(r'(?:\r\n|\r(?!\n)|\n){2,}')
 
     @evalcontextfilter
     def nl2br(eval_ctx, value):


### PR DESCRIPTION
This example attempts to handle both Windows-style and Unix-style line endings, but does it wrong; as noted at https://stackoverflow.com/q/12521127/1709587, the regex here will match a single \r\n as if it were a double line-break, which results in all single Windows-style line-breaks getting converted into `<p>` breaks instead of `<br>` breaks as intended.

This patch fixes that by applying Alan Moore's proposed fix from https://stackoverflow.com/a/12521544/1709587 of using a negative lookahead so that a \r cannot be counted as a line break if it is followed by a \n (while still allowing the \r\n combination to count as a line break).