### PR TITLE
This is the correct thing to do, vim-wise, although whether

### DIFF
--- a/ext/Vim/jinja.vim
+++ b/ext/Vim/jinja.vim
@@ -82,6 +82,9 @@ syn region jinjaRaw matchgroup=jinjaRawDelim start="{%\s*raw\s*%}" end="{%\s*end
 
 " Jinja comments
 syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,jinjaComment
+" help support folding for some setups
+setlocal commentstring={#%s#}
+setlocal comments=s:{#,e:#}
 
 " Block start keywords.  A bit tricker.  We only highlight at the start of a
 " tag block and only if the name is not followed by a comma or equals sign


### PR DESCRIPTION
This is the correct thing to do, vim-wise, although whether
it has any impact depends on how the user has folding set up
in vim. I confirmed that with the change, a folding setup that
uses these variables works, whereas without the change, the same
setup doesn't work.

Change only effects a file that has to be manually copied to the user's
~/.vim/syntax folder, so it won't impact jinja execution in any way.