### PR TITLE
Provide support for grouping iterable with 'None' value in keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 -   Fix a bug that caused imported macros to not have access to the
     current template's globals. :issue:`688`
 -   Add ability to ignore ``trim_blocks`` using ``+%}``. :issue:`1036`
+-   Add ability to group iterables for ``None`` returned as ``key``
 
 Version 2.11.2
 --------------

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -961,10 +961,20 @@ def do_groupby(environment, value, attribute):
     .. versionchanged:: 2.6
         The attribute supports dot notation for nested access.
     """
+
+    class NoneStub:
+        def __lt__(self, other):
+            return True
+
     expr = make_attrgetter(environment, attribute)
+
+    def sortExpr(item):
+        retVal = expr(item)
+        return NoneStub() if retVal is None else retVal
+
     return [
         _GroupTuple(key, list(values))
-        for key, values in groupby(sorted(value, key=expr), expr)
+        for key, values in groupby(sorted(value, key=sortExpr), expr)
     ]
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -528,11 +528,18 @@ class TestFilter:
         {%- for grouper, list in [{'foo': 1, 'bar': 2},
                                   {'foo': 2, 'bar': 3},
                                   {'foo': 1, 'bar': 1},
+                                  {'foo': None, 'bar': 5},
                                   {'foo': 3, 'bar': 4}]|groupby('foo') -%}
             {{ grouper }}{% for x in list %}: {{ x.foo }}, {{ x.bar }}{% endfor %}|
         {%- endfor %}"""
         )
-        assert tmpl.render().split("|") == ["1: 1, 2: 1, 1", "2: 2, 3", "3: 3, 4", ""]
+        assert tmpl.render().split("|") == [
+            "None: None, 5",
+            "1: 1, 2: 1, 1",
+            "2: 2, 3",
+            "3: 3, 4",
+            "",
+        ]
 
     def test_groupby_tuple_index(self, env):
         tmpl = env.from_string(


### PR DESCRIPTION
This commit adds support for such case where ``key`` lambda returns ``None`` for groupby funciton.

- fixes #1287 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
