### PR TITLE
Use print() function in both Python2 and Python 3

### DIFF
--- a/examples/basic/cycle.py
+++ b/examples/basic/cycle.py
@@ -1,13 +1,14 @@
+from __future__ import print_function
 from jinja2 import Environment
 
 
 env = Environment(line_statement_prefix="#", variable_start_string="${", variable_end_string="}")
 
 
-print env.from_string("""\
+print(env.from_string("""\
 <ul>
 # for item in range(10)
     <li class="${loop.cycle('odd', 'even')}">${item}</li>
 # endfor
 </ul>\
-""").render()
+""").render())

--- a/examples/basic/debugger.py
+++ b/examples/basic/debugger.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from jinja2 import Environment
 from jinja2.loaders import FileSystemLoader
 
 env = Environment(loader=FileSystemLoader('templates'))
 
 tmpl = env.get_template('broken.html')
-print tmpl.render(seq=[3, 2, 4, 5, 3, 2, 0, 2, 1])
+print(tmpl.render(seq=[3, 2, 4, 5, 3, 2, 0, 2, 1]))

--- a/examples/basic/inheritance.py
+++ b/examples/basic/inheritance.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from jinja2 import Environment
 from jinja2.loaders import DictLoader
 
@@ -9,4 +10,4 @@ env = Environment(loader=DictLoader({
 }))
 
 
-print env.get_template('c').render()
+print(env.get_template('c').render())

--- a/examples/basic/test.py
+++ b/examples/basic/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from jinja2 import Environment
 from jinja2.loaders import DictLoader
 

--- a/examples/basic/test_filter_and_linestatements.py
+++ b/examples/basic/test_filter_and_linestatements.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from jinja2 import Environment
 
 

--- a/examples/basic/test_loop_filter.py
+++ b/examples/basic/test_loop_filter.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from jinja2 import Environment
 
 tmpl = Environment().from_string("""\

--- a/examples/basic/translate.py
+++ b/examples/basic/translate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from jinja2 import Environment
 
 env = Environment(extensions=['jinja2.ext.i18n'])
@@ -8,7 +9,7 @@ env.globals['ngettext'] = lambda s, p, n: {
     '%(count)s user': '%(count)d Benutzer',
     '%(count)s users': '%(count)d Benutzer'
 }[n == 1 and s or p]
-print env.from_string("""\
+print(env.from_string("""\
 {% trans %}Hello {{ user }}!{% endtrans %}
 {% trans count=users|count %}{{ count }} user{% pluralize %}{{ count }} users{% endtrans %}
-""").render(user="someone", users=[1, 2, 3])
+""").render(user="someone", users=[1, 2, 3]))

--- a/examples/profile.py
+++ b/examples/profile.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 try:
     from cProfile import Profile
 except ImportError:
@@ -42,7 +43,7 @@ jinja_template = JinjaEnvironment(
     variable_start_string="${",
     variable_end_string="}"
 ).from_string(source)
-print jinja_template.environment.compile(source, raw=True)
+print(jinja_template.environment.compile(source, raw=True))
 
 
 p = Profile()

--- a/examples/rwbench/rwbench.py
+++ b/examples/rwbench/rwbench.py
@@ -10,6 +10,7 @@
     :copyright: (c) 2009 by the Jinja Team.
     :license: BSD.
 """
+from __future__ import print_function
 import sys
 from os.path import join, dirname, abspath
 try:
@@ -104,7 +105,7 @@ if __name__ == '__main__':
         sys.stdout.write('\r    %-20s%.4f seconds\n' % (test, t.timeit(number=200) / 200))
 
     if '-p' in sys.argv:
-        print 'Jinja profile'
+        print('Jinja profile')
         p = Profile()
         p.runcall(test_jinja)
         stats = Stats(p)

--- a/ext/django2jinja/django2jinja.py
+++ b/ext/django2jinja/django2jinja.py
@@ -68,6 +68,7 @@
     :copyright: (c) 2009 by the Jinja Team.
     :license: BSD.
 """
+from __future__ import print_function
 import re
 import os
 import sys
@@ -128,7 +129,7 @@ def convert_templates(output_dir, extensions=('.html', '.txt'), writer=None,
 
     if callback is None:
         def callback(template):
-            print template
+            print(template)
 
     for directory in settings.TEMPLATE_DIRS:
         for dirname, _, files in os.walk(directory):
@@ -308,7 +309,7 @@ class Writer(object):
         if node is not None and hasattr(node, 'source'):
             filename, lineno = self.get_location(*node.source)
             message = '[%s:%d] %s' % (filename, lineno, message)
-        print >> self.error_stream, message
+        print(message, file=self.error_stream)
 
     def translate_variable_name(self, var):
         """Performs variable name translation."""

--- a/ext/djangojinja2.py
+++ b/ext/djangojinja2.py
@@ -53,7 +53,7 @@ def get_template(template_name, globals=None):
     """Load a template."""
     try:
         return get_env().get_template(template_name, globals=globals)
-    except TemplateNotFound, e:
+    except TemplateNotFound as e:
         raise TemplateDoesNotExist(str(e))
 
 

--- a/scripts/jinja2-debug.py
+++ b/scripts/jinja2-debug.py
@@ -9,6 +9,7 @@
     :copyright: Copyright 2010 by Armin Ronacher.
     :license: BSD.
 """
+from __future__ import print_function
 import sys
 import jinja2
 from werkzeug import script


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.