### PR TITLE
Improve and extend urlize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ Unreleased
     some point, but not necessarily by the direct child. :issue:`1147`
 -   Deprecate the ``autoescape`` and ``with`` extensions, they are
     built-in to the compiler. :issue:`1203`
+-   The ``urlize`` filter recognizes ``mailto:`` links and takes
+    ``extra_schemes`` (or ``env.policies["urlize.extra_schemes"]``) to
+    recognize other schemes such as ``ftp://`` or ``tel:``. It ignores
+    parentheses around URLs. The URL parsing in general has been
+    updated. URLs without a scheme are linked as ``https://`` instead of
+    ``http://``. :issue:`522, 827, 1172`, :pr:`1195`
 
 
 Version 2.11.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,10 +25,11 @@ Unreleased
     built-in to the compiler. :issue:`1203`
 -   The ``urlize`` filter recognizes ``mailto:`` links and takes
     ``extra_schemes`` (or ``env.policies["urlize.extra_schemes"]``) to
-    recognize other schemes such as ``ftp://`` or ``tel:``. It ignores
-    parentheses around URLs. The URL parsing in general has been
-    updated. URLs without a scheme are linked as ``https://`` instead of
-    ``http://``. :issue:`522, 827, 1172`, :pr:`1195`
+    recognize other schemes. It tries to balance parentheses within a
+    URL instead of ignoring trailing characters. The parsing in general
+    has been updated to be more efficient and match more cases. URLs
+    without a scheme are linked as ``https://`` instead of ``http://``.
+    :issue:`522, 827, 1172`, :pr:`1195`
 
 
 Version 2.11.2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -550,9 +550,9 @@ Example::
     The default target that is issued for links from the `urlize` filter
     if no other target is defined by the call explicitly.
 
-``urlize.additional_uri_schemes``:
-    Additional uri scheme prefixes that will generate links from the
-    `urlize` filter in addition to http://, https://, and mailto:.
+``urlize.extra_schemes``:
+    Recognize URLs that start with these schemes in addition to the
+    default ``http://``, ``https://``, and ``mailto:``.
 
 ``json.dumps_function``:
     If this is set to a value other than `None` then the `tojson` filter

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -550,6 +550,10 @@ Example::
     The default target that is issued for links from the `urlize` filter
     if no other target is defined by the call explicitly.
 
+``urlize.additional_uri_schemes``:
+    Additional uri scheme prefixes that will generate links from the
+    `urlize` filter in addition to http://, https://, and mailto:.
+
 ``json.dumps_function``:
     If this is set to a value other than `None` then the `tojson` filter
     will dump with this function instead of the default one.  Note that

--- a/src/jinja2/defaults.py
+++ b/src/jinja2/defaults.py
@@ -35,6 +35,7 @@ DEFAULT_POLICIES = {
     "compiler.ascii_str": True,
     "urlize.rel": "noopener",
     "urlize.target": None,
+    "urlize.extra_uri_schemes": None,
     "truncate.leeway": 5,
     "json.dumps_function": None,
     "json.dumps_kwargs": {"sort_keys": True},

--- a/src/jinja2/defaults.py
+++ b/src/jinja2/defaults.py
@@ -35,7 +35,7 @@ DEFAULT_POLICIES = {
     "compiler.ascii_str": True,
     "urlize.rel": "noopener",
     "urlize.target": None,
-    "urlize.extra_uri_schemes": None,
+    "urlize.extra_schemes": None,
     "truncate.leeway": 5,
     "json.dumps_function": None,
     "json.dumps_kwargs": {"sort_keys": True},

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -373,10 +373,10 @@ class TestFilter:
             "http://www.example.com/</a> bar"
         )
 
-    def test_urlize_extra_uri_schemes_parameter(self, env):
+    def test_urlize_extra_schemes_parameter(self, env):
         tmpl = env.from_string(
             '{{ "foo tel:+1-514-555-1234 ftp://localhost bar"|'
-            'urlize(extra_uri_schemes=["tel:", "ftp:"]) }}'
+            'urlize(extra_schemes=["tel:", "ftp:"]) }}'
         )
         assert tmpl.render() == (
             'foo <a href="tel:+1-514-555-1234" rel="noopener">'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -337,10 +337,22 @@ class TestFilter:
         assert tmpl.render() == "FOO"
 
     def test_urlize(self, env):
+        tmpl = env.from_string('{{ "foo example.org bar"|urlize }}')
+        assert tmpl.render() == (
+            'foo <a href="https://example.org" rel="noopener">' "example.org</a> bar"
+        )
         tmpl = env.from_string('{{ "foo http://www.example.com/ bar"|urlize }}')
         assert tmpl.render() == (
             'foo <a href="http://www.example.com/" rel="noopener">'
             "http://www.example.com/</a> bar"
+        )
+        tmpl = env.from_string('{{ "foo mailto:email@example.com bar"|urlize }}')
+        assert tmpl.render() == (
+            'foo <a href="mailto:email@example.com">email@example.com</a> bar'
+        )
+        tmpl = env.from_string('{{ "foo email@example.com bar"|urlize }}')
+        assert tmpl.render() == (
+            'foo <a href="mailto:email@example.com">email@example.com</a> bar'
         )
 
     def test_urlize_rel_policy(self):
@@ -359,6 +371,17 @@ class TestFilter:
             tmpl.render()
             == 'foo <a href="http://www.example.com/" rel="noopener" target="_blank">'
             "http://www.example.com/</a> bar"
+        )
+
+    def test_urlize_extra_uri_schemes_parameter(self, env):
+        tmpl = env.from_string(
+            '{{ "foo tel:+1-514-555-1234 ftp://localhost bar"|'
+            'urlize(extra_uri_schemes=["tel:", "ftp:"]) }}'
+        )
+        assert tmpl.render() == (
+            'foo <a href="tel:+1-514-555-1234" rel="noopener">'
+            'tel:+1-514-555-1234</a> <a href="ftp://localhost" rel="noopener">'
+            "ftp://localhost</a> bar"
         )
 
     def test_wordcount(self, env):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -109,6 +109,15 @@ class TestBug:
             "http://www.example.org/&lt;foo</a>"
         )
 
+    def test_urlize_filter_closing_punctuation(self, env):
+        tmpl = env.from_string(
+            '{{ "(see http://www.example.org/?page=subj_<desc.h>)"|urlize }}'
+        )
+        assert tmpl.render() == (
+            '(see <a href="http://www.example.org/?page=subj_&lt;desc.h&gt;" '
+            'rel="noopener">http://www.example.org/?page=subj_&lt;desc.h&gt;</a>)'
+        )
+
     def test_loop_call_loop(self, env):
         tmpl = env.from_string(
             """


### PR DESCRIPTION
Fixes #522
Fixes #827 
Fixes #1172

The 'urlize' function does not as expected both in terms of some missing support. Among a few a few of the behaviors were a lack of support for 5/8 of the original TLDs, emails prefixed with `mailto:` would not be returned as links, and no support for `ftp://`.

This PR does not "fix" the latter point, but does add a `policy` that can be set so that the function will create the links.  This can also be used to add support for any arbitrary URI scheme.

Specifically:
- Adds mailto: link support (issue #1172)
- Adds an `extra_uri_schemes` policy and parameter to address lack of `ftp:` support and allow for other schemes (for example `tel:`) to be added as needed. (issue #522 and PR #587)
- Parentheses at the end of a URL are now included if they match an opening parenthesis in the URL (issue #827)
- Adds support for all of the original top-level domains when creating links such as example.org
- Uses the same regex used to validate URLs to ensure that ipv4 and ipv6 `https//` and `https://` links are well-formed.
- Sets the default URI scheme for URLs to be `https` instead of `http`