### PR TITLE
Use soft_str in do_wordcount, to trigger undefined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Unreleased
 -   Fix a bug that caused callable objects with ``__getattr__``, like
     :class:`~unittest.mock.Mock` to be treated as a
     :func:`contextfunction`. :issue:`1145`
-
+-   Update ``wordcount`` filter to trigger :class:`Undefined` methods
+    by wrapping the input in :func:`soft_unicode`. :pr:`1160`
 
 
 Version 2.11.1

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -761,7 +761,7 @@ def do_wordwrap(
 
 def do_wordcount(s):
     """Count the words in that string."""
-    return len(_word_re.findall(s))
+    return len(_word_re.findall(soft_unicode(s)))
 
 
 def do_int(value, default=0, base=10):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,6 +6,8 @@ import pytest
 
 from jinja2 import Environment
 from jinja2 import Markup
+from jinja2 import StrictUndefined
+from jinja2 import UndefinedError
 from jinja2._compat import implements_to_string
 from jinja2._compat import text_type
 
@@ -368,6 +370,11 @@ class TestFilter(object):
     def test_wordcount(self, env):
         tmpl = env.from_string('{{ "foo bar baz"|wordcount }}')
         assert tmpl.render() == "3"
+
+        strict_env = Environment(undefined=StrictUndefined)
+        t = strict_env.from_string("{{ s|wordcount }}")
+        with pytest.raises(UndefinedError):
+            t.render()
 
     def test_block(self, env):
         tmpl = env.from_string("{% filter lower|escape %}<HEHE>{% endfilter %}")


### PR DESCRIPTION
Currently the `wordcount` filter doesn't properly fail when passed an undefined variable.

This PR updates `do_wordcount` to utilize `soft_str` so that the `StrictUndefined` methods are invoked.

Before:

```pycon
>>> from jinja2 import Environment, StrictUndefined
>>> e = Environment(undefined=StrictUndefined)
>>> t = e.from_string('{{ undef | wordcount }}')
>>> t.render()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/filters.py", line 764, in do_wordcount
    return len(_word_re.findall(s))
TypeError: expected string or bytes-like object
```

After:
```pycon
>>> from jinja2 import Environment, StrictUndefined
>>> e = Environment(undefined=StrictUndefined)
>>> t = e.from_string('{{ undef | wordcount }}')
>>> t.render()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
  File "/Users/matt/venvs/ansibledev/lib/python3.8/site-packages/jinja2/filters.py", line 764, in do_wordcount
    return len(_word_re.findall(soft_str(s)))
jinja2.exceptions.UndefinedError: 'undef' is undefined
```