### PR TITLE
allow optional use of a filter based on its existence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Unreleased
 -   Update the template globals when calling
     ``Environment.get_template(globals=...)`` even if the template was
     already loaded. :issue:`295`
+-   Do not raise an error for undefined filters in unexecuted
+    if-statements and conditional expressions. :issue:`842`
 
 
 Version 2.11.3

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -36,6 +36,7 @@ exported = [
     "TemplateNotFound",
     "Namespace",
     "Undefined",
+    "internalcode",
 ]
 
 


### PR DESCRIPTION
Resolves #842 

- Undefined filters nested in if/elif/else statements and conditional expressions will cause an error only if executed during runtime

Files changed:
- `nodes.py`
- `compiler.py`
- `runtime.py`
