### PR TITLE
Fix pytest unknown mark warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,52 @@ from jinja2.utils import have_async_gen
 from jinja2 import Environment
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(path):
     if 'async' in path.basename and not have_async_gen:
         return True
     return False
+
+
+def pytest_configure(config):
+    '''Register custom marks for test categories.'''
+    custom_markers = [
+        'api',
+        'byte_code_cache',
+        'core_tags',
+        'debug',
+        'escapeUrlizeTarget',
+        'ext',
+        'extended',
+        'filter',
+        'for_loop',
+        'helpers',
+        'if_condition',
+        'imports',
+        'includes',
+        'inheritance',
+        'lexer',
+        'lexnparse',
+        'loaders',
+        'lowlevel',
+        'lrucache',
+        'lstripblocks',
+        'macros',
+        'meta',
+        'moduleloader',
+        'parser',
+        'regression',
+        'sandbox',
+        'set',
+        'streaming',
+        'syntax',
+        'test_tests',
+        'tokenstream',
+        'undefined',
+        'utils',
+        'with_',
+    ]
+    for mark in custom_markers:
+        config.addinivalue_line('markers', mark + ': test category')
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters = true
 deps =
     coverage
     pytest
-commands = coverage run -p -m pytest --tb=short --basetemp={envtmpdir} {posargs}
+commands = coverage run -p -m pytest --tb=short -Werror --basetemp={envtmpdir} {posargs}
 
 [testenv:docs-html]
 deps =


### PR DESCRIPTION
Clean up the test output with recent versions of `pytest`.