### PR TITLE
add default to map filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,11 @@ unreleased
 - The ``map`` filter in async mode now automatically awaits
 - Added a new ``ChainableUndefined`` class to support getitem
   and getattr on an undefined object. (`#977`_)
-- Allow `'{%+'` syntax (with NOP behavior) when
-  `lstrip_blocks == False` (`#748`_)
+- Allow ``{%+`` syntax (with NOP behavior) when
+  ``lstrip_blocks == False`` (`#748`_)
+- Added ``default`` param for ``map`` filter. (`#557`_)
 
+.. _#557: https://github.com/pallets/jinja/issues/557
 .. _#765: https://github.com/pallets/jinja/issues/765
 .. _#748: https://github.com/pallets/jinja/issues/748
 .. _#977: https://github.com/pallets/jinja/issues/977

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -599,6 +599,28 @@ class TestFilter(object):
         tmpl = env.from_string('{{ none|map("upper")|list }}')
         assert tmpl.render() == '[]'
 
+    def test_map_default(self, env):
+        class Fullname(object):
+            def __init__(self, firstname, lastname):
+                self.firstname = firstname
+                self.lastname = lastname
+
+        class Firstname(object):
+            def __init__(self, firstname):
+                self.firstname = firstname
+
+        env = Environment()
+        tmpl = env.from_string(
+            '{{ users|map(attribute="lastname", default="smith")|join(", ") }}'
+        )
+        users = [
+            Fullname("john", "lennon"),
+            Fullname("jane", "edwards"),
+            Fullname("jon", None),
+            Firstname("mike")
+        ]
+        assert tmpl.render(users=users) == "lennon, edwards, None, smith"
+
     def test_simple_select(self, env):
         env = Environment()
         tmpl = env.from_string('{{ [1, 2, 3, 4, 5]|select("odd")|join("|") }}')


### PR DESCRIPTION
added ability to pass default entry to map filter if attribute is not defined. If default is not defined it defaults to an empty string.

fixes #557