### PR TITLE
Remove sandbox Python < 3.5 compat

### DIFF
--- a/src/jinja2/sandbox.py
+++ b/src/jinja2/sandbox.py
@@ -75,37 +75,6 @@ _mutable_spec = (
 )
 
 
-class _MagicFormatMapping(abc.Mapping):
-    """This class implements a dummy wrapper to fix a bug in the Python
-    standard library for string formatting.
-
-    See https://bugs.python.org/issue13598 for information about why
-    this is necessary.
-    """
-
-    def __init__(self, args, kwargs):
-        self._args = args
-        self._kwargs = kwargs
-        self._last_index = 0
-
-    def __getitem__(self, key):
-        if key == "":
-            idx = self._last_index
-            self._last_index += 1
-            try:
-                return self._args[idx]
-            except LookupError:
-                pass
-            key = str(idx)
-        return self._kwargs[key]
-
-    def __iter__(self):
-        return iter(self._kwargs)
-
-    def __len__(self):
-        return len(self._kwargs)
-
-
 def inspect_format_method(callable):
     if not isinstance(
         callable, (types.MethodType, types.BuiltinMethodType)
@@ -395,7 +364,6 @@ class SandboxedEnvironment(Environment):
             kwargs = args[0]
             args = None
 
-        kwargs = _MagicFormatMapping(args, kwargs)
         rv = formatter.vformat(s, args, kwargs)
         return type(s)(rv)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -146,6 +146,13 @@ class TestStringFormat:
         t = env.from_string('{{ ("a{0.foo}b{1}"|safe).format({"foo": 42}, "<foo>") }}')
         assert t.render() == "a42b&lt;foo&gt;"
 
+    def test_empty_braces_format(self):
+        env = SandboxedEnvironment()
+        t1 = env.from_string('{{ ("a{}b{}").format("foo", "42")}}')
+        t2 = env.from_string('{{ ("a{}b{}"|safe).format(42, "<foo>") }}')
+        assert t1.render() == "afoob42"
+        assert t2.render() == "a42b&lt;foo&gt;"
+
 
 class TestStringFormatMap:
     def test_basic_format_safety(self):


### PR DESCRIPTION
Summary:
- Removed `sandbox._MagicFormatMapping` as `string.Formatter` now supports empty braces. 
- Tested with both `SandboxedFormatter` and `SandboxedEscapeFormatter` 

Files affected:
- `sandbox.py`
- `test_security.py`

Resolves #1197 