### PR TITLE
Better repr for TemplateNotFound.

### DIFF
--- a/jinja2/exceptions.py
+++ b/jinja2/exceptions.py
@@ -50,7 +50,7 @@ class TemplateNotFound(IOError, LookupError, TemplateError):
     message = None
 
     def __init__(self, name, message=None):
-        IOError.__init__(self)
+        IOError.__init__(self, name)
         if message is None:
             message = name
         self.message = message


### PR DESCRIPTION
Without this, a TemplateNotFound representation is just `TemplateNotFound()`, which is not really helpfull.

Giving this paramter up permits to have `TemplateNotFound('the template name')` which helps more.