### PR TITLE
BUGFIX #930 - Template parse if with when referencing with dictionary…

### DIFF
--- a/jinja2/parser.py
+++ b/jinja2/parser.py
@@ -841,7 +841,9 @@ class Parser(object):
                                            'name:and')):
             if self.stream.current.test('name:is'):
                 self.fail('You cannot chain multiple tests with is')
-            args = [self.parse_primary()]
+            arg_node = self.parse_primary()
+            arg_node = self.parse_postfix(arg_node)
+            args = [arg_node]
         else:
             args = []
         node = nodes.Test(node, name, args, kwargs, dyn_args,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -483,6 +483,10 @@ class TestBug(object):
         t = env.from_string('{% if foo %}{% else %}42{% endif %}')
         assert t.render(foo=False) == '42'
 
+    def test_subproperty_if(self, env):
+        t = env.from_string('{% if object1.subproperty1 is eq object2.subproperty2 %}42{% endif %}')
+        assert t.render(object1={'subproperty1': 'value'}, object2={'subproperty2': 'value'}) == '42'
+
     def test_set_and_include(self):
         env = Environment(loader=DictLoader({
             'inc': 'bar',


### PR DESCRIPTION
… subproperty

Fix #930 
Hi! I tracked down the issue to the parser, it wasn't checking if there was something after a dot or bracket because the `parse_test` needed the `parse_postfix` method, just like `parse_unary`
I also wrote a test to check it out, but if I am missing something please let me know to update the PR :D