### PR TITLE
tox.ini: Add flake8 test for undefined names

### DIFF
--- a/examples/bench.py
+++ b/examples/bench.py
@@ -8,6 +8,11 @@ import cgi
 from timeit import Timer
 from jinja2 import Environment as JinjaEnvironment
 
+try:
+  unicode  # Python 2
+except NameError:
+  unicode = str  # Python 3
+
 context = {
     'page_title': 'mitsuhiko\'s benchmark',
     'table': [dict(a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8,i=9,j=10) for x in range(1000)]

--- a/jinja2/_compat.py
+++ b/jinja2/_compat.py
@@ -16,14 +16,21 @@ PY2 = sys.version_info[0] == 2
 PYPY = hasattr(sys, 'pypy_translation_info')
 _identity = lambda x: x
 
-
-if not PY2:
+try:  # PY2
+    unichr = unichr
+    text_type = unicode
+    range_type = xrange
+    string_types = (str, unicode)
+    integer_types = (int, long)
+except NameError:  # PY3
     unichr = chr
     range_type = range
     text_type = str
     string_types = (str,)
     integer_types = (int,)
 
+
+if not PY2:
     iterkeys = lambda d: iter(d.keys())
     itervalues = lambda d: iter(d.values())
     iteritems = lambda d: iter(d.items())
@@ -47,12 +54,6 @@ if not PY2:
     encode_filename = _identity
 
 else:
-    unichr = unichr
-    text_type = unicode
-    range_type = xrange
-    string_types = (str, unicode)
-    integer_types = (int, long)
-
     iterkeys = lambda d: d.iterkeys()
     itervalues = lambda d: d.itervalues()
     iteritems = lambda d: d.iteritems()
@@ -77,7 +78,7 @@ else:
         return cls
 
     def encode_filename(filename):
-        if isinstance(filename, unicode):
+        if isinstance(filename, unicode):  # noqa: F821
             return filename.encode('utf-8')
         return filename
 

--- a/jinja2/bccache.py
+++ b/jinja2/bccache.py
@@ -34,13 +34,13 @@ if not PY2:
 else:
 
     def marshal_dump(code, f):
-        if isinstance(f, file):
+        if isinstance(f, file):  # noqa: F821
             marshal.dump(code, f)
         else:
             f.write(marshal.dumps(code))
 
     def marshal_load(f):
-        if isinstance(f, file):
+        if isinstance(f, file):  # noqa: F821
             return marshal.load(f)
         return marshal.loads(f.read())
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -28,7 +28,7 @@ def test_ascii_str():
 
     env.policies['compiler.ascii_str'] = False
     t = env.from_string('{{ "foo"|assert }}')
-    t.render(expected_type=unicode)
+    t.render(expected_type=unicode)  # noqa: F821
 
     env.policies['compiler.ascii_str'] = True
     t = env.from_string('{{ "foo"|assert }}')
@@ -37,4 +37,4 @@ def test_ascii_str():
     for val in True, False:
         env.policies['compiler.ascii_str'] = val
         t = env.from_string(u'{{ "\N{SNOWMAN}"|assert }}')
-        t.render(expected_type=unicode)
+        t.render(expected_type=unicode)  # noqa: F821

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,11 @@ skip_missing_interpreters = true
 [testenv]
 deps =
     coverage
+    flake8
     pytest
-commands = coverage run -p -m pytest --tb=short -Werror --basetemp={envtmpdir} {posargs}
+commands =
+    coverage run -p -m pytest --tb=short -Werror --basetemp={envtmpdir} {posargs}
+    flake8 --select=F821 --show-source
 
 [testenv:docs-html]
 deps =


### PR DESCRIPTION
The flake8 F821 test for undefined names is extremely helpful when porting Python 2 code to Python 3 because it flags names like basestring, cmp, execfile, file, long, reload, unicode, xrange that were all removed in Python 3.  Many large codebases like [Node.js and V8](https://travis-ci.com/nodejs/node/jobs/249904779#L221) vendor in Python dependencies such as Jinja instead of pip installing them.  As we try to port these codebases to Python 3, Jinja's undefined names are cluttering their test output.

This PR advocates the use of `try: except NameError:` blocks [as discussed](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) in the Python porting guide.