### PR TITLE
apply optimizer to all Expr nodes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,6 +88,8 @@ Unreleased
 -   Add a ``DerivedContextReference`` node that can be used by
     extensions to get the current context and local variables such as
     ``loop``. :issue:`860`
+-   Constant folding during compilation is applied to some node types
+    that were previously overlooked. :issue:`733`
 
 
 Version 2.10.3


### PR DESCRIPTION
fixes #733 

Rather than assigning each node visitor manually, `generic_visit` checks if the node is any `Expr` and tries to optimize it, so `Optimizer` doesn't have to be kept in sync with `CodeGenerator`. There were some other nodes (`Pair` and `Keyword`) that had `as_const` but broke other things if they were folded, so this is limited to `Expr`, which seems to be the original intent anyway.