### PR TITLE
preserve quotes between nodes in native env

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ Unreleased
 -   Support :class:`os.PathLike` objects in
     :class:`~loader.FileSystemLoader` and :class:`~loader.ModuleLoader`.
     :issue:`870`
+-   :class:`~nativetypes.NativeTemplate` correctly handles quotes
+    between expressions. ``"'{{ a }}', '{{ b }}'"`` renders as the tuple
+    ``('1', '2')`` rather than the string ``'1, 2'``. :issue:`1020`
 
 
 Version 2.10.3

--- a/tests/test_nativetypes.py
+++ b/tests/test_nativetypes.py
@@ -109,8 +109,24 @@ class TestNativeEnvironment(object):
         assert not isinstance(result, type)
         assert result in ["<type 'bool'>", "<class 'bool'>"]
 
-    def test_string(self, env):
+    def test_string_literal_var(self, env):
         t = env.from_string("[{{ 'all' }}]")
         result = t.render()
         assert isinstance(result, text_type)
         assert result == "[all]"
+
+    def test_string_top_level(self, env):
+        t = env.from_string("'Jinja'")
+        result = t.render()
+        assert result == 'Jinja'
+
+    def test_tuple_of_variable_strings(self, env):
+        t = env.from_string("'{{ a }}', 'data', '{{ b }}', b'{{ c }}'")
+        result = t.render(a=1, b=2, c="bytes")
+        assert isinstance(result, tuple)
+        assert result == ("1", "data", "2", b"bytes")
+
+    def test_concat_strings_with_quotes(self, env):
+        t = env.from_string("--host='{{ host }}' --user \"{{ user }}\"")
+        result = t.render(host="localhost", user="Jinja")
+        assert result == "--host='localhost' --user \"Jinja\""


### PR DESCRIPTION
closes #1020 

Due to the way the lexer works, `'{{ a }}', '{{ b }}'` would get parsed as the nodes `'`, `{{ a }}`, `', '`, `{{ b }}`, `'`. `native_concat` would get called on the intermediate node `', '`, which parses to a string, which drops the quotes.

Now, if `literal_eval` results in a string, it is re-quoted except for the top-level concat in `Template.render`. The original quote character is preserved. This carries the quotes through to the final call to `literal_eval`, so quotes around expressions are preserved.

cc @jctanner @mkrizek 