### PR TITLE
Raise UndefinedError from Undefined.__contains__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ Unreleased
     indent by. :pr:`1167`
 -   The parser understands hex, octal, and binary integer literals.
     :issue:`1170`
+-   ``Undefined.__contains__`` (``in``) raises an ``UndefinedError``
+    instead of a ``TypeError``. :issue:`1198`
 
 
 Version 2.11.3

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -755,7 +755,7 @@ class Undefined:
     __floordiv__ = __rfloordiv__ = _fail_with_undefined_error
     __mod__ = __rmod__ = _fail_with_undefined_error
     __pos__ = __neg__ = _fail_with_undefined_error
-    __call__ = __getitem__ = _fail_with_undefined_error
+    __call__ = __getitem__ = __contains__ = _fail_with_undefined_error
     __lt__ = __le__ = __gt__ = __ge__ = _fail_with_undefined_error
     __int__ = __float__ = __complex__ = _fail_with_undefined_error
     __pow__ = __rpow__ = _fail_with_undefined_error

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -317,6 +317,7 @@ class TestUndefined:
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
         assert env.from_string("{{ not missing }}").render() == "True"
         pytest.raises(UndefinedError, env.from_string("{{ missing - 1}}").render)
+        pytest.raises(UndefinedError, env.from_string("{{ 'foo' in missing }}").render)
         und1 = Undefined(name="x")
         und2 = Undefined(name="y")
         assert und1 == und2


### PR DESCRIPTION
Fixes #1198. I'm assuming this is the desired behavior -- let me know if not!