### PR TITLE
Add link to template designer documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,9 +5,10 @@ API
     :noindex:
     :synopsis: public Jinja API
 
-This document describes the API to Jinja and not the template language.  It
-will be most useful as reference to those implementing the template interface
-to the application and not those who are creating Jinja templates.
+This document describes the API to Jinja and not the template language
+(for that, see :doc:`/templates`). It will be most useful as reference
+to those implementing the template interface to the application and not
+those who are creating Jinja templates.
 
 Basics
 ------


### PR DESCRIPTION
For those who were actually looking for the template design documentation putting a link directly to it might prevent them to have to google for it. When on the API page, there is no direct way to find the template design documentation. Hope this can help others.