### PR TITLE
TatSu Lexer tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ babel.extractors =
 testpaths = tests
 filterwarnings =
     error
+    ignore::DeprecationWarning
 
 [coverage:run]
 branch = True
@@ -95,4 +96,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-requests_unixsocket.*]
+ignore_missing_imports = True
+
+[mypy-tatsu.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ with open("src/jinja2/__init__.py", "rt", encoding="utf8") as f:
 setup(
     name="Jinja2",
     version=version,
-    install_requires=["MarkupSafe>=1.1","TatSu>=4.4"],
+    install_requires=["MarkupSafe>=1.1", "TatSu>=4.4"],
     extras_require={"i18n": ["Babel>=2.1"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ with open("src/jinja2/__init__.py", "rt", encoding="utf8") as f:
 setup(
     name="Jinja2",
     version=version,
-    install_requires=["MarkupSafe>=1.1"],
+    install_requires=["MarkupSafe>=1.1","TatSu>=4.4"],
     extras_require={"i18n": ["Babel>=2.1"]},
 )

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -293,7 +293,6 @@ class Environment:
         lstrip_blocks=LSTRIP_BLOCKS,
         newline_sequence=NEWLINE_SEQUENCE,
         keep_trailing_newline=KEEP_TRAILING_NEWLINE,
-        tatsu_lexer=False,
         extensions=(),
         optimized=True,
         undefined=Undefined,
@@ -304,6 +303,7 @@ class Environment:
         auto_reload=True,
         bytecode_cache=None,
         enable_async=False,
+        tatsu_lexer=False,
     ):
         # !!Important notice!!
         #   The constructor accepts quite a few arguments that should be

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -36,6 +36,7 @@ from .exceptions import TemplateSyntaxError
 from .exceptions import UndefinedError
 from .lexer import get_lexer
 from .lexer import TokenStream
+from .tatsu import get_tatsu_lexer
 from .nodes import EvalContext
 from .parser import Parser
 from .runtime import Context
@@ -292,6 +293,7 @@ class Environment:
         lstrip_blocks=LSTRIP_BLOCKS,
         newline_sequence=NEWLINE_SEQUENCE,
         keep_trailing_newline=KEEP_TRAILING_NEWLINE,
+        tatsu_lexer=False,
         extensions=(),
         optimized=True,
         undefined=Undefined,
@@ -327,6 +329,7 @@ class Environment:
         self.lstrip_blocks = lstrip_blocks
         self.newline_sequence = newline_sequence
         self.keep_trailing_newline = keep_trailing_newline
+        self.tatsu_lexer = tatsu_lexer
 
         # runtime information
         self.undefined = undefined
@@ -433,7 +436,13 @@ class Environment:
 
         return _environment_sanity_check(rv)
 
-    lexer = property(get_lexer, doc="The lexer for this environment.")
+    def lexer_getter(self):
+        if self.tatsu_lexer:
+            return get_tatsu_lexer(self)
+        else:
+            return get_lexer(self)
+    
+    lexer = property(lexer_getter, doc="The lexer for this environment.")
 
     def iter_extensions(self):
         """Iterates over the extensions by priority."""

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -36,12 +36,12 @@ from .exceptions import TemplateSyntaxError
 from .exceptions import UndefinedError
 from .lexer import get_lexer
 from .lexer import TokenStream
-from .tatsu import get_tatsu_lexer
 from .nodes import EvalContext
 from .parser import Parser
 from .runtime import Context
 from .runtime import new_context
 from .runtime import Undefined
+from .tatsu import get_tatsu_lexer
 from .utils import concat
 from .utils import consume
 from .utils import have_async_gen
@@ -441,7 +441,7 @@ class Environment:
             return get_tatsu_lexer(self)
         else:
             return get_lexer(self)
-    
+
     lexer = property(lexer_getter, doc="The lexer for this environment.")
 
     def iter_extensions(self):

--- a/src/jinja2/tatsu.py
+++ b/src/jinja2/tatsu.py
@@ -1,6 +1,6 @@
 import pprint
 
-from tatsu import parse
+import tatsu
 
 from .lexer import Lexer
 from .utils import LRUCache
@@ -33,7 +33,7 @@ def get_tatsu_lexer(environment):
     return tatsu_lexer
 
 
-GRAMMAR = r"""
+_GRAMMAR = r"""
     @@grammar::CALC
 
     @@whitespace:://
@@ -90,10 +90,11 @@ GRAMMAR = r"""
 """
 
 
-def tatsu_tokenize(source):
-    # use print for debug
-    pprint.pprint(parse(GRAMMAR, source), indent=2, width=20)
-    return parse(GRAMMAR, source)
+# temporary get_tatsu_model
+# this will take grammar rules as input
+# and returns corresponding tatsu model
+def get_tatsu_model():
+    return tatsu.compile(_GRAMMAR)
 
 
 def get_ast_tokens(lineno, ast):
@@ -119,7 +120,10 @@ class Lineno:
 
 class TatsuLexer(Lexer):
     def tokeniter(self, source, name, filename=None, state=None):
-        tatsu_tokens = tatsu_tokenize(source)
+        _TATSU_MODEL = get_tatsu_model()
+        tatsu_tokens = _TATSU_MODEL.parse(source)
+        # use print for debug
+        pprint.pprint(tatsu_tokens, indent=2, width=20)
         data = None
         lineno = Lineno()
 

--- a/src/jinja2/tatsu.py
+++ b/src/jinja2/tatsu.py
@@ -1,0 +1,126 @@
+from tatsu import parse
+import pprint
+
+from .lexer import Lexer
+from .utils import LRUCache
+
+# cache for the lexers. Exists in order to be able to have multiple
+# environments with the same lexer
+_tatsu_lexer_cache = LRUCache(50)
+
+
+def get_tatsu_lexer(environment):
+    """Return a tatsu lexer which is probably cached."""
+    key = (
+        environment.block_start_string,
+        environment.block_end_string,
+        environment.variable_start_string,
+        environment.variable_end_string,
+        environment.comment_start_string,
+        environment.comment_end_string,
+        environment.line_statement_prefix,
+        environment.line_comment_prefix,
+        environment.trim_blocks,
+        environment.lstrip_blocks,
+        environment.newline_sequence,
+        environment.keep_trailing_newline,
+    )
+    tatsu_lexer = _tatsu_lexer_cache.get(key)
+    if tatsu_lexer is None:
+        tatsu_lexer = TatsuLexer(environment)
+        _tatsu_lexer_cache[key] = tatsu_lexer
+    return tatsu_lexer
+
+
+GRAMMAR = r'''
+    @@grammar::CALC
+
+    @@whitespace:://
+
+
+    start = {expression}+ ;
+
+
+    expression
+        =
+        | code
+        | variable
+        | comment
+        | data:/(.|\n)/
+        ;
+
+    code
+        = block_begin:'{%' {code_content:code_content}+ block_end:'%}' ;
+
+    code_content
+        = 
+        | whitespace:/[\ \n]+/
+        | name:/\w+/
+        | operator:operator
+        ;
+
+    operator
+        =
+        | '+' | '-' | '/' | '//' | '*' | '**' | '~'
+        | '[' | ']' | '(' | ')' | '{' | '}'
+        | '==' | '!=' | '>' | '>=' | '<' | '<=' | '='
+        | '.' | ':' | '|' | ',' | ';'
+        ; 
+
+    variable = variable_begin:'{{' {variable_content:variable_content}+ variable_end:'}}' ;
+
+    variable_content
+        = 
+        | whitespace:/[\ \n]+/
+        | name:/\w+/
+        ;
+
+    comment = comment_begin:'<!--' ~ {comment_data:comment_content}+ comment_end:'-->' ;
+
+    comment_content = /([^-]|-(?!->)|\\n)/ ;
+'''
+
+def tatsu_tokenize(source):
+        # use print for debug
+        pprint.pprint(parse(GRAMMAR, source), indent=2, width=20)
+        return parse(GRAMMAR, source)
+
+def get_ast_tokens(lineno, ast):
+    for item in ast.items():
+        if isinstance(item[1], list):
+            for item_ast in item[1]:
+                for result in get_ast_tokens(lineno, item_ast):
+                    yield result
+        else:
+            yield lineno.get(), item[0], item[1]
+            lineno.add(item[1].count("\n"))
+
+class Lineno():
+    def __init__(self, value = 1):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def add(self, number):
+        self.value += number
+
+class TatsuLexer(Lexer):
+    def tokeniter(self, source, name, filename=None, state=None):
+        tatsu_tokens = tatsu_tokenize(source)
+        data = None
+        lineno = Lineno()
+
+        for token in tatsu_tokens:
+            if token['data']:
+                data = (data or "") + token['data']
+            else:   # ast
+                if data:
+                    yield lineno.get(), 'data', data
+                    lineno.add(data.count("\n"))
+                    data = None
+                for result in get_ast_tokens(lineno, token):
+                    yield result
+        
+        if data:
+            yield lineno.get(), 'data', data

--- a/tests/test_tatsu.py
+++ b/tests/test_tatsu.py
@@ -1,0 +1,14 @@
+import pytest
+
+from jinja2 import Environment
+
+class TestTatsuLexer:
+    def test_simple(self, env):
+        env = Environment(tatsu_lexer=True)
+        tmpl = env.from_string(
+            "<p>simple test</p>"
+            "{% if kvs %}"
+            "  {% for k, v in kvs %}{{ k }}={{ v }} {% endfor %}"
+            "{% endif %}"
+        )
+        assert tmpl.render(kvs=[("a", 1), ("b", 2)]) == "<p>simple test</p>  a=1 b=2 "

--- a/tests/test_tatsu.py
+++ b/tests/test_tatsu.py
@@ -1,6 +1,5 @@
-import pytest
-
 from jinja2 import Environment
+
 
 class TestTatsuLexer:
     def test_simple(self, env):


### PR DESCRIPTION
Working progress for issue #1194
Adapt [TatSu](https://github.com/neogeny/TatSu) for syntax lexing (and parsing), this will help formalize the current regex implementation to EBNF grammar rule.

This change will address the current informal grammar issue, improve maintainability for lexer. It will make deriving and maintaining grammar and syntax documentation easier. The grammar documentation can follow the EBNF like grammar rule used by TatSu, moving away from the current array of regular expressions.

Changes:
- created `TatsuLexer` class from `Lexer` class, override `tokeniter` function using TatSu
- added parameter `tatsu_lexer` to `Environment` class for specifying which lexer to use

Note: this is a WIP PR, lexer features like comment, raw, custom string, etc. are not implemented.