### PR TITLE
Fix bug with imported macros and template globals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 -   Remove code that was marked deprecated.
 -   Use :pep:`451` API to load templates with
     :class:`~loaders.PackageLoader`. :issue:`1168`
+-   Fix a bug that caused imported macros to not have access to the
+    current template's globals. :issue:`688`
 
 
 Version 2.11.2

--- a/src/jinja2/asyncsupport.py
+++ b/src/jinja2/asyncsupport.py
@@ -116,10 +116,10 @@ async def get_default_module_async(self):
 
 def wrap_default_module(original_default_module):
     @internalcode
-    def _get_default_module(self):
+    def _get_default_module(self, ctx=None):
         if self.environment.is_async:
             raise RuntimeError("Template module attribute is unavailable in async mode")
-        return original_default_module(self)
+        return original_default_module(self, ctx)
 
     return _get_default_module
 

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -925,7 +925,7 @@ class CodeGenerator(NodeVisitor):
         elif self.environment.is_async:
             self.write("_get_default_module_async()")
         else:
-            self.write("_get_default_module()")
+            self.write("_get_default_module(context)")
         if frame.toplevel and not node.target.startswith("_"):
             self.writeline(f"context.exported_vars.discard({node.target!r})")
 
@@ -944,7 +944,7 @@ class CodeGenerator(NodeVisitor):
         elif self.environment.is_async:
             self.write("_get_default_module_async()")
         else:
-            self.write("_get_default_module()")
+            self.write("_get_default_module(context)")
 
         var_names = []
         discarded_names = []

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -1120,7 +1120,24 @@ class Template:
         )
 
     @internalcode
-    def _get_default_module(self):
+    def _get_default_module(self, ctx=None):
+        """If a context is passed in, this means that the template was
+        imported.  Imported templates have access to the current template's
+        globals by default, but they can only be accessed via the context
+        during runtime.
+
+        If there are new globals, we need to create a new
+        module because the cached module is already rendered and will not have
+        access to globals from the current context.  This new module is not
+        cached as :attr:`_module` because the template can be imported elsewhere,
+        and it should have access to only the current template's globals.
+        """
+        if ctx is not None:
+            globals = {
+                key: ctx.parent[key] for key in ctx.globals_keys - self.globals.keys()
+            }
+            if globals:
+                return self.make_module(globals)
         if self._module is not None:
             return self._module
         self._module = rv = self.make_module()

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -97,7 +97,9 @@ def new_context(
         for key, value in locals.items():
             if value is not missing:
                 parent[key] = value
-    return environment.context_class(environment, parent, template_name, blocks)
+    return environment.context_class(
+        environment, parent, template_name, blocks, globals=globals
+    )
 
 
 class TemplateReference:
@@ -179,13 +181,14 @@ class Context(metaclass=ContextMeta):
     _legacy_resolve_mode = False
     _fast_resolve_mode = False
 
-    def __init__(self, environment, parent, name, blocks):
+    def __init__(self, environment, parent, name, blocks, globals=None):
         self.parent = parent
         self.vars = {}
         self.environment = environment
         self.eval_ctx = EvalContext(self.environment, name)
         self.exported_vars = set()
         self.name = name
+        self.globals_keys = set() if globals is None else set(globals)
 
         # create the initial mapping of blocks.  Whenever template inheritance
         # takes place the runtime will update this mapping with the new blocks

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -102,13 +102,30 @@ class TestImports:
         env = Environment(
             loader=DictLoader(
                 {
-                    "macros": "{% macro testing() %}foo: {{ foo }}{% endmacro %}",
-                    "test": "{% import 'macros' as m %}{{ m.testing() }}",
+                    "macros": "{% macro test() %}foo: {{ foo }}{% endmacro %}",
+                    "test": "{% import 'macros' as m %}{{ m.test() }}",
+                    "test1": "{% import 'macros' as m %}{{ m.test() }}",
                 }
             )
         )
         tmpl = env.get_template("test", globals={"foo": "bar"})
         assert tmpl.render() == "foo: bar"
+
+        tmpl = env.get_template("test1")
+        assert tmpl.render() == "foo: "
+
+    def test_import_with_globals_override(self, test_env):
+        env = Environment(
+            loader=DictLoader(
+                {
+                    "macros": "{% set foo = '42' %}{% macro test() %}"
+                    "foo: {{ foo }}{% endmacro %}",
+                    "test": "{% from 'macros' import test %}{{ test() }}",
+                }
+            )
+        )
+        tmpl = env.get_template("test", globals={"foo": "bar"})
+        assert tmpl.render() == "foo: 42"
 
     def test_from_import_with_globals(self, test_env):
         env = Environment(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -98,6 +98,30 @@ class TestImports:
         with pytest.raises(UndefinedError, match="does not export the requested name"):
             t.render()
 
+    def test_import_with_globals(self, test_env):
+        env = Environment(
+            loader=DictLoader(
+                {
+                    "macros": "{% macro testing() %}foo: {{ foo }}{% endmacro %}",
+                    "test": "{% import 'macros' as m %}{{ m.testing() }}",
+                }
+            )
+        )
+        tmpl = env.get_template("test", globals={"foo": "bar"})
+        assert tmpl.render() == "foo: bar"
+
+    def test_from_import_with_globals(self, test_env):
+        env = Environment(
+            loader=DictLoader(
+                {
+                    "macros": "{% macro testing() %}foo: {{ foo }}{% endmacro %}",
+                    "test": "{% from 'macros' import testing %}{{ testing() }}",
+                }
+            )
+        )
+        tmpl = env.get_template("test", globals={"foo": "bar"})
+        assert tmpl.render() == "foo: bar"
+
 
 class TestIncludes:
     def test_context_include(self, test_env):


### PR DESCRIPTION
Fixes #688 
- Added parameter to `_get_default_module` to take in the current context and make a new module if template globals are found
- Added `self.globals` to the Context class to differentiate between template variables from render variables. 

