### PR TITLE
Add __aiter__ to Undefined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Unreleased
     :issue:`1170`
 -   ``Undefined.__contains__`` (``in``) raises an ``UndefinedError``
     instead of a ``TypeError``. :issue:`1198`
+-   ``Undefined`` is iterable in an async environment. :issue:`1294`
 
 
 Version 2.11.3

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -778,6 +778,10 @@ class Undefined:
     def __iter__(self):
         yield from ()
 
+    async def __aiter__(self):
+        for _ in ():
+            yield
+
     def __bool__(self):
         return False
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from jinja2 import ChainableUndefined
 from jinja2 import DictLoader
 from jinja2 import Environment
 from jinja2 import Template
@@ -586,5 +587,18 @@ def test_namespace_awaitable(test_env_async):
         )
         actual = await t.render_async()
         assert actual == "Bar"
+
+    run(_test())
+
+
+def test_chainable_undefined_aiter():
+    async def _test():
+        t = Template(
+            "{% for x in a['b']['c'] %}{{ x }}{% endfor %}",
+            enable_async=True,
+            undefined=ChainableUndefined,
+        )
+        rv = await t.render_async(a={})
+        assert rv == ""
 
     run(_test())


### PR DESCRIPTION
Allows iterating over `ChainableUndefined` when using `render_async`.

Added `__aiter__` method to `Undefined` which `ChainableUndefined` inherits from.

- fixes #1293

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
