### PR TITLE
Fix tox docs-html builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,10 +46,10 @@ import pkg_resources
 try:
     release = pkg_resources.get_distribution('Jinja2').version
 except ImportError:
-    print 'To build the documentation, The distribution information of Jinja2'
-    print 'Has to be available.  Either install the package into your'
-    print 'development environment or run "setup.py develop" to setup the'
-    print 'metadata.  A virtualenv is recommended!'
+    print('To build the documentation, The distribution information of Jinja2')
+    print('Has to be available.  Either install the package into your')
+    print('development environment or run "setup.py develop" to setup the')
+    print('metadata.  A virtualenv is recommended!')
     sys.exit(1)
 if 'dev' in release:
     release = release.split('dev')[0] + 'dev'


### PR DESCRIPTION
These have been broken for about a month now because of the upgrade
to Sphinx 2. This upgrade happened automatically because we do not
have the version pinned.

Luckily this issue appears to only be from having Python 2 syntax in
the docs script, so making that compatible with Python 3 fixes the
error and allows the docs to pass.