### PR TITLE
indent filter can indent with arbitrary characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,8 @@ Unreleased
     or ``@contextfunction``. :issue:`842`, :pr:`1248`
 -   Support ``pgettext`` and ``npgettext`` (message contexts) in i18n
     extension. :issue:`441`
+-   The ``|indent`` filter's ``width`` argument can be a string to
+    indent by. :pr:`1167`
 
 
 Version 2.11.3

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -748,20 +748,29 @@ def do_urlize(
     return rv
 
 
-def do_indent(s: str, width: int = 4, first: bool = False, blank: bool = False) -> str:
+def do_indent(
+    s: str, width: t.Union[int, str] = 4, first: bool = False, blank: bool = False
+) -> str:
     """Return a copy of the string with each line indented by 4 spaces. The
     first line and blank lines are not indented by default.
 
-    :param width: Number of spaces to indent by.
+    :param width: Number of spaces, or a string, to indent by.
     :param first: Don't skip indenting the first line.
     :param blank: Don't skip indenting empty lines.
+
+    .. versionchanged:: 3.0
+        ``width`` can be a string.
 
     .. versionchanged:: 2.10
         Blank lines are not indented by default.
 
         Rename the ``indentfirst`` argument to ``first``.
     """
-    indention = " " * width
+    if isinstance(width, str):
+        indention = width
+    else:
+        indention = " " * width
+
     newline = "\n"
 
     if isinstance(s, Markup):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -185,6 +185,10 @@ class TestFilter:
         """
         self._test_indent_multiline_template(env, markup=True)
 
+    def test_indent_width_string(self, env):
+        t = env.from_string("{{ 'jinja\nflask'|indent(width='>>> ', first=True) }}")
+        assert t.render() == ">>> jinja\n>>> flask"
+
     @pytest.mark.parametrize(
         ("value", "expect"),
         (


### PR DESCRIPTION
Implemenented also indention with tabulator characters instead of
whitespace characters. This will also allow the use of other characters or character sequences. It's the more generic way I already promised in #1166, choose the best and close the other one.

This is needed if this is used within a template with a specified tab indention. ;-)

Kind regards
     Lars