### PR TITLE
Fix use of 'is' operator for comparison

### DIFF
--- a/ext/inlinegettext.py
+++ b/ext/inlinegettext.py
@@ -32,7 +32,7 @@ class InlineGettext(Extension):
         paren_stack = 0
 
         for token in stream:
-            if token.type is not 'data':
+            if token.type != 'data':
                 yield token
                 continue
 


### PR DESCRIPTION
The 'is' operator is not meant to be used for comparisons. It currently working is an implementation detail of CPython.
CPython 3.8 has added a SyntaxWarning for this.