### PR TITLE
Fix tokens line number calculation when whitespace stripping is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Unreleased
     when using Pytest. Due to the difficulty in supporting Python 2 and
     :pep:`451` simultaneously, the changes are reverted until 3.0.
     :pr:`1182`
+-   Fix line numbers in error messages when newlines are stripped.
+    :pr:`1178`
 
 
 Version 2.11.1

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -681,6 +681,7 @@ class Lexer(object):
         source_length = len(source)
         balancing_stack = []
         lstrip_unless_re = self.lstrip_unless_re
+        newlines_stripped = 0
 
         while 1:
             # tokenizer loop
@@ -717,7 +718,9 @@ class Lexer(object):
 
                         if strip_sign == "-":
                             # Strip all whitespace between the text and the tag.
-                            groups = (text.rstrip(),) + groups[1:]
+                            stripped = text.rstrip()
+                            newlines_stripped = text[len(stripped) :].count("\n")
+                            groups = (stripped,) + groups[1:]
                         elif (
                             # Not marked for preserving whitespace.
                             strip_sign != "+"
@@ -758,7 +761,8 @@ class Lexer(object):
                             data = groups[idx]
                             if data or token not in ignore_if_empty:
                                 yield lineno, token, data
-                            lineno += data.count("\n")
+                            lineno += data.count("\n") + newlines_stripped
+                            newlines_stripped = 0
 
                 # strings as token just are yielded as it.
                 else:

--- a/tests/test_lexnparse.py
+++ b/tests/test_lexnparse.py
@@ -178,6 +178,24 @@ class TestLexer(object):
         else:
             pytest.raises(TemplateSyntaxError, env.from_string, t)
 
+    def test_lineno_with_strip(self, env):
+        tokens = env.lex(
+            """\
+<html>
+    <body>
+    {%- block content -%}
+        <hr>
+        {{ item }}
+    {% endblock %}
+    </body>
+</html>"""
+        )
+        for tok in tokens:
+            lineno, token_type, value = tok
+            if token_type == "name" and value == "item":
+                assert lineno == 5
+                break
+
 
 class TestParser(object):
     def test_php_syntax(self, env):


### PR DESCRIPTION
The current version seems to assign wrong line numbers to tokens when whitespace trimming is used. For example this code:

```python
from jinja2 import Environment

if __name__ == '__main__':
    env = Environment()
    tmpl = env.from_string(
"""\
<html>
<body>
{%- block content -%}
    <hr>
    {{ item }}
{% endblock %}
</body>
</html>"""
    )
    print(tmpl.debug_info)
```

prints `[(2, 12), (4, 23)]` when it should be `[(3, 12), (5, 23)]`. In particular, this causes troubles for debuggers (see [here](https://youtrack.jetbrains.com/issue/PY-40968)).

The suggested patch attempts to fix the line number calculation. Please let me know if I have missed something. Thanks in advance!
