### PR TITLE
Fix for Loop properties revindex and revindex0 still wrong in Jinja2 2.10 #794

### DIFF
--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -423,19 +423,17 @@ class LoopContext(LoopContextBase):
     def __init__(self, iterable, undefined, recurse=None, depth0=0):
         LoopContextBase.__init__(self, undefined, recurse, depth0)
         self._iterator = iter(iterable)
-
-        # try to get the length of the iterable early.  This must be done
-        # here because there are some broken iterators around where there
-        # __len__ is the number of iterations left (i'm looking at your
-        # listreverseiterator!).
-        try:
-            self._length = len(iterable)
-        except (TypeError, AttributeError):
-            self._length = None
+        self._iterations_done_count = 0
+        self._length = None
         self._after = self._safe_next()
 
     @property
     def length(self):
+        """
+        Getting length of an iterator is a costly operation which requires extra memory
+        and traversing in linear time. So make it an on demand param that iterates from
+        the point onwards of the iterator and accounts for iterated elements.
+        """
         if self._length is None:
             # if was not possible to get the length of the iterator when
             # the loop context was created (ie: iterating over a generator)
@@ -443,8 +441,7 @@ class LoopContext(LoopContextBase):
             # length of that + the number of iterations so far.
             iterable = tuple(self._iterator)
             self._iterator = iter(iterable)
-            iterations_done = self.index0 + 2
-            self._length = len(iterable) + iterations_done
+            self._length = len(iterable) + self._iterations_done_count
         return self._length
 
     def __iter__(self):
@@ -452,7 +449,9 @@ class LoopContext(LoopContextBase):
 
     def _safe_next(self):
         try:
-            return next(self._iterator)
+            tmp = next(self._iterator)
+            self._iterations_done_count += 1
+            return tmp
         except StopIteration:
             return _last_iteration
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,48 @@
+from jinja2 import Template
+from jinja2.runtime import LoopContext
+
+
+TEST_IDX_TEMPLATE_STR_1 = (
+    "[{% for i in lst|reverse %}"
+    + "(len={{ loop.length }}, revindex={{ loop.revindex }}, index={{ loop.index }}, val={{ i }})"
+    + "{% endfor %}]"
+)
+
+
+TEST_IDX0_TEMPLATE_STR_1 = (
+    "[{% for i in lst|reverse %}"
+    + "(len={{ loop.length }}, revindex0={{ loop.revindex0 }}, index0={{ loop.index0 }}, val={{ i }})"
+    + "{% endfor %}]"
+)
+
+
+def test_loop_idx():
+    t = Template(TEST_IDX_TEMPLATE_STR_1)
+    lst = [10]
+    excepted_render = "[(len=1, revindex=1, index=1, val=10)]"
+    assert excepted_render == t.render(lst=lst)
+
+
+def test_loop_idx0():
+    t = Template(TEST_IDX0_TEMPLATE_STR_1)
+    lst = [10]
+    excepted_render = "[(len=1, revindex0=0, index0=0, val=10)]"
+    assert excepted_render == t.render(lst=lst)
+
+
+def test_loopcontext0():
+    in_lst = []
+    l = LoopContext(reversed(in_lst), None)
+    assert l.length == len(in_lst)
+
+
+def test_loopcontext1():
+    in_lst = [10]
+    l = LoopContext(reversed(in_lst), None)
+    assert l.length == len(in_lst)
+
+
+def test_loopcontext2():
+    in_lst = [10, 11]
+    l = LoopContext(reversed(in_lst), None)
+    assert l.length == len(in_lst)


### PR DESCRIPTION
- Fix for issue #794 
- The approach to set length param is costly and should be avoided. only if someone expects the iterator length should the cost be borne.
- Added test cases to validate rendering and LoopContext behavior