### PR TITLE
Fix bug with when using Markup on ChainableUndefined

### DIFF
--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -753,9 +753,9 @@ def make_logging_undefined(logger=None, base=None):
 # is not overwritten from Undefined in this class.
 # This would cause a recursion error in Python 2.
 class ChainableUndefined(Undefined):
-    """An undefined that is chainable, where both
-    __getattr__ and __getitem__ return itself rather than
-    raising an :exc:`UndefinedError`:
+    """An undefined that is chainable, where both ``__getattr__`` and
+    ``__getitem__`` return itself rather than raising an
+    :exc:`UndefinedError`.
 
     >>> foo = ChainableUndefined(name='foo')
     >>> str(foo.bar['baz'])
@@ -765,9 +765,12 @@ class ChainableUndefined(Undefined):
       ...
     jinja2.exceptions.UndefinedError: 'foo' is undefined
 
-    .. versionadded:: 2.11
+    .. versionadded:: 2.11.0
     """
     __slots__ = ()
+
+    def __html__(self):
+        return self.__str__()
 
     def __getattr__(self, _):
         return self

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -543,3 +543,8 @@ class TestBug(object):
             {%- for value in values recursive %}1{% else %}0{% endfor -%}
         ''')
         assert tmpl.render(values=[]) == '0'
+
+    def test_markup_and_chainable_undefined(self):
+        from jinja2 import Markup
+        from jinja2.runtime import ChainableUndefined
+        assert str(Markup(ChainableUndefined())) == ''


### PR DESCRIPTION
## Issue

Wrapping a `ChainableUndefined` object with Markup causes an `UndefinedError` because Markup thinks that `ChainableUndefined` has an attribute called `__html__` and tries to call it.

This has a couple of knock-on effects; for instance, if you have an environment with `undefined=ChainableUndefined` and `autoescape=True`, you are no longer able to use short conditional expressions, i.e.:

```
# this test will fail because .render raises UndefinedError
def test_short_conditional_with_chainable_undefined_and_autoescape():
    env = Environment(undefined=ChainableUndefined, autoescape=True)
    t = env.from_string("<{{ 1 if false }}>")
    assert t.render() == "<>"
```

## Suggested fix

This pull request fixes this by defining a method `__html__` that calls `ChainableUndefined.__str__`. We also add a regression test.