### PR TITLE
backport urlize speedup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 .. currentmodule:: jinja2
 
+Version 2.11.3
+--------------
+
+Unreleased
+
+-   Improve the speed of the ``urlize`` filter by reducing regex
+    backtracking. Email matching requires a word character at the start
+    of the domain part, and only word characters in the TLD. :pr:`1343`
+
+
 Version 2.11.2
 --------------
 


### PR DESCRIPTION
Match leading and trailing punctuation as separate steps. For trailing punctuation, perform a basic check first to reduce backtracking. Update the email regex to reduce backtracking and also be more accurate: the domain part must start with a word character, and the tld only matches word characters.

This is backported from #1195, but only includes the regex speedups, not the other changes.

Checklist:

- ~Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~
- ~Add or update relevant docs, in the docs folder and in code.~
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- ~Add `.. versionchanged::` entries in any relevant code docs.~
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
