### PR TITLE
Provide basic support for sorting list of dictionaries

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -103,6 +103,11 @@ def make_multi_attrgetter(environment, attribute, postprocess=None):
             for part in attribute_part:
                 item_i = environment.getitem(item_i, part)
 
+            try:
+                item_i < item_i
+            except TypeError:
+                item_i = str(item_i)
+
             if postprocess is not None:
                 item_i = postprocess(item_i)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -490,6 +490,24 @@ class TestFilter:
             == "([2],[1])([2],[2])([2],[5])([3],[1])"
         )
 
+    def test_sort9(self, env):
+        tmpl = env.from_string("""{{ items|sort }}""")
+        assert tmpl.render(
+            items=[
+                {"b": 4},
+                {"b": 3},
+                {"b": 2},
+                {"b": 1},
+                {"a": 4},
+                {"a": 3},
+                {"a": 2},
+                {"a": 1},
+            ]
+        ) == (
+            "[{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}, "
+            "{'b': 1}, {'b': 2}, {'b': 3}, {'b': 4}]"
+        )
+
     def test_unique(self, env):
         t = env.from_string('{{ "".join(["b", "A", "a", "b"]|unique) }}')
         assert t.render() == "bA"


### PR DESCRIPTION

This commit adds support for sorting list of dictionaries.

fixes #1283

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
