### PR TITLE
Add 'linetable' to the list of preserved CodeType attributes.

### DIFF
--- a/src/jinja2/debug.py
+++ b/src/jinja2/debug.py
@@ -130,6 +130,7 @@ def fake_traceback(exc_value, tb, filename, lineno):
             "lnotab",
             "freevars",
             "cellvars",
+            "linetable", # Python 3.10
         ):
             if isinstance(attr, tuple):
                 # Replace with given value.

--- a/src/jinja2/debug.py
+++ b/src/jinja2/debug.py
@@ -130,7 +130,7 @@ def fake_traceback(exc_value, tb, filename, lineno):
             "lnotab",
             "freevars",
             "cellvars",
-            "linetable", # Python 3.10
+            "linetable",  # Python 3.10
         ):
             if isinstance(attr, tuple):
                 # Replace with given value.


### PR DESCRIPTION
As part of https://github.com/python/cpython/pull/23113 partly
implementing PEP 626 (see https://bugs.python.org/issue42246), the
co_lnotab member of struct PyCodeObject was replaced by co_linetable,
implementing a new line number table.

This commit therefore adds linetable to the list of attributes that
are copied over into the final CodeType executed by fake_traceback()
to ensure proper line numbers and contents in fake stack traces
generated when running under Python 3.10.

Fixes #1333.