### PR TITLE
Fixing compiler handling of parens around boolean comparisons.

### DIFF
--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1529,9 +1529,11 @@ class CodeGenerator(NodeVisitor):
 
     @optimizeconst
     def visit_Compare(self, node, frame):
+        self.write('(')
         self.visit(node.expr, frame)
         for op in node.ops:
             self.visit(op, frame)
+        self.write(')')
 
     def visit_Operand(self, node, frame):
         self.write(' %s ' % operators[node.op])

--- a/tests/test_lexnparse.py
+++ b/tests/test_lexnparse.py
@@ -332,6 +332,12 @@ class TestSyntax(object):
                                '{{ 2 == 2 }}|{{ 1 <= 1 }}')
         assert tmpl.render() == 'True|True|True|True|True'
 
+    def test_compare_parens(self, env):
+        tmpl = env.from_string(
+            "{{ i*(j<5) }}"
+        )
+        assert tmpl.render(i=2, j=3) == '2'
+
     def test_inop(self, env):
         tmpl = env.from_string('{{ 1 in [1, 2, 3] }}|{{ 1 not in [1, 2, 3] }}')
         assert tmpl.render() == 'True|False'


### PR DESCRIPTION
In response to: [[BUG] Unexpected TypeError when using boolean test inside numeric expression](https://github.com/pallets/jinja/issues/755)

Full details in the latest post in that issue.

Not sure if this is the right place for a unit test, or if this is the right test; I didn't see any compiler-specific tests, and I wasn't able to get them running successfully on my laptop.  However, I applied the change directly to the installed version of jinja2 and it fixed the problem, and the code in the unit test in the commit executes as desired when run on its own.