### PR TITLE
Fix deadlock in LRUCache and improve test coverage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Unreleased
     2.56e-3. :issue:`912`, :pr:`922`
 -   Int and float literals can be written with the '_' separator for
     legibility, like 12_345. :pr:`923`
+-   Fix a bug causing deadlocks in ``LRUCache.setdefault``. :pr:`1000`
 
 
 Version 2.10.2

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -355,15 +355,11 @@ class LRUCache(object):
         """Set `default` if the key is not in the cache otherwise
         leave unchanged. Return the value of this key.
         """
-        self._wlock.acquire()
         try:
-            try:
-                return self[key]
-            except KeyError:
-                self[key] = default
-                return default
-        finally:
-            self._wlock.release()
+            return self[key]
+        except KeyError:
+            self[key] = default
+            return default
 
     def clear(self):
         """Clear the cache."""
@@ -435,7 +431,6 @@ class LRUCache(object):
             try:
                 self._remove(key)
             except ValueError:
-                # __getitem__ is not locked, it might happen
                 pass
         finally:
             self._wlock.release()
@@ -479,7 +474,7 @@ class LRUCache(object):
     __iter__ = iterkeys
 
     def __reversed__(self):
-        """Iterate over the values in the cache dict, oldest items
+        """Iterate over the keys in the cache dict, oldest items
         coming first.
         """
         return iter(tuple(self._queue))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def pytest_configure(config):
         'lexer',
         'lexnparse',
         'loaders',
+        'loremIpsum',
         'lowlevel',
         'lrucache',
         'lstripblocks',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -270,6 +270,13 @@ class TestUndefined(object):
         assert env.from_string('{{ not missing }}').render() == 'True'
         pytest.raises(UndefinedError,
                       env.from_string('{{ missing - 1}}').render)
+        und1 = Undefined(name='x')
+        und2 = Undefined(name='y')
+        assert und1 == und2
+        assert und1 != 42
+        assert hash(und1) == hash(und2) == hash(Undefined())
+        with pytest.raises(AttributeError):
+            getattr(Undefined, '__slots__')
 
     def test_chainable_undefined(self):
         env = Environment(undefined=ChainableUndefined)
@@ -282,6 +289,8 @@ class TestUndefined(object):
         assert env.from_string('{{ not missing }}').render() == 'True'
         pytest.raises(UndefinedError,
                       env.from_string('{{ missing - 1}}').render)
+        with pytest.raises(AttributeError):
+            getattr(ChainableUndefined, '__slots__')
 
         # The following tests ensure subclass functionality works as expected
         assert env.from_string('{{ missing.bar["baz"] }}').render() == u''
@@ -303,6 +312,10 @@ class TestUndefined(object):
         assert env.from_string('{{ foo.missing }}').render(foo=42) \
             == u"{{ no such element: int object['missing'] }}"
         assert env.from_string('{{ not missing }}').render() == 'True'
+        undefined_hint = 'this is testing undefined hint of DebugUndefined'
+        assert str(DebugUndefined(hint=undefined_hint)) == u'{{ undefined value printed: %s }}' % undefined_hint
+        with pytest.raises(AttributeError):
+            getattr(DebugUndefined, '__slots__')
 
     def test_strict_undefined(self):
         env = Environment(undefined=StrictUndefined)
@@ -319,6 +332,8 @@ class TestUndefined(object):
                       env.from_string('{{ not missing }}').render)
         assert env.from_string('{{ missing|default("default", true) }}')\
             .render() == 'default'
+        with pytest.raises(AttributeError):
+            getattr(StrictUndefined, '__slots__')
 
     def test_indexing_gives_undefined(self):
         t = Template("{{ var[42].foo }}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,15 +8,18 @@
     :copyright: (c) 2017 by the Jinja Team.
     :license: BSD, see LICENSE for more details.
 """
+
+from collections import deque
 import gc
+import pickle
+import random
 
 import pytest
 
-import pickle
-
+from jinja2._compat import string_types, range_type
 from jinja2.utils import LRUCache, escape, object_type_repr, urlize, \
-     select_autoescape
-
+     select_autoescape, generate_lorem_ipsum, missing, consume
+from markupsafe import Markup
 
 @pytest.mark.utils
 @pytest.mark.lrucache
@@ -65,6 +68,50 @@ class TestLRUCache(object):
             assert copy._mapping == cache._mapping
             assert copy._queue == cache._queue
 
+    def test_clear(self):
+        d = LRUCache(3)
+        d["a"] = 1
+        d["b"] = 2
+        d["c"] = 3
+        d.clear()
+        assert d.__getstate__() == {'capacity': 3, '_mapping': {}, '_queue': deque([])}
+
+    def test_repr(self):
+        d = LRUCache(3)
+        d["a"] = 1
+        d["b"] = 2
+        d["c"] = 3
+        # Sort the strings - mapping is unordered
+        assert sorted(repr(d)) == sorted(u"<LRUCache {'a': 1, 'b': 2, 'c': 3}>")
+
+    def test_items(self):
+        """Test various items, keys, values and iterators of LRUCache."""
+        d = LRUCache(3)
+        d["a"] = 1
+        d["b"] = 2
+        d["c"] = 3
+        assert d.items() == list(d.iteritems()) == [('c', 3), ('b', 2), ('a', 1)]
+        assert d.keys() == list(d.iterkeys()) == ['c', 'b', 'a']
+        assert d.values() == list(d.itervalues()) == [3, 2, 1]
+        assert list(reversed(d)) == ['a', 'b', 'c']
+
+        # Change the cache a little
+        d["b"]
+        d["a"] = 4
+        assert d.items() == list(d.iteritems()) == [('a', 4), ('b', 2), ('c', 3)]
+        assert d.keys() == list(d.iterkeys()) == ['a', 'b', 'c']
+        assert d.values() == list(d.itervalues()) == [4, 2, 3]
+        assert list(reversed(d)) == ['c', 'b', 'a']
+
+    def test_setdefault(self):
+        d = LRUCache(3)
+        assert len(d) == 0
+        assert d.setdefault("a") is None
+        assert d.setdefault("a", 1) is None
+        assert len(d) == 1
+        assert d.setdefault("b", 2) == 2
+        assert len(d) == 2
+
 
 @pytest.mark.utils
 @pytest.mark.helpers
@@ -105,3 +152,47 @@ class TestEscapeUrlizeTarget(object):
         assert urlize(url, target=target) == ('<a href="http://example.org"'
                                               ' target="&lt;script&gt;">'
                                               'http://example.org</a>')
+
+
+@pytest.mark.utils
+@pytest.mark.loremIpsum
+class TestLoremIpsum(object):
+    def test_lorem_ipsum_markup(self):
+        """Test that output of lorem_ipsum is Markup by default."""
+        assert isinstance(generate_lorem_ipsum(), Markup)
+
+    def test_lorem_ipsum_html(self):
+        """Test that output of lorem_ipsum is a string_type when not html."""
+        assert isinstance(generate_lorem_ipsum(html=False), string_types)
+
+    def test_lorem_ipsum_n(self):
+        """Test that the n (number of lines) works as expected."""
+        assert generate_lorem_ipsum(n=0, html=False) == u''
+        for n in range_type(1, 50):
+            assert generate_lorem_ipsum(n=n, html=False).count('\n') == (n - 1) * 2
+
+    def test_lorem_ipsum_min(self):
+        """Test that at least min words are in the output of each line"""
+        for _ in range_type(5):
+           m = random.randrange(20, 99)
+           for _ in range_type(10):
+               assert generate_lorem_ipsum(n=1, min=m, html=False).count(' ') >= m - 1
+
+    def test_lorem_ipsum_max(self):
+        """Test that at least max words are in the output of each line"""
+        for _ in range_type(5):
+           m = random.randrange(21, 100)
+           for _ in range_type(10):
+               assert generate_lorem_ipsum(n=1, max=m, html=False).count(' ') < m - 1
+
+
+def test_missing():
+    """Test the repr of missing."""
+    assert repr(missing) == u'missing'
+
+def test_consume():
+    """Test that consume consumes an iterator."""
+    x = iter([1, 2, 3, 4, 5])
+    consume(x)
+    with pytest.raises(StopIteration):
+        next(x)


### PR DESCRIPTION
I was adding tests for Undefined and other utils by running coverage and finding which lines did not have test coverage, then I found there is a deadlock bug in the LRUCache's setdefault method.

As documented in the commit: setdefault was acquiring write_lock, then calling getitem and also
potentially setitem, which both try to acquire the write lock.
Minimal snippet to reproduce the bug with Python 3.7.3 and Jinja 2.10.1:
```python
from jinja2.utils import LRUCache
x = LRUCache(1)
x.setdefault(1)  # <-- deadlock :(
```

It's fixed now and we have better test coverage :smile: 