### PR TITLE
handle Undefined in get/select_template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,7 +94,11 @@ Unreleased
     that were previously overlooked. :issue:`733`
 -   ``TemplateSyntaxError.source`` is not empty when raised from an
     included template. :issue:`457`
-
+-   Passing an ``Undefined`` value to ``get_template`` (such as through
+    ``extends``, ``import``, or ``include``), raises an
+    ``UndefinedError`` consistently. ``select_template`` will show the
+    undefined message in the list of attempts rather than the empty
+    string. :issue:`1037`
 
 Version 2.10.3
 --------------

--- a/jinja2/runtime.py
+++ b/jinja2/runtime.py
@@ -668,27 +668,34 @@ class Undefined(object):
         self._undefined_name = name
         self._undefined_exception = exc
 
+    @property
+    def _undefined_message(self):
+        """Build a message about the undefined value based on how it was
+        accessed.
+        """
+        if self._undefined_hint:
+            return self._undefined_hint
+
+        if self._undefined_obj is missing:
+            return '%r is undefined' % self._undefined_name
+
+        if not isinstance(self._undefined_name, string_types):
+            return '%s has no element %r' % (
+                object_type_repr(self._undefined_obj),
+                self._undefined_name
+            )
+
+        return '%r has no attribute %r' % (
+            object_type_repr(self._undefined_obj),
+            self._undefined_name
+        )
+
     @internalcode
     def _fail_with_undefined_error(self, *args, **kwargs):
-        """Regular callback function for undefined objects that raises an
-        `UndefinedError` on call.
+        """Raise an :exc:`UndefinedError` when operations are performed
+        on the undefined value.
         """
-        if self._undefined_hint is None:
-            if self._undefined_obj is missing:
-                hint = '%r is undefined' % self._undefined_name
-            elif not isinstance(self._undefined_name, string_types):
-                hint = '%s has no element %r' % (
-                    object_type_repr(self._undefined_obj),
-                    self._undefined_name
-                )
-            else:
-                hint = '%r has no attribute %r' % (
-                    object_type_repr(self._undefined_obj),
-                    self._undefined_name
-                )
-        else:
-            hint = self._undefined_hint
-        raise self._undefined_exception(hint)
+        raise self._undefined_exception(self._undefined_message)
 
     @internalcode
     def __getattr__(self, name):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ import pytest
 from jinja2 import Environment, Undefined, ChainableUndefined, \
      DebugUndefined, StrictUndefined, UndefinedError, meta, \
      is_undefined, Template, DictLoader, make_logging_undefined
+from jinja2 import TemplatesNotFound
 from jinja2.compiler import CodeGenerator
 from jinja2.runtime import Context
 from jinja2.utils import Cycler
@@ -124,6 +125,30 @@ class TestExtendedAPI(object):
         assert env.select_template([t]) is t
         assert env.get_or_select_template([t]) is t
         assert env.get_or_select_template(t) is t
+
+    def test_get_template_undefined(self, env):
+        """Passing Undefined to get/select_template raises an
+        UndefinedError or shows the undefined message in the list.
+        """
+        env.loader=DictLoader({})
+        t = Undefined(name="no_name_1")
+
+        with pytest.raises(UndefinedError):
+            env.get_template(t)
+
+        with pytest.raises(UndefinedError):
+            env.get_or_select_template(t)
+
+        with pytest.raises(UndefinedError):
+            env.select_template(t)
+
+        with pytest.raises(TemplatesNotFound) as exc_info:
+            env.select_template([t, "no_name_2"])
+
+        exc_message = str(exc_info.value)
+        assert "'no_name_1' is undefined" in exc_message
+        assert "no_name_2" in exc_message
+
 
     def test_autoescape_autoselect(self, env):
         def select_autoescape(name):


### PR DESCRIPTION
fixes #1037 

The value passed to `extends`, `import`, or `include` could be a variable, which could be undefined. Some loaders would incidentally trigger the `UndefinedError`, while others such as `DictLoader` would not, producing an unhelpful `TemplateNotFound` message.

Passing `Undefined` to `get_template` raises an `UndefinedError`. If `select_template` raises `TemplatesNotFound`, any undefined values in the list of attempts show as their undefined message rather than the empty string. `get_or_select_template` passes `Undefined` to `get_template`.