### PR TITLE
Map filter can use False as default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Unreleased
     has been updated to be more efficient and match more cases. URLs
     without a scheme are linked as ``https://`` instead of ``http://``.
     :issue:`522, 827, 1172`, :pr:`1195`
+-   Filters that get attributes, such as ``map`` and ``groupby``, can
+    use a false or empty value as a default. :issue:`1331`
 
 
 Version 2.11.3

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -67,7 +67,7 @@ def make_attrgetter(environment, attribute, postprocess=None, default=None):
         for part in attribute:
             item = environment.getitem(item, part)
 
-            if default and isinstance(item, Undefined):
+            if default is not None and isinstance(item, Undefined):
                 item = default
 
         if postprocess is not None:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -666,6 +666,12 @@ class TestFilter:
         tmpl = env.from_string(
             '{{ users|map(attribute="lastname", default="smith")|join(", ") }}'
         )
+        test_list = env.from_string(
+            '{{ users|map(attribute="lastname", default=["smith","x"])|join(", ") }}'
+        )
+        test_str = env.from_string(
+            '{{ users|map(attribute="lastname", default="")|join(", ") }}'
+        )
         users = [
             Fullname("john", "lennon"),
             Fullname("jane", "edwards"),
@@ -673,6 +679,8 @@ class TestFilter:
             Firstname("mike"),
         ]
         assert tmpl.render(users=users) == "lennon, edwards, None, smith"
+        assert test_list.render(users=users) == "lennon, edwards, None, ['smith', 'x']"
+        assert test_str.render(users=users) == "lennon, edwards, None, "
 
     def test_simple_select(self, env):
         env = Environment()


### PR DESCRIPTION
According to Issue #1331, the map filter doesn't allow values like [],{},(),None etc ( that automatically default to False ) to be set as the value to the default argument. The user can now set False values to the default argument of the map filter in Jinja2.

- fixes #1331 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
