### PR TITLE
exclude globals from find_undeclared_variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ unreleased
 - Allow ``{%+`` syntax (with NOP behavior) when
   ``lstrip_blocks == False`` (`#748`_)
 - Added a ``default`` parameter for the ``map`` filter. (`#557`_)
+-   Exclude environment globals from
+    :func:`meta.find_undeclared_variables`. #931
 
 .. _#557: https://github.com/pallets/jinja/issues/557
 .. _#765: https://github.com/pallets/jinja/issues/765

--- a/jinja2/meta.py
+++ b/jinja2/meta.py
@@ -29,7 +29,7 @@ class TrackingCodeGenerator(CodeGenerator):
         """Remember all undeclared identifiers."""
         CodeGenerator.enter_frame(self, frame)
         for _, (action, param) in iteritems(frame.symbols.loads):
-            if action == 'resolve':
+            if action == 'resolve' and param not in self.environment.globals:
                 self.undeclared_identifiers.add(param)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,6 +121,10 @@ class TestMeta(object):
         x = meta.find_undeclared_variables(ast)
         assert x == set(['bar', 'seq', 'muh'])
 
+        ast = env.parse('{% for x in range(5) %}{{ x }}{% endfor %}{{ foo }}')
+        x = meta.find_undeclared_variables(ast)
+        assert x == set(['foo'])
+
     def test_find_refererenced_templates(self, env):
         ast = env.parse('{% extends "layout.html" %}{% include helper %}')
         i = meta.find_referenced_templates(ast)


### PR DESCRIPTION
Added a check for global variables when running `find_undeclared_variables`. Tests updated to reflect the change as well.

Written at PyCon 2019 Sprints.

fixes #931 