### PR TITLE
Fix TracebackFrameProxy.set_next() on Python 3.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Fix Python 3.7 deprecation warnings.
 -   Using ``range`` in the sandboxed environment uses ``xrange`` on
     Python 2 to avoid memory use. :issue:`933`
+-   Use Python 3.7's better traceback support to avoid a core dump when
+    using debug builds of Python 3.7. :issue:`1050`
 
 
 Version 2.10.1

--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -365,8 +365,14 @@ def _init_ugly_crap():
 # proxies.
 tb_set_next = None
 if tproxy is None:
-    try:
-        tb_set_next = _init_ugly_crap()
-    except:
-        pass
-    del _init_ugly_crap
+    # traceback.tb_next can be modified since CPython 3.7
+    if sys.version_info >= (3, 7):
+        def tb_set_next(tb, next):
+            tb.tb_next = next
+    else:
+        # On Python 3.6 and older, use ctypes
+        try:
+            tb_set_next = _init_ugly_crap()
+        except Exception:
+            pass
+del _init_ugly_crap


### PR DESCRIPTION
Fix issue #1050: fix a crash in TracebackFrameProxy.set_next() on
Python 3.7 and newer, when Python is build in debug mode.

Since Python 3.7, traceback.tb_next field can be modified: ctypes is
no longer needed.