### PR TITLE
Add new maintenance branch format to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ cache:
 branches:
   only:
     - master
-    - /^.*-maintenance$/
-    - /^.*\.x$/
+    - /^\d+(\.\d+)*(\.x)?$/
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ branches:
   only:
     - master
     - /^.*-maintenance$/
+    - /^.*\.x$/
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
+dist: xenial
 sudo: false
 language: python
 
 python:
+  - 3.7
   - 3.6
   - 3.5
   - 3.4
-  - 3.3
   - 2.7
-  - 2.6
-  - pypy
+  - pypy3.5-6.0
+  - pypy2.7-6.0
 
 env:
   - TOXENV=py,codecov


### PR DESCRIPTION
The maintenance branch format appeared to change from `[version]-maintenance` to `[version].x` in the recent months, and this broke Travis CI builds made to those branches. Because they no longer meet the branch regex, the pull requests builds against these branches were no longer being run.

This adds the regex for any branch which ends in `.x`, which should catch the new pattern for maintenance branches.