### PR TITLE
refactor visit_Output

### DIFF
--- a/jinja2/nativetypes.py
+++ b/jinja2/nativetypes.py
@@ -6,7 +6,6 @@ from jinja2 import nodes
 from jinja2._compat import text_type
 from jinja2.compiler import CodeGenerator, has_safe_repr
 from jinja2.environment import Environment, Template
-from jinja2.utils import concat, escape
 
 
 def native_concat(nodes, preserve_quotes=True):
@@ -49,167 +48,36 @@ def native_concat(nodes, preserve_quotes=True):
 
 
 class NativeCodeGenerator(CodeGenerator):
-    """A code generator which avoids injecting ``to_string()`` calls around the
-    internal code Jinja uses to render templates.
+    """A code generator which renders Python types by not adding
+    ``to_string()`` around output nodes, and using :func:`native_concat`
+    to convert complex strings back to Python types if possible.
     """
 
-    def visit_Output(self, node, frame):
-        """Same as :meth:`CodeGenerator.visit_Output`, but do not call
-        ``to_string`` on output nodes in generated code.
-        """
-        if self.has_known_extends and frame.require_output_check:
-            return
+    @staticmethod
+    def _default_finalize(value):
+        return value
 
-        finalize = self.environment.finalize
-        finalize_context = getattr(finalize, 'contextfunction', False)
-        finalize_eval = getattr(finalize, 'evalcontextfunction', False)
-        finalize_env = getattr(finalize, 'environmentfunction', False)
+    def _output_const_repr(self, group):
+        return repr(native_concat(group))
 
-        if finalize is not None:
-            if finalize_context or finalize_eval:
-                const_finalize = None
-            elif finalize_env:
-                def const_finalize(x):
-                    return finalize(self.environment, x)
-            else:
-                const_finalize = finalize
-        else:
-            def const_finalize(x):
-                return x
+    def _output_child_to_const(self, node, frame, finalize):
+        const = node.as_const(frame.eval_ctx)
 
-        # If we are inside a frame that requires output checking, we do so.
-        outdent_later = False
+        if not has_safe_repr(const):
+            raise nodes.Impossible()
 
-        if frame.require_output_check:
-            self.writeline('if parent_template is None:')
-            self.indent()
-            outdent_later = True
+        if isinstance(node, nodes.TemplateData):
+            return const
 
-        # Try to evaluate as many chunks as possible into a static string at
-        # compile time.
-        body = []
+        return finalize.const(const)
 
-        for child in node.nodes:
-            try:
-                if const_finalize is None:
-                    raise nodes.Impossible()
+    def _output_child_pre(self, node, frame, finalize):
+        if finalize.src is not None:
+            self.write(finalize.src)
 
-                const = child.as_const(frame.eval_ctx)
-                if not has_safe_repr(const):
-                    raise nodes.Impossible()
-            except nodes.Impossible:
-                body.append(child)
-                continue
-
-            # the frame can't be volatile here, because otherwise the as_const
-            # function would raise an Impossible exception at that point
-            try:
-                if frame.eval_ctx.autoescape:
-                    if hasattr(const, '__html__'):
-                        const = const.__html__()
-                    else:
-                        const = escape(const)
-
-                const = const_finalize(const)
-            except Exception:
-                # if something goes wrong here we evaluate the node at runtime
-                # for easier debugging
-                body.append(child)
-                continue
-
-            if body and isinstance(body[-1], list):
-                body[-1].append(const)
-            else:
-                body.append([const])
-
-        # if we have less than 3 nodes or a buffer we yield or extend/append
-        if len(body) < 3 or frame.buffer is not None:
-            if frame.buffer is not None:
-                # for one item we append, for more we extend
-                if len(body) == 1:
-                    self.writeline('%s.append(' % frame.buffer)
-                else:
-                    self.writeline('%s.extend((' % frame.buffer)
-
-                self.indent()
-
-            for item in body:
-                if isinstance(item, list):
-                    val = repr(native_concat(item))
-
-                    if frame.buffer is None:
-                        self.writeline('yield ' + val)
-                    else:
-                        self.writeline(val + ',')
-                else:
-                    if frame.buffer is None:
-                        self.writeline('yield ', item)
-                    else:
-                        self.newline(item)
-
-                    close = 0
-
-                    if finalize is not None:
-                        self.write('environment.finalize(')
-
-                        if finalize_context:
-                            self.write('context, ')
-
-                        close += 1
-
-                    self.visit(item, frame)
-
-                    if close > 0:
-                        self.write(')' * close)
-
-                    if frame.buffer is not None:
-                        self.write(',')
-
-            if frame.buffer is not None:
-                # close the open parentheses
-                self.outdent()
-                self.writeline(len(body) == 1 and ')' or '))')
-
-        # otherwise we create a format string as this is faster in that case
-        else:
-            format = []
-            arguments = []
-
-            for item in body:
-                if isinstance(item, list):
-                    format.append(native_concat(item).replace('%', '%%'))
-                else:
-                    format.append('%s')
-                    arguments.append(item)
-
-            self.writeline('yield ')
-            self.write(repr(concat(format)) + ' % (')
-            self.indent()
-
-            for argument in arguments:
-                self.newline(argument)
-                close = 0
-
-                if finalize is not None:
-                    self.write('environment.finalize(')
-
-                    if finalize_context:
-                        self.write('context, ')
-                    elif finalize_eval:
-                        self.write('context.eval_ctx, ')
-                    elif finalize_env:
-                        self.write('environment, ')
-
-                    close += 1
-
-                self.visit(argument, frame)
-                self.write(')' * close + ', ')
-
-            self.outdent()
-            self.writeline(')')
-
-        if outdent_later:
-            self.outdent()
+    def _output_child_post(self, node, frame, finalize):
+        if finalize.src is not None:
+            self.write(")")
 
 
 class NativeEnvironment(Environment):

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -505,7 +505,6 @@ class LoopContext:
     def __iter__(self):
         return self
 
-    @internalcode
     def __next__(self):
         if self._after is not missing:
             rv = self._after
@@ -518,6 +517,7 @@ class LoopContext:
         self._current = rv
         return rv, self
 
+    @internalcode
     def __call__(self, iterable):
         """When iterating over nested data, render the body of the loop
         recursively with the given inner iterable data.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@
 import os
 import tempfile
 import shutil
+from io import StringIO
 
 import pytest
 from jinja2 import Environment, Undefined, ChainableUndefined, \
@@ -206,25 +207,24 @@ class TestMeta(object):
 @pytest.mark.api
 @pytest.mark.streaming
 class TestStreaming(object):
-
     def test_basic_streaming(self, env):
-        tmpl = env.from_string("<ul>{% for item in seq %}<li>{{ loop.index "
-                               "}} - {{ item }}</li>{%- endfor %}</ul>")
-        stream = tmpl.stream(seq=list(range(4)))
-        assert next(stream) == '<ul>'
-        assert next(stream) == '<li>1 - 0</li>'
-        assert next(stream) == '<li>2 - 1</li>'
-        assert next(stream) == '<li>3 - 2</li>'
-        assert next(stream) == '<li>4 - 3</li>'
-        assert next(stream) == '</ul>'
+        t = env.from_string(
+            "<ul>{% for item in seq %}<li>{{ loop.index }} - {{ item }}</li>"
+            "{%- endfor %}</ul>"
+        )
+        stream = t.stream(seq=list(range(3)))
+        assert next(stream) == "<ul>"
+        assert "".join(stream) == "<li>1 - 0</li><li>2 - 1</li><li>3 - 2</li></ul>"
 
     def test_buffered_streaming(self, env):
-        tmpl = env.from_string("<ul>{% for item in seq %}<li>{{ loop.index "
-                               "}} - {{ item }}</li>{%- endfor %}</ul>")
-        stream = tmpl.stream(seq=list(range(4)))
+        tmpl = env.from_string(
+            "<ul>{% for item in seq %}<li>{{ loop.index }} - {{ item }}</li>"
+            "{%- endfor %}</ul>"
+        )
+        stream = tmpl.stream(seq=list(range(3)))
         stream.enable_buffering(size=3)
-        assert next(stream) == u'<ul><li>1 - 0</li><li>2 - 1</li>'
-        assert next(stream) == u'<li>3 - 2</li><li>4 - 3</li></ul>'
+        assert next(stream) == u'<ul><li>1'
+        assert next(stream) == u' - 0</li>'
 
     def test_streaming_behavior(self, env):
         tmpl = env.from_string("")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -102,13 +102,12 @@ def test_async_iteration_in_templates():
 
 
 def test_async_iteration_in_templates_extended():
-    t = Template('{% for x in rng %}{{ loop.index0 }}/{{ x }}{% endfor %}',
-                 enable_async=True)
-    async def async_iterator():
-        for item in [1, 2, 3]:
-            yield item
-    rv = list(t.generate(rng=async_iterator()))
-    assert rv == ['0/1', '1/2', '2/3']
+    t = Template(
+        "{% for x in rng %}{{ loop.index0 }}/{{ x }}{% endfor %}", enable_async=True
+    )
+    stream = t.generate(rng=auto_aiter(range(1, 4)))
+    assert next(stream) == "0"
+    assert "".join(stream) == "/11/22/3"
 
 
 @pytest.fixture


### PR DESCRIPTION
This originally started after I realized that since `NativeCodeGenerator.visist_Output()` is mostly a copy of the code from `compiler.py`, the changes made in #1080 weren't applied to it. To mitigate that in the future, I extracted the differences between them into some internal methods, so `NativeCodeGenerator` only needs to override those instead of the entire `visit_Output` method.

This made me realize that we were doing the same processing to generate the `finalize()` function for every output node, even though it's the same for all of them. Now the compile time function and runtime source are generated once and cached.

Finally, `visit_Output` had two code paths for rendering the source: if there were < 3 nodes, each node would be yielded directly, otherwise a format string was generated to collect all the nodes and yield one big value. The two code paths were almost identical, which made keeping them in sync difficult. I experimented with removing the format string path, and it made the benchmarks in the examples folder about 30% faster. (Admittedly they were already very fast, but the results were consistent across machines).

This also fixes #276, since there are no multi-line format strings anymore. It also helps #408, although since the lexer still combines template data across line breaks some lines still don't have coverage mapping.