### PR TITLE
Use 'callable' instead of typechecking for runtime calls ctx/env injection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,8 @@ Unreleased
     lines. :issue:`175`
 -   Add ``break_on_hyphens`` parameter to ``|wordwrap`` filter.
     :issue:`550`
+-   Use :func:`callable` to inject context at runtime for compatibility
+    with Cython compiled functions. :pr:`1108`
 
 
 Version 2.10.3

--- a/jinja2/nodes.py
+++ b/jinja2/nodes.py
@@ -20,10 +20,6 @@ from jinja2.utils import Markup
 from jinja2._compat import izip, with_metaclass, text_type, PY2
 
 
-#: the types we support for context functions
-_context_function_types = (types.FunctionType, types.MethodType)
-
-
 _binop_to_func = {
     '*':        operator.mul,
     '/':        operator.truediv,

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -13,7 +13,7 @@ import sys
 from itertools import chain
 from types import MethodType
 
-from jinja2.nodes import EvalContext, _context_function_types
+from jinja2.nodes import EvalContext
 from jinja2.utils import Markup, soft_unicode, escape, missing, concat, \
      internalcode, object_type_repr, evalcontextfunction, Namespace
 from jinja2.exceptions import UndefinedError, TemplateRuntimeError, \
@@ -251,7 +251,7 @@ class Context(with_metaclass(ContextMeta)):
                     __obj = fn
                     break
 
-        if isinstance(__obj, _context_function_types):
+        if callable(__obj):
             if getattr(__obj, 'contextfunction', 0):
                 args = (__self,) + args
             elif getattr(__obj, 'evalcontextfunction', 0):


### PR DESCRIPTION
When jinja2 is used from Cython-compiled code, Functions and Methods are not  `types.FunctionType` or `types.MethodType` anymore. Instead they are `cython_function_or_method`. The framework does not recognize decorated functions/methods and doesn't inject the needed parameters before the call execution.

Using `callable` is backward compatible with existing implementation and also compatible with Cython-compiled code. 
