### PR TITLE
LRUCache.copy's queue methods point to the correct queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,8 +55,8 @@ Unreleased
 -   :class:`~nativetypes.NativeTemplate` correctly handles quotes
     between expressions. ``"'{{ a }}', '{{ b }}'"`` renders as the tuple
     ``('1', '2')`` rather than the string ``'1, 2'``. :issue:`1020`
--   ``LRUCache.copy()`` correctly re-initializes the queue methods
-    after copying. :issue:`843`
+-   After calling ``LRUCache.copy()``, the copy's queue methods point to
+    the correct queue. :issue:`843`
 
 
 Version 2.10.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Unreleased
 -   :class:`~nativetypes.NativeTemplate` correctly handles quotes
     between expressions. ``"'{{ a }}', '{{ b }}'"`` renders as the tuple
     ``('1', '2')`` rather than the string ``'1, 2'``. :issue:`1020`
+-   ``LRUCache.copy()`` correctly re-initializes the queue methods
+    after copying. :issue:`843`
 
 
 Version 2.10.3

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -340,8 +340,7 @@ class LRUCache(object):
         """Return a shallow copy of the instance."""
         rv = self.__class__(self.capacity)
         rv._mapping.update(self._mapping)
-        rv._queue = deque(self._queue)
-        rv._postinit()
+        rv._queue.extend(self._queue)
         return rv
 
     def get(self, key, default=None):

--- a/jinja2/utils.py
+++ b/jinja2/utils.py
@@ -341,6 +341,7 @@ class LRUCache(object):
         rv = self.__class__(self.capacity)
         rv._mapping.update(self._mapping)
         rv._queue = deque(self._queue)
+        rv._postinit()
         return rv
 
     def get(self, key, default=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,9 +17,10 @@ import random
 import pytest
 
 from jinja2._compat import string_types, range_type
-from jinja2.utils import LRUCache, escape, object_type_repr, urlize, \
+from jinja2.utils import LRUCache, object_type_repr, urlize, \
      select_autoescape, generate_lorem_ipsum, missing, consume
 from markupsafe import Markup
+
 
 @pytest.mark.utils
 @pytest.mark.lrucache

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@
 """
 
 from collections import deque
-import gc
+from copy import copy as shallow_copy
 import pickle
 import random
 
@@ -67,6 +67,17 @@ class TestLRUCache(object):
             assert copy.capacity == cache.capacity
             assert copy._mapping == cache._mapping
             assert copy._queue == cache._queue
+
+    @pytest.mark.parametrize("copy_func", [LRUCache.copy, shallow_copy])
+    def test_copy(self, copy_func):
+        cache = LRUCache(2)
+        cache['a'] = 1
+        cache['b'] = 2
+        copy = copy_func(cache)
+        assert copy._queue == cache._queue
+        copy['c'] = 3
+        assert copy._queue != cache._queue
+        assert 'a' not in copy and 'b' in copy and 'c' in copy
 
     def test_clear(self):
         d = LRUCache(3)


### PR DESCRIPTION
continues #844 
closes #843 

`LRUCache.copy()` wasn't calling `_postinit`, so the queue methods pointed at the empty initial queue rather than the copied queue. Previous PR fixed this by calling `_postinit` in `copy`. I've modified this to use `queue.extend` instead of creating an extra queue, so `_postinit` isn't required.