### PR TITLE
Fix bug with cached templates not registering new globals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Unreleased
     being accessed in custom context functions. :issue:`768`
 -   Fix a bug that caused scoped blocks from accessing special loop
     variables. :issue:`1088`
+-   Fix a bug that prevented cached templates from registering new globals.
+    :issue:`295`
 
 
 Version 2.11.3

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -811,6 +811,16 @@ class Environment:
             if template is not None and (
                 not self.auto_reload or template.is_up_to_date
             ):
+                # update globals if changed
+                new_globals = globals.items() - template.globals.items()
+                if new_globals:
+                    # it is possible for the template and environment to share
+                    # a globals object, in which case, a new copy should be
+                    # made to avoid affecting other templates
+                    if template.globals is self.globals:
+                        template.globals = dict(template.globals, **globals)
+                    else:
+                        template.globals.update(dict(new_globals))
                 return template
         template = self.loader.load(self, name, globals)
         if self.cache is not None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -716,3 +716,37 @@ End"""
         # values set within a block or loop should not
         # show up outside of it
         assert tmpl.render() == "42\n0\n24\n0\n42\n1\n24\n1\n42"
+
+    def test_cached_extends(self):
+        env = Environment(
+            loader=DictLoader(
+                {"parent": "{{ foo }}", "child": "{% extends 'parent' %}"}
+            )
+        )
+        tmpl = env.get_template("child", globals={"foo": "bar"})
+        assert tmpl.render() == "bar"
+
+        tmpl = env.get_template("parent", globals={"foo": 42})
+        assert tmpl.render() == "42"
+
+        tmpl = env.get_template("child")
+        assert tmpl.render() == "bar"
+
+        tmpl = env.get_template("parent")
+        assert tmpl.render() == "42"
+
+    def test_cached_includes(self):
+        env = Environment(
+            loader=DictLoader({"base": "{{ foo }}", "main": "{% include 'base' %}"})
+        )
+        tmpl = env.get_template("main", globals={"foo": "bar"})
+        assert tmpl.render() == "bar"
+
+        tmpl = env.get_template("base", globals={"foo": 42})
+        assert tmpl.render() == "42"
+
+        tmpl = env.get_template("main")
+        assert tmpl.render() == "bar"
+
+        tmpl = env.get_template("base")
+        assert tmpl.render() == "42"


### PR DESCRIPTION
Fixes #295
Summary:
- Issue affected templates rendered and cached due to `extend` and `include` tags 
  -  Now updates Template object with new globals, if any, when retrieving from cache 

Files affected:
- `environment.py`
- `test_regression.py`