### PR TITLE
add 'is filter' and 'is test' tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ Unreleased
     already loaded. :issue:`295`
 -   Do not raise an error for undefined filters in unexecuted
     if-statements and conditional expressions. :issue:`842`
+-   Add ``is filter`` and ``is test`` tests to test if a name is a
+    registered filter or test. This allows checking if a filter is
+    available in a template before using it. Test functions can be
+    decorated with ``@environmentfunction``, ``@evalcontextfunction``,
+    or ``@contextfunction``. :issue:`842`, :pr:`1248`
 
 
 Version 2.11.3

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -5,6 +5,7 @@ from collections import abc
 from numbers import Number
 
 from .runtime import Undefined
+from .utils import environmentfunction
 
 number_re = re.compile(r"^-?\d+(\.\d+)?$")
 regex_type = type(number_re)
@@ -46,6 +47,46 @@ def test_defined(value):
 def test_undefined(value):
     """Like :func:`defined` but the other way round."""
     return isinstance(value, Undefined)
+
+
+@environmentfunction
+def test_filter(env, value):
+    """Check if a filter exists by name. Useful if a filter may be
+    optionally available.
+
+    .. code-block:: jinja
+
+        {% if 'markdown' is filter %}
+            {{ value | markdown }}
+        {% else %}
+            {{ value }}
+        {% endif %}
+
+    .. versionadded:: 3.0
+    """
+    return value in env.filters
+
+
+@environmentfunction
+def test_test(env, value):
+    """Check if a test exists by name. Useful if a test may be
+    optionally available.
+
+    .. code-block:: jinja
+
+        {% if 'loud' is test %}
+            {% if value is loud %}
+                {{ value|upper }}
+            {% else %}
+                {{ value|lower }}
+            {% endif %}
+        {% else %}
+            {{ value }}
+        {% endif %}
+
+    .. versionadded:: 3.0
+    """
+    return value in env.tests
 
 
 def test_none(value):
@@ -176,6 +217,8 @@ TESTS = {
     "divisibleby": test_divisibleby,
     "defined": test_defined,
     "undefined": test_undefined,
+    "filter": test_filter,
+    "test": test_test,
     "none": test_none,
     "boolean": test_boolean,
     "false": test_false,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -778,13 +778,13 @@ class TestFilter:
         assert result == "Hello!\nThis is Jinja saying\nsomething."
 
     def test_filter_undefined(self, env):
-        with pytest.raises(TemplateAssertionError, match="no filter named 'f'"):
+        with pytest.raises(TemplateAssertionError, match="No filter named 'f'"):
             env.from_string("{{ var|f }}")
 
     def test_filter_undefined_in_if(self, env):
         t = env.from_string("{%- if x is defined -%}{{ x|f }}{%- else -%}x{% endif %}")
         assert t.render() == "x"
-        with pytest.raises(TemplateRuntimeError, match="no filter named 'f'"):
+        with pytest.raises(TemplateRuntimeError, match="No filter named 'f'"):
             t.render(x=42)
 
     def test_filter_undefined_in_elif(self, env):
@@ -793,7 +793,7 @@ class TestFilter:
             "{{ y|f }}{%- else -%}foo{%- endif -%}"
         )
         assert t.render() == "foo"
-        with pytest.raises(TemplateRuntimeError, match="no filter named 'f'"):
+        with pytest.raises(TemplateRuntimeError, match="No filter named 'f'"):
             t.render(y=42)
 
     def test_filter_undefined_in_else(self, env):
@@ -801,7 +801,7 @@ class TestFilter:
             "{%- if x is not defined -%}foo{%- else -%}{{ x|f }}{%- endif -%}"
         )
         assert t.render() == "foo"
-        with pytest.raises(TemplateRuntimeError, match="no filter named 'f'"):
+        with pytest.raises(TemplateRuntimeError, match="No filter named 'f'"):
             t.render(x=42)
 
     def test_filter_undefined_in_nested_if(self, env):
@@ -811,7 +811,7 @@ class TestFilter:
         )
         assert t.render() == "foo"
         assert t.render(x=42) == "42"
-        with pytest.raises(TemplateRuntimeError, match="no filter named 'f'"):
+        with pytest.raises(TemplateRuntimeError, match="No filter named 'f'"):
             t.render(x=24, y=42)
 
     def test_filter_undefined_in_condexpr(self, env):
@@ -819,6 +819,6 @@ class TestFilter:
         t2 = env.from_string("{{ 'foo' if x is not defined else x|f }}")
         assert t1.render() == t2.render() == "foo"
 
-        with pytest.raises(TemplateRuntimeError, match="no filter named 'f'"):
+        with pytest.raises(TemplateRuntimeError, match="No filter named 'f'"):
             t1.render(x=42)
             t2.render(x=42)


### PR DESCRIPTION
#1248 allowed deferring checking if a filter exists until runtime when writing the filter within in an if block. To make it easy to take advantage of such optionally available filters, this PR adds an `is filter` test.

This required allowing tests to be decorated with `@environmentfilter`. It's not clear why this wasn't allowed before. The docs mentioned it wasn't possible, but didn't give a justification. Perhaps the idea was that tests should be as simple as possible; if so that's up to the discretion of a project now.

Tests are essentially the same as filters now. The difference is only the syntax used to call them and the namespace they're registered in. Most of the code in `nodes`, `compiler`, and `environment` is common between the two, so it was refactored to extract it. Tests won't be constant folded in volatile contexts. The compile supports async tests, but I'm not declaring that a public API yet, as there's not really any way to write them or apparent need for them yet. Like filters, undefined test names are checked at runtime in if blocks.

Tests can be decorated with `environmentfunction`, `evalcontextfunction`, and `contextfunction`. Filters use `{type}filter` instead but do exactly the same thing internally, which led me to open #1381 to pick one set of names.

- fixes #842
- continues #1248

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
