### PR TITLE
Fixed a bug that unique filter couldn't handle 'list', 'dict' and 'set' type values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 -   Remove code that was marked deprecated.
 -   Use :pep:`451` API to load templates with
     :class:`~loaders.PackageLoader`. :issue:`1168`
+-   Fix a bug that 'unique' filter couldn't handle
+    'dict', 'list' and 'set' type variable.
 
 
 2.11.2

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -13,6 +13,7 @@ from markupsafe import soft_str
 
 from .exceptions import FilterArgumentError
 from .runtime import Undefined
+from .utils import convert_value_to_be_hashable
 from .utils import htmlsafe_json_dumps
 from .utils import pformat
 from .utils import url_quote
@@ -362,7 +363,7 @@ def do_unique(environment, value, case_sensitive=False, attribute=None):
     seen = set()
 
     for item in value:
-        key = getter(item)
+        key = getter(convert_value_to_be_hashable(item))
 
         if key not in seen:
             seen.add(key)

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -566,6 +566,17 @@ def htmlsafe_json_dumps(obj, dumper=None, **kwargs):
     return Markup(rv)
 
 
+def convert_value_to_be_hashable(value, rec=None):
+    if rec is None:
+        rec = convert_value_to_be_hashable
+    if isinstance(value, list) or isinstance(value, set):
+        return tuple(rec(x, rec) for x in value)
+    if isinstance(value, dict):
+        return HashableDict([(rec(k, rec), rec(v, rec)) for (k, v) in value.items()])
+    else:
+        return value
+
+
 class Cycler:
     """Cycle through values by yield them one at a time, then restarting
     once the end is reached. Available as ``cycler`` in templates.
@@ -656,6 +667,11 @@ class Namespace:
 
     def __repr__(self):
         return f"<Namespace {self.__attrs!r}>"
+
+
+class HashableDict(dict):
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))
 
 
 # does this python version support async for in and async generators?

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -522,8 +522,7 @@ class TestFilter:
             """
         {%- for val in value|unique -%}
           {{ val }}
-        {%- endfor %}
-        """
+        {%- endfor %}"""
         )
         assert t.render(value=value).strip() == expect
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -503,6 +503,31 @@ class TestFilter:
         assert t.render(items=map(Magic, [3, 2, 4, 1, 2])) == "3241"
 
     @pytest.mark.parametrize(
+        "value,expect",
+        (
+            ([1, 2, 3, 1], "123"),
+            (["a", "b", "c", "a"], "abc"),
+            ([(1,), (2,), (3,), (1,)], "(1,)(2,)(3,)"),
+            ([[1], [2], [3], [1]], "[1][2][3]"),
+            ([{1}, {2}, {3}, {1}], "{1}{2}{3}"),
+            ([{"a": 1}, {"b": 2}, {"c": 3}, {"a": 1}], "{'a': 1}{'b': 2}{'c': 3}"),
+            (
+                [None, 1, 0.2, "a", False, (3,), {4}, [5], {"a": 6}],
+                "None10.2aFalse(3,){4}[5]{'a': 6}",
+            ),
+        ),
+    )
+    def test_unique_list_value(self, env, value, expect):
+        t = env.from_string(
+            """
+        {%- for val in value|unique -%}
+          {{ val }}
+        {%- endfor %}
+        """
+        )
+        assert t.render(value=value).strip() == expect
+
+    @pytest.mark.parametrize(
         "source,expect",
         (
             ('{{ ["a", "B"]|min }}', "a"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,7 +200,7 @@ class TestConvertToBeHashable:
         for value in self.TEST_DATA:
             assert isinstance(hash(convert_value_to_be_hashable(value)), int)
 
-    def test_nexted_type_of_data(self):
+    def test_nested_type_of_data(self):
         """
         This tests the convert_value_to_be_hashable method could convert
         a value that list and dict are nested.


### PR DESCRIPTION
This fixes a problem of #1187.

After applying this patch, I confirmed that unique filter would work as expected as below.
<img width="468" alt="スクリーンショット 2020-04-11 18 33 09" src="https://user-images.githubusercontent.com/469934/79040371-ec18c500-7c22-11ea-857d-ef704f19746a.png">
