### PR TITLE
adds strict argument to FileSystemLoader

### DIFF
--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -180,7 +180,7 @@ class FileSystemLoader(BaseLoader):
         searchpaths = self.searchpath
         if not self.strict and path.isabs(template):
             searchpaths = [ template, ]
-            pieces = (,)
+            pieces = tuple()
         for searchpath in searchpaths:
             filename = path.join(searchpath, *pieces)
             f = open_if_exists(filename)

--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -152,13 +152,15 @@ class FileSystemLoader(BaseLoader):
 
     To follow symbolic links, set the *followlinks* parameter to ``True``::
 
+    To allow absolute template paths in the get_source, set the *strict* paramater to ``True``::
+
     >>> loader = FileSystemLoader('/path/to/templates', followlinks=True)
 
     .. versionchanged:: 2.8
        The ``followlinks`` parameter was added.
     """
 
-    def __init__(self, searchpath, encoding='utf-8', followlinks=False):
+    def __init__(self, searchpath, encoding='utf-8', followlinks=False, strict=True):
         if (
             not isinstance(searchpath, abc.Iterable)
             or isinstance(searchpath, string_types)
@@ -171,10 +173,14 @@ class FileSystemLoader(BaseLoader):
 
         self.encoding = encoding
         self.followlinks = followlinks
+        self.strict = strict
 
     def get_source(self, environment, template):
         pieces = split_template_path(template)
-        for searchpath in self.searchpath:
+        searchpaths = self.searchpath
+        if not self.strict and path.isabs(template):
+            pieces = [ template, ]
+        for searchpath in searchpaths:
             filename = path.join(searchpath, *pieces)
             f = open_if_exists(filename)
             if f is None:

--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -179,7 +179,8 @@ class FileSystemLoader(BaseLoader):
         pieces = split_template_path(template)
         searchpaths = self.searchpath
         if not self.strict and path.isabs(template):
-            pieces = [ template, ]
+            searchpaths = [ template, ]
+            pieces = (,)
         for searchpath in searchpaths:
             filename = path.join(searchpath, *pieces)
             f = open_if_exists(filename)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,14 @@ def filesystem_loader():
 
 
 @pytest.fixture
+def filesystem_loader_nostrict():
+    '''returns FileSystemLoader initialized to res/templates directory, no strict
+    '''
+    here = os.path.dirname(os.path.abspath(__file__))
+    return loaders.FileSystemLoader(here + '/res/templates', strict=False)
+
+
+@pytest.fixture
 def function_loader():
     '''returns a FunctionLoader
     '''

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -49,6 +49,16 @@ class TestLoaders(object):
         e.get_template("foo")
         # This would raise NotADirectoryError if "t2/foo" wasn't skipped.
         e.get_template("foo/test.html")
+        assert len(filesystem_loader.searchpath) == 2
+        fullpath = os.path.join(filesystem_loader.searchpath[1], "foo/test.html")
+        assert os.path.exists(fullpath)
+        if filesystem_loader.strict:
+            pytest.raises(TemplateNotFound, e.get_template, fullpath)
+        else:
+            assert e.get_template(fullpath).render().strip() == 'FOO'
+
+    def test_filesystem_loader_nostrict(self, filesystem_loader_nostrict):
+        self.test_filesystem_loader_overlapping_names(filesystem_loader_nostrict)
 
     def test_choice_loader(self, choice_loader):
         env = Environment(loader=choice_loader)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -50,7 +50,7 @@ class TestLoaders(object):
         # This would raise NotADirectoryError if "t2/foo" wasn't skipped.
         e.get_template("foo/test.html")
         assert len(filesystem_loader.searchpath) == 2
-        fullpath = os.path.join(filesystem_loader.searchpath[1], "foo/test.html")
+        fullpath = os.path.join(filesystem_loader.searchpath[1], "foo", "test.html")
         assert os.path.exists(fullpath)
         if filesystem_loader.strict:
             pytest.raises(TemplateNotFound, e.get_template, fullpath)


### PR DESCRIPTION
This pacth introduce the strict parameter to the FileSystemLoader.

Eg.
```python
>>> import jinja2 as jj, os.path

>>> relpath = 'templates/test.html'
>>> fullpath = os.path.abspath('tests/res/templates/test.html')

>>> fsl = jj.FileSystemLoader(['tests/res', ])
>>> fsl_nostrict = jj.FileSystemLoader(['tests/res', ], strict=False)

>>> jj.Environment(loader=fsl).get_template(relpath).render()
'BAR'

>>> jj.Environment(loader=fsl).get_template(fullpath).render()
raises TemplateNotFound

>>> jj.Environment(loader=fsl_nostrict).get_template(fullpath).render()
'BAR'


