### PR TITLE
Allow +%} to ignore trim_blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Unreleased
     :class:`~loaders.PackageLoader`. :issue:`1168`
 -   Fix a bug that caused imported macros to not have access to the
     current template's globals. :issue:`688`
-
+-   Add ability to ignore ``trim_blocks`` using ``+%}``. :issue:`1036`
 
 Version 2.11.2
 --------------

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -230,6 +230,15 @@ plus sign (``+``) at the start of a block::
             {%+ if something %}yay{% endif %}
     </div>
 
+Similarly, you can manually disable the ``trim_blocks`` behavior by
+putting a plus sign (``+``) at the end of a block::
+
+    <div>
+        {% if something +%}
+            yay
+        {% endif %}
+    </div>
+
 You can also strip whitespace in templates by hand.  If you add a minus
 sign (``-``) to the start or end of a block (e.g. a :ref:`for-loop` tag), a
 comment, or a variable expression, the whitespaces before or after

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -509,8 +509,8 @@ class Lexer:
             TOKEN_COMMENT_BEGIN: [
                 (
                     c(
-                        fr"(.*?)((?:\-{comment_end_re}\s*"
-                        fr"|{comment_end_re}){block_suffix_re})"
+                        fr"(.*?)((?:\+{comment_end_re}|\-{comment_end_re}\s*"
+                        fr"|{comment_end_re}{block_suffix_re}))"
                     ),
                     (TOKEN_COMMENT, TOKEN_COMMENT_END),
                     "#pop",
@@ -520,7 +520,10 @@ class Lexer:
             # blocks
             TOKEN_BLOCK_BEGIN: [
                 (
-                    c(fr"(?:\-{block_end_re}\s*|{block_end_re}){block_suffix_re}"),
+                    c(
+                        fr"(?:\+{block_end_re}|\-{block_end_re}\s*"
+                        fr"|{block_end_re}{block_suffix_re})"
+                    ),
                     TOKEN_BLOCK_END,
                     "#pop",
                 ),
@@ -540,7 +543,8 @@ class Lexer:
                 (
                     c(
                         fr"(.*?)((?:{block_start_re}(\-|\+|))\s*endraw\s*"
-                        fr"(?:\-{block_end_re}\s*|{block_end_re}{block_suffix_re}))"
+                        fr"(?:\+{block_end_re}|\-{block_end_re}\s*"
+                        fr"|{block_end_re}{block_suffix_re}))"
                     ),
                     OptionalLStrip(TOKEN_DATA, TOKEN_RAW_END),
                     "#pop",


### PR DESCRIPTION
Resolves #1036 

**Summary**:
- When `trim_block` is enabled and a block ends with `+%}` or `+#}`, the behavior will be ignored.
  - Note: does *not* apply to raw start tags (i.e. `{% raw +%}` will raise an error) because they don't process the inner text
  - `+%}` is still allowed when `trim_block` is disabled but exhibits NOP behavior  
  - So following the example from the original issue, when `trim_block` is enabled:
```jinja
{% if something %}X{% endif +%}
more things
```
results in
```jinja
X
more things
```


**Tests**:
- Added tests to `test_lexnparse.py`
  - Specifically added a class for testing trim called `TestTrimBlocks`
  - Tests majority of the same cases as `TrimLstripBlocks`


**Files affected**:
- `lexer.py`
- `test_lexnparse.py`
