### PR TITLE
Add symbol names for tilde and pipe

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1389,10 +1389,10 @@ two categories:
 ``is``
     Performs a :ref:`test <tests>`.
 
-``|``
+``|`` (pipe, vertical bar)
     Applies a :ref:`filter <filters>`.
 
-``~``
+``~`` (tilde)
     Converts all operands into strings and concatenates them.
 
     ``{{ "Hello " ~ name ~ "!" }}`` would return (assuming `name` is set


### PR DESCRIPTION
Came across the ~ character in an existing template and it was hard to find the help docs via a web search. Adding tilde and pipe may make the help docs easier to find. 