### PR TITLE
Fix for Loop properties revindex and revindex0 still wrong in Jinja2 2.10 #794

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ Unreleased
     environment's ``undefined`` class. Omitting the ``else`` clause is a
     valid shortcut and should not raise an error when using
     :class:`StrictUndefined`). :issue:`710`, :pr:`1079`
+-   Fix behavior of ``loop`` control variables such as ``length`` and
+    ``revindex0`` when looping over a generator. :issue:`459, 751, 794`,
+    :pr:`993`
 
 
 Version 2.10.3

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,48 @@
+from jinja2 import Template
+from jinja2.runtime import LoopContext
+
+
+TEST_IDX_TEMPLATE_STR_1 = (
+    "[{% for i in lst|reverse %}"
+    + "(len={{ loop.length }}, revindex={{ loop.revindex }}, index={{ loop.index }}, val={{ i }})"
+    + "{% endfor %}]"
+)
+
+
+TEST_IDX0_TEMPLATE_STR_1 = (
+    "[{% for i in lst|reverse %}"
+    + "(len={{ loop.length }}, revindex0={{ loop.revindex0 }}, index0={{ loop.index0 }}, val={{ i }})"
+    + "{% endfor %}]"
+)
+
+
+def test_loop_idx():
+    t = Template(TEST_IDX_TEMPLATE_STR_1)
+    lst = [10]
+    excepted_render = "[(len=1, revindex=1, index=1, val=10)]"
+    assert excepted_render == t.render(lst=lst)
+
+
+def test_loop_idx0():
+    t = Template(TEST_IDX0_TEMPLATE_STR_1)
+    lst = [10]
+    excepted_render = "[(len=1, revindex0=0, index0=0, val=10)]"
+    assert excepted_render == t.render(lst=lst)
+
+
+def test_loopcontext0():
+    in_lst = []
+    l = LoopContext(reversed(in_lst), None)
+    assert l.length == len(in_lst)
+
+
+def test_loopcontext1():
+    in_lst = [10]
+    l = LoopContext(reversed(in_lst), None)
+    assert l.length == len(in_lst)
+
+
+def test_loopcontext2():
+    in_lst = [10, 11]
+    l = LoopContext(reversed(in_lst), None)
+    assert l.length == len(in_lst)


### PR DESCRIPTION
- The approach to set length param is costly and should be avoided. only if someone expects the iterator length should the cost be borne.
- Added test cases to validate rendering and LoopContext behavior

fixes #459
fixes #751
fixes #794