### PR TITLE
add list filter to make example match output

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -284,7 +284,7 @@ def do_unique(environment, value, case_sensitive=False, attribute=None):
 
     .. sourcecode:: jinja
 
-        {{ ['foo', 'bar', 'foobar', 'FooBar']|unique }}
+        {{ ['foo', 'bar', 'foobar', 'FooBar']|unique|list }}
             -> ['foo', 'bar', 'foobar']
 
     The unique items are yielded in the same order as their first occurrence in


### PR DESCRIPTION
without `|list` filter the output is `<generator object do_unique at 0x7f64de96a780>`
So I thought adding it to example was useful.