### PR TITLE
native_concat: pass only strings to literal_eval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Unreleased
 -   Add ability to ignore ``trim_blocks`` using ``+%}``. :issue:`1036`
 -   Fix a bug that caused custom async-only filters to fail with
     constant input. :issue:`1279`
+-   Fix UndefinedError incorrectly being thrown on an undefined variable
+    instead of ``Undefined`` being returned on
+    ``NativeEnvironment`` on Python 3.10. :issue:`1335`
 
 
 Version 2.11.2

--- a/src/jinja2/nativetypes.py
+++ b/src/jinja2/nativetypes.py
@@ -26,6 +26,8 @@ def native_concat(nodes):
 
     if len(head) == 1:
         raw = head[0]
+        if not isinstance(raw, str):
+            return raw
     else:
         raw = "".join([str(v) for v in chain(head, nodes)])
 


### PR DESCRIPTION
If there is only single node and it is not a string, there is no point
in passing it into ``literal_eval``, just return it immediately.

One of the examples where passing a non-string node into
``literal_eval`` would actually cause problems is when the node is
``Undefined``. On Python 3.10 this would cause ``UndefinedError``
instead of just ``Undefined`` being returned.

Fixes #1335