### PR TITLE
don't finalize TemplateData nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv-*/
 .coverage.*
 htmlcov
 .pytest_cache/
+/.vscode/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Unreleased
     :issue:`755`, :pr:`938`
 -   Add new ``boolean``, ``false``, ``true``, ``integer`` and ``float``
     tests. :pr:`824`
+-   The environment's ``finalize`` function is only applied to the
+    output of expressions (constant or not), not static template data.
+    :issue:`63`
 
 
 Version 2.10.3


### PR DESCRIPTION
Finalize only applies to the output of expressions (constant or not). `TemplateData` nodes are static content that should not be finalized.

closes #63 
closes #535 

Given the following template:

```
abc
{{ value }}
def
```

A finalize function that always returned the value "replaced" would result in:

```
replaced
replaced
replaced
```

Now it returns:

```
abc
replaced
def
```

This also cleans up the code gen for the `finalize` function and adds tests for `@contextfunction`, `@evalcontextfunction` and `@environmentfunction`.