### PR TITLE
Unpin Pytest on master branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 passenv = LANG
 usedevelop = true
 deps =
-    pytest>=3,<3.7
+    pytest>=3
     coverage
 
 commands = coverage run -p -m pytest {posargs}


### PR DESCRIPTION
The pytest plugin was "temporarily" pinned many months back. Given that this is not pinned on the stable branch we should be able to remove it here.

There are likely a few other changes required to get the nightly build working, since it appears as though pytest broke during the release of Python 3.8.0a4.