### PR TITLE
better PyObject_HEAD size calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
     :func:`contextfunction`. :issue:`1145`
 -   Update ``wordcount`` filter to trigger :class:`Undefined` methods
     by wrapping the input in :func:`soft_unicode`. :pr:`1160`
+-   Fix a hang when displaying tracebacks on Python 32-bit.
+    :issue:`1162`
 
 
 Version 2.11.1

--- a/src/jinja2/debug.py
+++ b/src/jinja2/debug.py
@@ -245,10 +245,7 @@ else:
     class _CTraceback(ctypes.Structure):
         _fields_ = [
             # Extra PyObject slots when compiled with Py_TRACE_REFS.
-            (
-                "PyObject_HEAD",
-                ctypes.c_byte * (32 if hasattr(sys, "getobjects") else 16),
-            ),
+            ("PyObject_HEAD", ctypes.c_byte * object().__sizeof__()),
             # Only care about tb_next as an object, not a traceback.
             ("tb_next", ctypes.py_object),
         ]


### PR DESCRIPTION
The old way was causing an infinite loop on Python 3.6 32-bit because `PyObject_HEAD` is only 8 bytes on that version, not 32 or 16. Uses a more general way to calculate the size. This was not an issue on Python 3.7+ or PyPy, which don't need `ctypes` to set `tb_next`.

fixes #1162 