### PR TITLE
explain what autoescaping does

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -132,7 +132,7 @@ extraction tools in case you are not using Babel's.
 
 What's the big difference between standard and newstyle gettext calls?  In
 general they are less to type and less error prone.  Also if they are used
-in an autoescaping environment they better support automatic escaping.
+in an :ref:`autescaping` environment they better support automatic escaping.
 Here are some common differences between old and new calls:
 
 standard gettext:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -95,7 +95,7 @@ means that you will less likely have an XSS problem it also causes a huge
 amount of extra processing in the template engine which can cause serious
 performance problems.  As Python doesn't provide a way to mark strings as
 unsafe Jinja has to hack around that limitation by providing a custom
-string class (the :class:`Markup` string) that safely interacts with safe
+string class (the :class:`~markupsafe.Markup` string) that safely interacts with safe
 and unsafe strings.
 
 With explicit escaping however the template engine doesn't have to perform

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -391,7 +391,7 @@ this template, it first locates the parent.  The extends tag should be the
 first tag in the template.  Everything before it is printed out normally and
 may cause confusion.  For details about this behavior and how to take
 advantage of it, see :ref:`null-master-fallback`. Also a block will always be
-filled in regardless of whether the surrounding condition is evaluated to be true 
+filled in regardless of whether the surrounding condition is evaluated to be true
 or false.
 
 The filename of the template depends on the template loader.  For example, the
@@ -527,7 +527,7 @@ When automatic escaping is enabled, everything is escaped by default except
 for values explicitly marked as safe.  Variables and expressions
 can be marked as safe either in:
 
-a. the context dictionary by the application with `MarkupSafe.Markup`, or
+a. the context dictionary by the application with :class:`markupsafe.Markup`, or
 b. the template, with the `|safe` filter
 
 The main problem with this approach is that Python itself doesn't have the
@@ -543,7 +543,7 @@ data that is marked as safe.
 
 String literals in templates with automatic escaping are considered unsafe
 because native Python strings (``str``, ``unicode``, ``basestring``) are not
-`MarkupSafe.Markup` strings with an ``__html__`` attribute.
+:class:`markupsafe.Markup` strings with an ``__html__`` attribute.
 
 .. _list-of-control-structures:
 
@@ -1672,8 +1672,8 @@ Autoescape Overrides
 
 .. versionadded:: 2.4
 
-If you want you can activate and deactivate the autoescaping from within
-the templates.
+If you want you can activate and deactivate :ref:`autoescaping` from within
+a template.
 
 Example::
 
@@ -1685,7 +1685,7 @@ Example::
         Autoescaping is inactive within this block
     {% endautoescape %}
 
-After an `endautoescape` the behavior is reverted to what it was before.
+After an ``endautoescape`` the behavior is reverted to what it was before.
 
 .. admonition:: Extension
 

--- a/jinja2/__init__.py
+++ b/jinja2/__init__.py
@@ -53,9 +53,10 @@ from jinja2.exceptions import TemplateError, UndefinedError, \
 # decorators and public utilities
 from jinja2.filters import environmentfilter, contextfilter, \
      evalcontextfilter
-from jinja2.utils import Markup, escape, clear_caches, \
+from jinja2.utils import clear_caches, \
      environmentfunction, evalcontextfunction, contextfunction, \
      is_undefined, select_autoescape
+from markupsafe import Markup, escape
 
 __all__ = [
     'Environment', 'Template', 'BaseLoader', 'FileSystemLoader',

--- a/jinja2/asyncsupport.py
+++ b/jinja2/asyncsupport.py
@@ -14,7 +14,9 @@ import asyncio
 import inspect
 from functools import update_wrapper
 
-from jinja2.utils import concat, internalcode, Markup
+from markupsafe import Markup
+
+from jinja2.utils import concat, internalcode
 from jinja2.environment import TemplateModule
 from jinja2.runtime import LoopContextBase, _last_iteration
 

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -9,20 +9,21 @@
     :license: BSD, see LICENSE for more details.
 """
 from itertools import chain
-from copy import deepcopy
-from keyword import iskeyword as is_python_keyword
 from functools import update_wrapper
+from keyword import iskeyword as is_python_keyword
+
+from markupsafe import Markup, escape
+
 from jinja2 import nodes
 from jinja2.nodes import EvalContext
 from jinja2.visitor import NodeVisitor
 from jinja2.optimizer import Optimizer
 from jinja2.exceptions import TemplateAssertionError
-from jinja2.utils import Markup, concat, escape
+from jinja2.utils import concat
 from jinja2._compat import range_type, text_type, string_types, \
      iteritems, NativeStringIO, imap, izip
 from jinja2.idtracking import Symbols, VAR_LOAD_PARAMETER, \
      VAR_LOAD_RESOLVE, VAR_LOAD_ALIAS, VAR_LOAD_UNDEFINED
-
 
 operators = {
     'eq':       '==',

--- a/jinja2/environment.py
+++ b/jinja2/environment.py
@@ -12,6 +12,9 @@ import os
 import sys
 import weakref
 from functools import reduce, partial
+
+from markupsafe import Markup
+
 from jinja2 import nodes
 from jinja2.defaults import BLOCK_START_STRING, \
      BLOCK_END_STRING, VARIABLE_START_STRING, VARIABLE_END_STRING, \
@@ -26,7 +29,7 @@ from jinja2.compiler import generate, CodeGenerator
 from jinja2.runtime import Undefined, new_context, Context
 from jinja2.exceptions import TemplateSyntaxError, TemplateNotFound, \
      TemplatesNotFound, TemplateRuntimeError
-from jinja2.utils import import_string, LRUCache, Markup, missing, \
+from jinja2.utils import import_string, LRUCache, missing, \
      concat, consume, internalcode, have_async_gen
 from jinja2._compat import imap, ifilter, string_types, iteritems, \
      text_type, reraise, implements_iterator, implements_to_string, \
@@ -189,15 +192,14 @@ class Environment(object):
             ``None`` implicitly into an empty string here.
 
         `autoescape`
-            If set to ``True`` the XML/HTML autoescaping feature is enabled by
-            default.  For more details about autoescaping see
-            :class:`~jinja2.utils.Markup`.  As of Jinja 2.4 this can also
-            be a callable that is passed the template name and has to
-            return ``True`` or ``False`` depending on autoescape should be
-            enabled by default.
+            If set to ``True`` the HTML/XML autoescaping feature is
+            enabled by default. For more details about autoescaping see
+            :ref:`autoescaping`. This can also be a callable that is
+            passed the template name and returns whether autoescaping
+            should be enabled.
 
             .. versionchanged:: 2.4
-               `autoescape` can now be a function
+                Can be a function.
 
         `loader`
             The template loader for this environment.

--- a/jinja2/ext.py
+++ b/jinja2/ext.py
@@ -12,6 +12,8 @@
 """
 import re
 
+from markupsafe import Markup
+
 from jinja2 import nodes
 from jinja2.defaults import BLOCK_START_STRING, \
      BLOCK_END_STRING, VARIABLE_START_STRING, VARIABLE_END_STRING, \
@@ -21,7 +23,7 @@ from jinja2.defaults import BLOCK_START_STRING, \
 from jinja2.environment import Environment
 from jinja2.runtime import concat
 from jinja2.exceptions import TemplateAssertionError, TemplateSyntaxError
-from jinja2.utils import contextfunction, import_string, Markup
+from jinja2.utils import contextfunction, import_string
 from jinja2._compat import with_metaclass, string_types, iteritems
 
 

--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -12,14 +12,16 @@ import re
 import math
 import random
 import warnings
-
 from itertools import groupby, chain
 from collections import namedtuple
-from jinja2.utils import Markup, escape, pformat, urlize, soft_unicode, \
+
+from markupsafe import Markup, escape, soft_unicode
+
+from jinja2.utils import pformat, urlize, \
      unicode_urlencode, htmlsafe_json_dumps
 from jinja2.runtime import Undefined
 from jinja2.exceptions import FilterArgumentError
-from jinja2._compat import imap, string_types, text_type, iteritems, PY2
+from jinja2._compat import imap, string_types, text_type, iteritems
 
 
 _word_re = re.compile(r'\w+', re.UNICODE)

--- a/jinja2/nativetypes.py
+++ b/jinja2/nativetypes.py
@@ -1,11 +1,14 @@
 import sys
 from ast import literal_eval
+
+from markupsafe import escape
+
 from itertools import islice, chain
 from jinja2 import nodes
 from jinja2._compat import text_type
 from jinja2.compiler import CodeGenerator, has_safe_repr
 from jinja2.environment import Environment, Template
-from jinja2.utils import concat, escape
+from jinja2.utils import concat
 
 
 def native_concat(nodes):

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -15,8 +15,9 @@
 import types
 import operator
 
+from markupsafe import Markup
+
 from collections import deque
-from jinja2.utils import Markup
 from jinja2._compat import izip, with_metaclass, text_type, PY2
 
 

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -13,8 +13,10 @@ import sys
 from itertools import chain
 from types import MethodType
 
+from markupsafe import Markup, escape, soft_unicode
+
 from jinja2.nodes import EvalContext, _context_function_types
-from jinja2.utils import Markup, soft_unicode, escape, missing, concat, \
+from jinja2.utils import missing, concat, \
      internalcode, object_type_repr, evalcontextfunction, Namespace
 from jinja2.exceptions import UndefinedError, TemplateRuntimeError, \
      TemplateNotFound

--- a/jinja2/sandbox.py
+++ b/jinja2/sandbox.py
@@ -14,13 +14,13 @@
 """
 import types
 import operator
+from string import Formatter
+
+from markupsafe import Markup, EscapeFormatter
+
 from jinja2.environment import Environment
 from jinja2.exceptions import SecurityError
 from jinja2._compat import string_types, PY2, abc, range_type
-from jinja2.utils import Markup
-
-from markupsafe import EscapeFormatter
-from string import Formatter
 
 
 #: maximum number of items a range may produce

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -1,6 +1,8 @@
 import pytest
+
+from markupsafe import Markup
+
 from jinja2 import Environment
-from jinja2.utils import Markup
 
 
 async def make_aiter(iter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -10,7 +10,10 @@
 """
 import random
 import pytest
-from jinja2 import Markup, Environment
+
+from markupsafe import Markup
+
+from jinja2 import Environment
 from jinja2._compat import text_type, implements_to_string
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -10,10 +10,12 @@
 """
 import pytest
 
+from markupsafe import Markup
+
 from jinja2 import Environment
 from jinja2.sandbox import SandboxedEnvironment, \
      ImmutableSandboxedEnvironment, unsafe
-from jinja2 import Markup, escape
+from jinja2 import escape
 from jinja2.exceptions import SecurityError, TemplateSyntaxError, \
      TemplateRuntimeError
 from jinja2.nodes import EvalContext

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -10,7 +10,9 @@
 """
 import pytest
 
-from jinja2 import Markup, Environment
+from markupsafe import Markup
+
+from jinja2 import Environment
 
 
 @pytest.mark.test_tests


### PR DESCRIPTION
closes #1067 

Also cleans up all references to `Markup` and `escape` to point to MarkupSafe instead of Jinja.