### PR TITLE
loaders.py: FileSystemLoader consider cwd (.) as default searchpath

### DIFF
--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -163,7 +163,7 @@ class FileSystemLoader(BaseLoader):
         Added the ``followlinks`` parameter.
     """
 
-    def __init__(self, searchpath, encoding="utf-8", followlinks=False):
+    def __init__(self, searchpath='.', encoding="utf-8", followlinks=False):
         if not isinstance(searchpath, abc.Iterable) or isinstance(searchpath, str):
             searchpath = [searchpath]
 

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -163,7 +163,7 @@ class FileSystemLoader(BaseLoader):
         Added the ``followlinks`` parameter.
     """
 
-    def __init__(self, searchpath='.', encoding="utf-8", followlinks=False):
+    def __init__(self, searchpath=".", encoding="utf-8", followlinks=False):
         if not isinstance(searchpath, abc.Iterable) or isinstance(searchpath, str):
             searchpath = [searchpath]
 


### PR DESCRIPTION
FileSystemLoader should use the [current working directory](https://en.wikipedia.org/wiki/Working_directory) as default searchpath.