### PR TITLE
remove docs requirements from dev requirments

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: python
-    directory: /
-    update_schedule: daily
-    ignored_updates:
-      - match:
-          dependency_name: "file:./setup.py"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,4 @@
--e file:.
--r docs.in
+# -r docs.in  # can't include due to Sphinx/Jinja mutual dependency
 -r tests.in
 pip-tools
 pre-commit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,52 +4,28 @@
 #
 #    pip-compile requirements/dev.in
 #
--e file:.                 # via -r requirements/dev.in, sphinx
-alabaster==0.7.12         # via sphinx
 appdirs==1.4.4            # via virtualenv
 attrs==19.3.0             # via pytest
-babel==2.8.0              # via sphinx
-certifi==2020.4.5.1       # via requests
 cfgv==3.1.0               # via pre-commit
-chardet==3.0.4            # via requests
 click==7.1.2              # via pip-tools
 distlib==0.3.0            # via virtualenv
-docutils==0.16            # via sphinx
 filelock==3.0.12          # via tox, virtualenv
 identify==1.4.15          # via pre-commit
-idna==2.9                 # via requests
-imagesize==1.2.0          # via sphinx
 more-itertools==8.3.0     # via pytest
 nodeenv==1.3.5            # via pre-commit
-packaging==20.3           # via pallets-sphinx-themes, pytest, sphinx, tox
-pallets-sphinx-themes==1.2.3  # via -r requirements/docs.in
+packaging==20.3           # via pytest, tox
 pip-tools==5.1.2          # via -r requirements/dev.in
 pluggy==0.13.1            # via pytest, tox
 pre-commit==2.4.0         # via -r requirements/dev.in
 py==1.8.1                 # via pytest, tox
-pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest==5.4.2             # via -r requirements/tests.in
-pytz==2020.1              # via babel
 pyyaml==5.3.1             # via pre-commit
-requests==2.23.0          # via sphinx
 six==1.14.0               # via packaging, pip-tools, tox, virtualenv
-snowballstemmer==2.0.0    # via sphinx
-sphinx-issues==1.2.0      # via -r requirements/docs.in
-sphinx==2.4.4             # via -r requirements/docs.in, pallets-sphinx-themes, sphinx-issues, sphinxcontrib-log-cabinet
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-log-cabinet==1.0.1  # via -r requirements/docs.in
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 toml==0.10.1              # via pre-commit, tox
 tox==3.15.0               # via -r requirements/dev.in
-urllib3==1.25.9           # via requests
 virtualenv==20.0.20       # via pre-commit, tox
 wcwidth==0.1.9            # via pytest
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
-# setuptools


### PR DESCRIPTION
Unfortunately, pinning Sphinx with pip-compile causes Jinja to be pinned as well, which then overwrites the editable install unless it's done afterwards. And adding `-e` in the requirements file causes Dependabot to fail. It doesn't seem like that's going to be solved by pip (pypa/pip#8307), pip-compile (jazzband/pip-tools#1150), or Dependabot (dependabot/feedback#936) any time soon, so for now I'm just going to remove the docs requirements from the dev requirements.

Alternatively could have left them in and required doing `pip install -e .` after `pip install -r requirements/dev.txt`, but I figured just removing it would be less error prone. If users need to build the docs locally, they can do `pip install -r requirements/doc.in` to get the direct dependencies without the sub-dependency pins. Read the Docs will still use the pinned file because it can install local Jinja after.

fixes #1215 