### PR TITLE
PackageLoader understands namespace packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,8 +55,10 @@ Unreleased
     ``revindex`` work for async iterators. :pr:`1101`
 -   In async environments, values from attribute/property access will
     be awaited if needed. :pr:`1101`
--   ``PackageLoader`` doesn't depend on setuptools or pkg_resources.
-    :issue:`970`
+-   :class:`~loader.PackageLoader` doesn't depend on setuptools or
+    pkg_resources. :issue:`970`
+-   ``PackageLoader`` has limited support for :pep:`420` namespace
+    packages. :issue:`1097`
 -   Support :class:`os.PathLike` objects in
     :class:`~loader.FileSystemLoader` and :class:`~loader.ModuleLoader`.
     :issue:`870`


### PR DESCRIPTION
fixes #1097 

Adds limited support for PEP 420 namespace packages. The template directory is assumed to be provided to by the first contributor encountered in the namespace package's path, and Zip files are not supported.

The loader now tries to import the package, so users will get an `ImportError` if it's misconfigured.