### PR TITLE
Allow namespaces to be used in asynchronously rendered templates.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Unreleased
     :pr:`1182`
 -   Fix line numbers in error messages when newlines are stripped.
     :pr:`1178`
+-   The special ``namespace()`` assignment object in templates works in
+    async environments. :issue:`1180`
 
 
 Version 2.11.1

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -697,7 +697,8 @@ class Namespace(object):
         self.__attrs = dict(*args, **kwargs)
 
     def __getattribute__(self, name):
-        if name == "_Namespace__attrs":
+        # __class__ is needed for the awaitable check in async mode
+        if name in {"_Namespace__attrs", "__class__"}:
             return object.__getattribute__(self, name)
         try:
             return self.__attrs[name]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -578,3 +578,14 @@ class TestAsyncForLoop(object):
     def test_awaitable_property_slicing(self, test_env_async):
         t = test_env_async.from_string("{% for x in a.b[:1] %}{{ x }}{% endfor %}")
         assert t.render(a=dict(b=[1, 2, 3])) == "1"
+
+
+def test_namespace_awaitable(test_env_async):
+    async def _test():
+        t = test_env_async.from_string(
+            '{% set ns = namespace(foo="Bar") %}{{ ns.foo }}'
+        )
+        actual = await t.render_async()
+        assert actual == "Bar"
+
+    run(_test())


### PR DESCRIPTION
This fixes https://github.com/pallets/jinja/issues/1180, by allowing `Namespace` instances to undergo the type checks necessary for async compatibility.