### PR TITLE
Fix TemplateSyntaxError pickling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,8 @@ Unreleased
     ``UndefinedError`` consistently. ``select_template`` will show the
     undefined message in the list of attempts rather than the empty
     string. :issue:`1037`
+-   ``TemplateSyntaxError`` can be pickled. :pr:`1117`
+
 
 Version 2.10.3
 --------------

--- a/jinja2/exceptions.py
+++ b/jinja2/exceptions.py
@@ -141,6 +141,13 @@ class TemplateSyntaxError(TemplateError):
 
         return u'\n'.join(lines)
 
+    def __reduce__(self):
+        # https://bugs.python.org/issue1692335 Exceptions that take
+        # multiple required arguments have problems with pickling.
+        # Without this, raises TypeError: __init__() missing 1 required
+        # positional argument: 'lineno'
+        return self.__class__, (self.message, self.lineno, self.name, self.filename)
+
 
 class TemplateAssertionError(TemplateSyntaxError):
     """Like a template syntax error, but covers cases where something in the

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -10,6 +10,7 @@
 """
 import pytest
 
+import pickle
 import re
 import sys
 from traceback import format_exception
@@ -70,6 +71,12 @@ ZeroDivisionError: (int(eger)? )?division (or modulo )?by zero
     raise TemplateSyntaxError\('wtf', 42\)
 (jinja2\.exceptions\.)?TemplateSyntaxError: wtf
   line 42''')
+
+    def test_pickleable_syntax_error(self, fs_env):
+        original = TemplateSyntaxError("bad template", 42, "test", "test.txt")
+        unpickled = pickle.loads(pickle.dumps(original))
+        assert str(original) == str(unpickled)
+        assert original.name == unpickled.name
 
     def test_include_syntax_error_source(self, filesystem_loader):
         e = Environment(loader=ChoiceLoader(


### PR DESCRIPTION
Implement [`__reduce__`](https://docs.python.org/2/library/pickle.html#object.__reduce__) to fix pickling of TemplateSyntaxError

New test output without the fix (Python 3.8):
```
________________________________________ TestDebug.test_pickleable_syntax_error _________________________________________

self = <test_debug.TestDebug object at 0x109740490>, fs_env = <jinja2.environment.Environment object at 0x1097400a0>

    def test_pickleable_syntax_error(self, fs_env):
        exc = TemplateSyntaxError('wtf', 42)
        pickled_exc = pickle.dumps(exc)
>       unpickled_exc = pickle.loads(pickled_exc)
E       TypeError: __init__() missing 1 required positional argument: 'lineno'

test_debug.py:78: TypeError
```