### PR TITLE
docs: Python3-ize the examples

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,7 +46,7 @@ To load a template from this environment you just have to call the
 
 To render it with some variables, just call the :meth:`render` method::
 
-    print template.render(the='variables', go='here')
+    print(template.render(the='variables', go='here'))
 
 Using a template loader rather than passing strings to :class:`Template`
 or :meth:`Environment.from_string` has multiple advantages.  Besides being
@@ -834,7 +834,7 @@ Here a simple test that checks if a variable is a prime number::
     def is_prime(n):
         if n == 2:
             return True
-        for i in xrange(2, int(math.ceil(math.sqrt(n))) + 1):
+        for i in range(2, int(math.ceil(math.sqrt(n))) + 1):
             if n % i == 0:
                 return False
         return True

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -572,7 +572,7 @@ As variables in templates retain their object properties, it is possible to
 iterate over containers like `dict`::
 
     <dl>
-    {% for key, value in my_dict.iteritems() %}
+    {% for key, value in my_dict.items() %}
         <dt>{{ key|e }}</dt>
         <dd>{{ value|e }}</dd>
     {% endfor %}
@@ -1196,7 +1196,6 @@ but exists for completeness' sake.  The following operators are supported:
 /
     Divide two numbers.  The return value will be a floating point number.
     ``{{ 1 / 2 }}`` is ``{{ 0.5 }}``.
-    (Just like ``from __future__ import division``.)
 
 //
     Divide two numbers and return the truncated integer result.


### PR DESCRIPTION
This commit updates the examples to conform to Python 3 instead
of Python 2, as Python 3 is more acceptable these days.