### PR TITLE
TemplateSyntaxError from included template has source

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ Unreleased
     ``loop``. :issue:`860`
 -   Constant folding during compilation is applied to some node types
     that were previously overlooked. :issue:`733`
+-   ``TemplateSyntaxError.source`` is not empty when raised from an
+    included template. :issue:`457`
 
 
 Version 2.10.3

--- a/jinja2/debug.py
+++ b/jinja2/debug.py
@@ -21,14 +21,10 @@ def rewrite_traceback_stack(source=None):
     :return: A :meth:`sys.exc_info` tuple that can be re-raised.
     """
     exc_type, exc_value, tb = sys.exc_info()
-    # The new stack of traceback objects, to be joined together by
-    # tb_set_next later.
-    stack = []
 
-    if isinstance(exc_value, TemplateSyntaxError):
-        exc_value.source = source
-        # The exception doesn't need to output location info manually.
+    if isinstance(exc_value, TemplateSyntaxError) and not exc_value.translated:
         exc_value.translated = True
+        exc_value.source = source
 
         try:
             # Remove the old traceback on Python 3, otherwise the frames
@@ -45,6 +41,8 @@ def rewrite_traceback_stack(source=None):
     else:
         # Skip the frame for the render function.
         tb = tb.tb_next
+
+    stack = []
 
     # Build the stack of traceback object, replacing any in template
     # code with the source file and line information.


### PR DESCRIPTION
fixes #457 

Rendering the included template caught, processed, and re-raised the `TemplateSyntaxError`, which was then caught and processed again in the top-level render call. Now prevent such tracebacks from being faked a second time.

This also fixes an issue introduced by #1110 that omitted the other template frames and only showed the template with the syntax error.