### PR TITLE
fix #884, set commentstring / comments for vim

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -153,7 +153,7 @@ Why is there no Python 2.3/2.4/2.5/3.1/3.2 support?
 Python 2.3 is missing a lot of features that are used heavily in Jinja2.  This
 decision was made as with the upcoming Python 2.6 and 3.0 versions it becomes
 harder to maintain the code for older Python versions.  If you really need
-Python 2.3 support you either have to use `Jinja 1`_ or other templating
+Python 2.3 support you either have to use Jinja 1 or other templating
 engines that still support 2.3.
 
 Python 2.4/2.5/3.1/3.2 support was removed when we switched to supporting
@@ -188,4 +188,3 @@ templates passing information to the parent template.  To avoid this
 issue rename the macro or variable in the parent template to have an
 uncommon prefix.
 
-.. _Jinja 1: http://jinja.pocoo.org/1/

--- a/ext/Vim/jinja.vim
+++ b/ext/Vim/jinja.vim
@@ -82,6 +82,9 @@ syn region jinjaRaw matchgroup=jinjaRawDelim start="{%\s*raw\s*%}" end="{%\s*end
 
 " Jinja comments
 syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,jinjaComment
+" help support folding for some setups
+setlocal commentstring={#%s#}
+setlocal comments=s:{#,e:#}
 
 " Block start keywords.  A bit tricker.  We only highlight at the start of a
 " tag block and only if the name is not followed by a comma or equals sign


### PR DESCRIPTION
This is the correct thing to do, vim-wise, although whether
it has any impact depends on how the user has folding set up
in vim.  I confirmed that with the change, a folding setup that
uses these variables works, whereas without the change, the same
setup doesn't work.

Change only effects a file that has to be manually copied to the user's
~/.vim/syntax folder, so it won't impact jinja execution in any way.