### PR TITLE
Wrap undefined with str() call to produce the correct lineno in the traceback

### DIFF
--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1409,7 +1409,7 @@ class CodeGenerator(NodeVisitor):
             load = frame.symbols.find_load(ref)
             if not (load is not None and load[0] == VAR_LOAD_PARAMETER and \
                     not self.parameter_is_undeclared(ref)):
-                self.write('(undefined(name=%r) if %s is missing else %s)' %
+                self.write('(str(undefined(name=%r)) if %s is missing else %s)' %
                            (node.name, ref, ref))
                 return
 

--- a/tests/res/templates/undefined.html
+++ b/tests/res/templates/undefined.html
@@ -1,0 +1,11 @@
+This is a text with
+one
+{{ two }} (error happens here first!)
+three
+{{ four }} (error here as well)
+five
+{{ six }} (no error)
+and more lines.
+
+The line using the "two" variable must be the one to appear in the
+traceback with a matching 'two' is missing message.


### PR DESCRIPTION
Hi,

This issue is affecting us (https://github.com/cylc/cylc-flow/issues/2572) and we are getting the wrong line reported in the traceback when loading our templates.

I wrote a small program to confirm what was going on:

```python
class Z(object):
    def __str__(self):
        raise ValueError('Z error')


def raise_generator():
    yield 'three values are: %s %s %s' % (
        'primeiro',
        Z(),  # traceback must point to this lineno 9
        'terceiro'  # but points to this lineno 10 (__str__ only, __eq__ is OK)
    )


print(list(raise_generator()))
```

The traceback printed is

```
Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cylc-flow/cylc/flow/tests/Z.py", line 14, in <module>
    print(list(raise_generator()))
  File "/home/kinow/Development/python/workspace/cylc-flow/cylc/flow/tests/Z.py", line 10, in raise_generator
    'terceiro'  # but points to this lineno 10 (__str__ only, __eq__ is OK)
  File "/home/kinow/Development/python/workspace/cylc-flow/cylc/flow/tests/Z.py", line 3, in __str__
    raise ValueError('Z error')
ValueError: Z error
```

The issue appears to be how Python is tracking the line numbers when you have a string with values appended. If you call `undefined(...).__str()__` or `str(undefined(...))`, instead of simply calling `"... %s " % (undefined(...))` then the traceback uses the correct line number.

If you change the code above to use call `__str__()` or `str(undefined(...))` as in this PR, then the right line is reported in the traceback.

Reported a [bug for Python devs](https://bugs.python.org/issue37647) to confirm if that behaviour was intentional, as I would expect it to pick the correct line number.

But in the meantime, this small change looks harmless, and fixes this %+ year old - and very annoying for us at least - issue.

And thanks for Jinja2 :tada: 

This closes #276 

Cheers
Bruno

