### PR TITLE
don't prefetch next item in loop context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,7 @@ Version 2.11.0
 
 Unreleased
 
--   Async support is only loaded the first time an
-    :class:`~environment.Environment` enables it, in order to avoid a
-    slow initial import. :issue:`765`
--   Python 2.6 and 3.3 are not supported anymore.
--   The ``map`` filter in async mode now automatically awaits
+-   Python 2.6, 3.3, and 3.4 are not supported anymore.
 -   Added a new ``ChainableUndefined`` class to support getitem and
     getattr on an undefined object. :issue:`977`
 -   Allow ``{%+`` syntax (with NOP behavior) when ``lstrip_blocks`` is
@@ -47,6 +43,18 @@ Unreleased
 -   Fix behavior of ``loop`` control variables such as ``length`` and
     ``revindex0`` when looping over a generator. :issue:`459, 751, 794`,
     :pr:`993`
+-   Async support is only loaded the first time an environment enables
+    it, in order to avoid a slow initial import. :issue:`765`
+-   In async environments, the ``|map`` filter will await the filter
+    call if needed. :pr:`913`
+-   In for loops that access ``loop`` attributes, the iterator is not
+    advanced ahead of the current iteration unless ``length``,
+    ``revindex``, ``nextitem``, or ``last`` are accessed. This makes it
+    less likely to break ``groupby`` results. :issue:`555`, :pr:`1101`
+-   In async environments, the ``loop`` attributes ``length`` and
+    ``revindex`` work for async iterators. :pr:`1101`
+-   In async environments, values from attribute/property access will
+    be awaited if needed. :pr:`1101`
 -   ``PackageLoader`` doesn't depend on setuptools or pkg_resources.
     :issue:`970`
 -   Support :class:`os.PathLike` objects in

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -705,7 +705,7 @@ class CodeGenerator(NodeVisitor):
 
         if self.environment.is_async:
             self.writeline('from jinja2.asyncsupport import auto_await, '
-                           'auto_aiter, make_async_loop_context')
+                           'auto_aiter, AsyncLoopContext')
 
         # if we want a deferred initialization we cannot move the
         # environment into a local name
@@ -1095,7 +1095,7 @@ class CodeGenerator(NodeVisitor):
         self.visit(node.target, loop_frame)
         if extended_loop:
             if self.environment.is_async:
-                self.write(', %s in await make_async_loop_context(' % loop_ref)
+                self.write(', %s in AsyncLoopContext(' % loop_ref)
             else:
                 self.write(', %s in LoopContext(' % loop_ref)
         else:

--- a/jinja2/compiler.py
+++ b/jinja2/compiler.py
@@ -1551,9 +1551,15 @@ class CodeGenerator(NodeVisitor):
 
     @optimizeconst
     def visit_Getattr(self, node, frame):
+        if self.environment.is_async:
+            self.write("await auto_await(")
+
         self.write('environment.getattr(')
         self.visit(node.node, frame)
         self.write(', %r)' % node.attr)
+
+        if self.environment.is_async:
+            self.write(")")
 
     @optimizeconst
     def visit_Getitem(self, node, frame):
@@ -1564,11 +1570,17 @@ class CodeGenerator(NodeVisitor):
             self.visit(node.arg, frame)
             self.write(']')
         else:
+            if self.environment.is_async:
+                self.write("await auto_await(")
+
             self.write('environment.getitem(')
             self.visit(node.node, frame)
             self.write(', ')
             self.visit(node.arg, frame)
             self.write(')')
+
+            if self.environment.is_async:
+                self.write(")")
 
     def visit_Slice(self, node, frame):
         if node.start is not None:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -2,6 +2,7 @@ import pytest
 import asyncio
 
 from jinja2 import Template, Environment, DictLoader
+from jinja2.asyncsupport import auto_aiter
 from jinja2.exceptions import TemplateNotFound, TemplatesNotFound, \
      UndefinedError
 
@@ -274,26 +275,17 @@ class TestAsyncForLoop(object):
         tmpl = test_env_async.from_string('<{% for item in seq %}{% else %}{% endfor %}>')
         assert tmpl.render() == '<>'
 
-    def test_context_vars(self, test_env_async):
-        slist = [42, 24]
-        for seq in [slist, iter(slist), reversed(slist), (_ for _ in slist)]:
-            tmpl = test_env_async.from_string('''{% for item in seq -%}
-            {{ loop.index }}|{{ loop.index0 }}|{{ loop.revindex }}|{{
-                loop.revindex0 }}|{{ loop.first }}|{{ loop.last }}|{{
-               loop.length }}###{% endfor %}''')
-            one, two, _ = tmpl.render(seq=seq).split('###')
-            (one_index, one_index0, one_revindex, one_revindex0, one_first,
-             one_last, one_length) = one.split('|')
-            (two_index, two_index0, two_revindex, two_revindex0, two_first,
-             two_last, two_length) = two.split('|')
-
-            assert int(one_index) == 1 and int(two_index) == 2
-            assert int(one_index0) == 0 and int(two_index0) == 1
-            assert int(one_revindex) == 2 and int(two_revindex) == 1
-            assert int(one_revindex0) == 1 and int(two_revindex0) == 0
-            assert one_first == 'True' and two_first == 'False'
-            assert one_last == 'False' and two_last == 'True'
-            assert one_length == two_length == '2'
+    @pytest.mark.parametrize(
+        "transform", [lambda x: x, iter, reversed, lambda x: (i for i in x), auto_aiter]
+    )
+    def test_context_vars(self, test_env_async, transform):
+        t = test_env_async.from_string(
+            "{% for item in seq %}{{ loop.index }}|{{ loop.index0 }}"
+            "|{{ loop.revindex }}|{{ loop.revindex0 }}|{{ loop.first }}"
+            "|{{ loop.last }}|{{ loop.length }}\n{% endfor %}"
+        )
+        out = t.render(seq=transform([42, 24]))
+        assert out == "1|0|2|1|True|False|2\n2|1|1|0|False|True|2\n"
 
     def test_cycling(self, test_env_async):
         tmpl = test_env_async.from_string('''{% for item in seq %}{{

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,3 +1,5 @@
+import itertools
+
 from jinja2 import Template
 from jinja2.runtime import LoopContext
 
@@ -46,3 +48,13 @@ def test_loopcontext2():
     in_lst = [10, 11]
     l = LoopContext(reversed(in_lst), None)
     assert l.length == len(in_lst)
+
+
+def test_iterator_not_advanced_early():
+    t = Template("{% for _, g in gs %}{{ loop.index }} {{ g|list }}\n{% endfor %}")
+    out = t.render(gs=itertools.groupby(
+        [(1, "a"), (1, "b"), (2, "c"), (3, "d")], lambda x: x[0]
+    ))
+    # groupby groups depend on the current position of the iterator. If
+    # it was advanced early, the lists would appear empty.
+    assert out == "1 [(1, 'a'), (1, 'b')]\n2 [(2, 'c')]\n3 [(3, 'd')]\n"


### PR DESCRIPTION
fixes #555 

Previously, `LoopContext` prefetched the next item in the iterable, the internal iterator was advanced one further than the index. This caused issues with `groupby` or other iterators where items depend on the state of the iterator.

Now, the iterator will only advance early for the `length`, `revindex`, `last` and `nextitem` properties, using any other properties in the loop will not mess up `groupby`.

Unfortunately, this couldn't carry over to `AsyncLoopContext` directly. To look ahead in async, you need to `await it.__anext__()` rather than `next(it)`. To `await`, you need to be in `async def`, but only `__anext__` is async, not the properties, and we're not prefetching during iteration anymore. So this reimplements some properties to be async. This has the extra effect of making `length`, `revindex`, and `revindex0` work for async iterables (they raised a `TypeError` before). The compiler must add `await auto_await()` around attribute access for these properties to resolve, previously it was only added for calls.

I feel like this implementation is cleaner overall, but I'm not sure of the implications for async performance.