### PR TITLE
filters.py: do_indent: allow also tab indentions

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -606,20 +606,24 @@ def do_urlize(
     return rv
 
 
-def do_indent(s, width=4, first=False, blank=False):
+def do_indent(s, width=4, first=False, blank=False, tabs=False):
     """Return a copy of the string with each line indented by 4 spaces. The
     first line and blank lines are not indented by default.
 
     :param width: Number of spaces to indent by.
     :param first: Don't skip indenting the first line.
     :param blank: Don't skip indenting empty lines.
+    :param tabs:  Use tabulator instead of whitespace to indent.
 
     .. versionchanged:: 2.10
         Blank lines are not indented by default.
 
         Rename the ``indentfirst`` argument to ``first``.
     """
-    indention = " " * width
+    if tabs:
+        indention = "\t" * width
+    else:
+        indention = " " * width
     newline = "\n"
 
     if isinstance(s, Markup):


### PR DESCRIPTION
Implemenented also indention with tabulator characters instead of
whitespace characters.

This is needed if this is used within a template with a specified tab indention. ;-)

It would be also thinkable to allow to indent with a generic character. This will follow soon, choose the best and close the other one.

Kind regards
     Lars