### PR TITLE
Don't use setlocal in syntax file

### DIFF
--- a/ext/Vim/jinja.vim
+++ b/ext/Vim/jinja.vim
@@ -82,9 +82,6 @@ syn region jinjaRaw matchgroup=jinjaRawDelim start="{%\s*raw\s*%}" end="{%\s*end
 
 " Jinja comments
 syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,jinjaComment
-" help support folding for some setups
-setlocal commentstring={#%s#}
-setlocal comments=s:{#,e:#}
 
 " Block start keywords.  A bit tricker.  We only highlight at the start of a
 " tag block and only if the name is not followed by a comma or equals sign


### PR DESCRIPTION
I'm not 100% sure that one should not use `setlocal` in a syntax file, but this breaks other filetypes that may include this syntax file, like the vim-markdown plugin if `jinja` is included in its `g:markdown_fenced_languages`.  The `comments` and `commentstring` end up set in the markdown buffer with the jinja settings.

See https://github.com/dhruvasagar/vim-table-mode/issues/162#issuecomment-595317626 for an example of side effects.