### PR TITLE
Always include context in macros

### DIFF
--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -547,8 +547,14 @@ class CodeGenerator(NodeVisitor):
         # macros are delayed, they never require output checks
         frame.require_output_check = False
         frame.symbols.analyze_node(node)
-        self.writeline('%s(%s):' % (self.func('macro'), ', '.join(args)), node)
+        self.writeline('outer_context = context')
+        self.writeline('%s(%s):' %
+                       (self.func('macro'), ', '.join(['context'] + args)),
+                       node)
         self.indent()
+        self.writeline('nonlocal outer_context')
+        self.writeline('context = context or outer_context')
+        self.writeline('resolve = context.resolve_or_missing')
 
         self.buffer(frame)
         self.enter_frame(frame)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -126,21 +126,21 @@ class TestAsyncImports(object):
 
     def test_context_imports(self, test_env_async):
         t = test_env_async.from_string('{% import "module" as m %}{{ m.test() }}')
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env_async.from_string(
             '{% import "module" as m without context %}{{ m.test() }}'
         )
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env_async.from_string(
             '{% import "module" as m with context %}{{ m.test() }}'
         )
         assert t.render(foo=42) == '[42|23]'
         t = test_env_async.from_string('{% from "module" import test %}{{ test() }}')
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env_async.from_string(
             '{% from "module" import test without context %}{{ test() }}'
         )
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env_async.from_string(
             '{% from "module" import test with context %}{{ test() }}'
         )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -31,21 +31,21 @@ class TestImports(object):
 
     def test_context_imports(self, test_env):
         t = test_env.from_string('{% import "module" as m %}{{ m.test() }}')
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env.from_string(
             '{% import "module" as m without context %}{{ m.test() }}'
         )
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env.from_string(
             '{% import "module" as m with context %}{{ m.test() }}'
         )
         assert t.render(foo=42) == '[42|23]'
         t = test_env.from_string('{% from "module" import test %}{{ test() }}')
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env.from_string(
             '{% from "module" import test without context %}{{ test() }}'
         )
-        assert t.render(foo=42) == '[|23]'
+        assert t.render(foo=42) == '[42|23]'
         t = test_env.from_string(
             '{% from "module" import test with context %}{{ test() }}'
         )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -16,7 +16,7 @@ from jinja2.sandbox import SandboxedEnvironment, \
 from jinja2 import Markup, escape
 from jinja2.exceptions import SecurityError, TemplateSyntaxError, \
      TemplateRuntimeError
-from jinja2.nodes import EvalContext
+from jinja2.runtime import new_context
 from jinja2._compat import text_type
 
 
@@ -121,7 +121,7 @@ class TestSandbox(object):
         assert escape(t.module) == escaped_out
         assert t.module.say_hello('<blink>foo</blink>') == escaped_out
         assert escape(t.module.say_hello(
-            EvalContext(env), '<blink>foo</blink>')) == escaped_out
+            new_context(env, 'name', {}), '<blink>foo</blink>')) == escaped_out
         assert escape(t.module.say_hello(
             '<blink>foo</blink>')) == escaped_out
 


### PR DESCRIPTION
Addresses #995, when using this instead of import `with context` everywhere, I see a 50% speed improvement.

This change is a proof of concept, if there are better approaches we should be using, I'd like to know. If this might break something, I'd really like to know!

