### PR TITLE
Fix incorrect release date for 2.10.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 Version 2.10.3
 --------------
 
-Released 2019-10-24
+Released 2019-10-04
 
 -   Fix a typo in Babel entry point in ``setup.py`` that was preventing
     installation.


### PR DESCRIPTION
2.10.3 is already released on PyPI, so I guess the date in the changelog is a typo.