### PR TITLE
Add required attribute to blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
 -   Fix UndefinedError incorrectly being thrown on an undefined variable
     instead of ``Undefined`` being returned on
     ``NativeEnvironment`` on Python 3.10. :issue:`1335`
+-   Add ``required`` attribute to blocks that must be overridden at some
+    point, but not necessarily by the direct child :issue:`1147`
 
 
 Version 2.11.2

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -540,6 +540,40 @@ modifier to a block declaration::
 When overriding a block, the `scoped` modifier does not have to be provided.
 
 
+Required Blocks
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Blocks can be marked as required. They must be overridden at some point,
+but not necessarily by the direct child template. Required blocks can
+only contain whitespace or comments, and they cannot be rendered directly.
+
+For example::
+
+    # parent.tmpl
+    body: {% block body required %}{% endblock %}
+
+    # child.tmpl
+    {% extends "parent.tmpl" %}
+
+    # grandchild.tmpl
+    {% extends "child.tmpl" %}
+    {% block body %}Hi from grandchild.{% endblock %}
+
+
+Rendering ``child.tmpl`` will give
+``TemplateRuntimeError``
+
+Rendering ``grandchild.tmpl`` will give
+``Hi from grandchild.``
+
+When combined with ``scoped``, the ``required`` modifier must be placed `after`
+the scoped modifier.  Here are some valid examples::
+
+    {% block body scoped %}{% endblock %}
+    {% block body required %}{% endblock %}
+    {% block body scoped required %}{% endblock %}
+
+
 Template Objects
 ~~~~~~~~~~~~~~~~
 

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -797,6 +797,15 @@ class CodeGenerator(NodeVisitor):
         else:
             context = self.get_context_ref()
 
+        if node.required:
+            self.writeline(f"if len(context.blocks[{node.name!r}]) <= 1:", node)
+            self.indent()
+            self.writeline(
+                f'raise TemplateRuntimeError("Required block {node.name!r} not found")',
+                node,
+            )
+            self.outdent()
+
         if not self.environment.is_async and frame.buffer is None:
             self.writeline(
                 f"yield from context.blocks[{node.name!r}][0]({context})", node

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -340,9 +340,13 @@ class With(Stmt):
 
 
 class Block(Stmt):
-    """A node that represents a block."""
+    """A node that represents a block.
 
-    fields = ("name", "body", "scoped")
+    .. versionchanged:: 3.0.0
+        the `required` field was added.
+    """
+
+    fields = ("name", "body", "scoped", "required")
 
 
 class Include(Stmt):

--- a/tests/test_idtracking.py
+++ b/tests/test_idtracking.py
@@ -38,7 +38,7 @@ def test_basics():
 
 def test_complex():
     title_block = nodes.Block(
-        "title", [nodes.Output([nodes.TemplateData("Page Title")])], False
+        "title", [nodes.Output([nodes.TemplateData("Page Title")])], False, False
     )
 
     render_title_macro = nodes.Macro(
@@ -136,6 +136,7 @@ def test_complex():
             for_loop,
             nodes.Output([nodes.TemplateData("\n  </ul>\n")]),
         ],
+        False,
         False,
     )
 


### PR DESCRIPTION
Resolves #1147 

Summary:
 - Added required field to blocks
   - Block nodes now have 4 fields (`scoped` must come before `required` if used together)
   - Must be overridden at some point, although not necessarily by the direct child. `TemplateRuntimeError` raised otherwise.
   - Required block itself cannot contain anything other than comments or whitespace. `TemplateSyntaxError` raised otherwise.
   - With current implementation, rendering the template containing the required block will also raise a `TemplateRuntimeError`.
 
Test:
- Added tests to `test_inheritance.py`
  - Tested up to three levels, made sure correct errors are raised, tested that scoped still works in conjunction with required
- Patched `test_idtracking.py` to include the new field when instantiating Block nodes

Files affected:
- `parser.py`
- `compile.py`
- `nodes.py`
- `test_inheritance.py`
- `test_idtracking.py`