### PR TITLE
fix AttributeError in property being swallowed

### DIFF
--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -452,9 +452,9 @@ class Environment:
                 else:
                     try:
                         return getattr(obj, attr)
-                    except AttributeError as e:
-                        if isinstance(getattr(type(obj), attr, None), property):
-                            raise e
+                    except AttributeError:
+                        if attr in dir(obj):
+                            raise
             return self.undefined(obj=obj, name=argument)
 
     def getattr(self, obj, attribute):
@@ -463,9 +463,9 @@ class Environment:
         """
         try:
             return getattr(obj, attribute)
-        except AttributeError as e:
-            if isinstance(getattr(type(obj), attribute, None), property):
-                raise e
+        except AttributeError:
+            if attribute in dir(obj):
+                raise
         try:
             return obj[attribute]
         except (TypeError, LookupError, AttributeError):

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -452,8 +452,9 @@ class Environment:
                 else:
                     try:
                         return getattr(obj, attr)
-                    except AttributeError:
-                        pass
+                    except AttributeError as e:
+                        if isinstance(getattr(type(obj), attr, None), property):
+                            raise e
             return self.undefined(obj=obj, name=argument)
 
     def getattr(self, obj, attribute):
@@ -462,8 +463,9 @@ class Environment:
         """
         try:
             return getattr(obj, attribute)
-        except AttributeError:
-            pass
+        except AttributeError as e:
+            if isinstance(getattr(type(obj), attribute, None), property):
+                raise e
         try:
             return obj[attribute]
         except (TypeError, LookupError, AttributeError):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,6 +414,20 @@ class TestUndefined:
         ):
             test_env.from_string("{{ obj.test }}").render(obj=TestClass())
 
+    def test_descriptor_error(self):
+        class Descriptor:
+            def __get__(self, obj, objtype=None):
+                return self.doesnt_exist
+
+        class TestClass:
+            test = Descriptor()
+
+        test_env = Environment(undefined=StrictUndefined)
+        with pytest.raises(
+            AttributeError, match=f"'Descriptor' object has no attribute 'doesnt_exist'"
+        ):
+            test_env.from_string("{{ obj.test }}").render(obj=TestClass())
+
 
 class TestLowLevel:
     def test_custom_code_generator(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -402,6 +402,18 @@ class TestUndefined:
         ):
             Undefined(obj=42, name="upper")()
 
+    def test_property_error(self):
+        class TestClass:
+            @property
+            def test(self):
+                return self.doesnt_exist
+
+        test_env = Environment(undefined=StrictUndefined)
+        with pytest.raises(
+            AttributeError, match=f"'TestClass' object has no attribute 'doesnt_exist'"
+        ):
+            test_env.from_string("{{ obj.test }}").render(obj=TestClass())
+
 
 class TestLowLevel:
     def test_custom_code_generator(self):


### PR DESCRIPTION
Before this, AttributeErrors in a property would be swallowed, this PR re-raises the AttributeError if the class has a property attribute with the correct name.

- fixes #1317 
- fixes #604 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
