### PR TITLE
Pytest cleanup

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -336,20 +336,12 @@ class TestUndefined(object):
         pytest.raises(UndefinedError, t.render, var=0)
 
     def test_none_gives_proper_error(self):
-        try:
+        with pytest.raises(UndefinedError, match= "'None' has no attribute 'split'"):
             Environment().getattr(None, 'split')()
-        except UndefinedError as e:
-            assert e.message == "'None' has no attribute 'split'"
-        else:
-            assert False, 'expected exception'
 
     def test_object_repr(self):
-        try:
+        with pytest.raises(UndefinedError, match="'int object' has no attribute 'upper'"):
             Undefined(obj=42, name='upper')()
-        except UndefinedError as e:
-            assert e.message == "'int object' has no attribute 'upper'"
-        else:
-            assert False, 'expected exception'
 
 
 @pytest.mark.api

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -191,13 +191,11 @@ class TestAsyncIncludes(object):
 
         t = test_env_async.from_string('{% include ["missing", "missing2"] %}')
         pytest.raises(TemplateNotFound, t.render)
-        try:
+        with pytest.raises(TemplatesNotFound) as e:
             t.render()
-        except TemplatesNotFound as e:
-            assert e.templates == ['missing', 'missing2']
-            assert e.name == 'missing2'
-        else:
-            assert False, 'thou shalt raise'
+
+        assert e.value.templates == ['missing', 'missing2']
+        assert e.value.name == 'missing2'
 
         def test_includes(t, **ctx):
             ctx['foo'] = 42

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -119,13 +119,11 @@ class TestIncludes(object):
 
         t = test_env.from_string('{% include ["missing", "missing2"] %}')
         pytest.raises(TemplateNotFound, t.render)
-        try:
+        with pytest.raises(TemplatesNotFound) as e:
             t.render()
-        except TemplatesNotFound as e:
-            assert e.templates == ['missing', 'missing2']
-            assert e.name == 'missing2'
-        else:
-            assert False, 'thou shalt raise'
+
+        assert e.value.templates == ['missing', 'missing2']
+        assert e.value.name == 'missing2'
 
         def test_includes(t, **ctx):
             ctx['foo'] = 42

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -242,7 +242,5 @@ class TestBugFix(object):
         """Ensures that a template with more than 1 {% extends ... %} usage
         raises a ``TemplateError``.
         """
-        try:
+        with pytest.raises(TemplateError):
             tmpl = env.get_template('doublee')
-        except Exception as e:
-            assert isinstance(e, TemplateError)

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -11,7 +11,7 @@
 import pytest
 
 from jinja2 import Environment, DictLoader, TemplateError
-
+from jinja2 import TemplateRuntimeError
 
 LAYOUTTEMPLATE = '''\
 |{% block block1 %}block 1 from layout{% endblock %}
@@ -242,5 +242,5 @@ class TestBugFix(object):
         """Ensures that a template with more than 1 {% extends ... %} usage
         raises a ``TemplateError``.
         """
-        with pytest.raises(TemplateError):
-            tmpl = env.get_template('doublee')
+        with pytest.raises(TemplateRuntimeError, match="extended multiple times"):
+            env.get_template('doublee').render()

--- a/tests/test_lexnparse.py
+++ b/tests/test_lexnparse.py
@@ -251,12 +251,8 @@ and bar comment #}
 
     def test_error_messages(self, env):
         def assert_error(code, expected):
-            try:
+            with pytest.raises(TemplateSyntaxError, match=expected):
                 Template(code)
-            except TemplateSyntaxError as e:
-                assert str(e) == expected, 'unexpected error message'
-            else:
-                assert False, 'that was supposed to be an error'
 
         assert_error('{% for item in seq %}...{% endif %}',
                      "Encountered unknown tag 'endif'. Jinja was looking "

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -257,12 +257,10 @@ class TestBug(object):
         env = Environment(loader=PrefixLoader({
             'foo':  DictLoader({})
         }))
-        try:
+        with pytest.raises(TemplateNotFound) as e:
             env.get_template('foo/bar.html')
-        except TemplateNotFound as e:
-            assert e.name == 'foo/bar.html'
-        else:
-            assert False, 'expected error here'
+
+        assert e.value.name == 'foo/bar.html'
 
     def test_contextfunction_callable_classes(self, env):
         from jinja2.utils import contextfunction


### PR DESCRIPTION
- Replace `try...catch` statements with `pytest.raises`
  * This was not done for the one in `test_debug` because it relies on the global exception handler to parse out the traceback