### PR TITLE
add type annotations to filters and tests

### DIFF
--- a/src/jinja2/asyncfilters.py
+++ b/src/jinja2/asyncfilters.py
@@ -1,31 +1,57 @@
+import typing
+import typing as t
 from functools import wraps
+from itertools import groupby
 
 from . import filters
 from .asyncsupport import auto_aiter
 from .asyncsupport import auto_await
 
+if t.TYPE_CHECKING:
+    from .environment import Environment
+    from .nodes import EvalContext
+    from .runtime import Context
+    from .runtime import Undefined
 
-async def auto_to_seq(value):
+    V = t.TypeVar("V")
+
+
+async def auto_to_seq(
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+) -> "t.List[V]":
     seq = []
+
     if hasattr(value, "__aiter__"):
-        async for item in value:
+        async for item in t.cast(t.AsyncIterable, value):
             seq.append(item)
     else:
-        for item in value:
+        for item in t.cast(t.Iterable, value):
             seq.append(item)
+
     return seq
 
 
-async def async_select_or_reject(args, kwargs, modfunc, lookup_attr):
-    seq, func = filters.prepare_select_or_reject(args, kwargs, modfunc, lookup_attr)
-    if seq:
-        async for item in auto_aiter(seq):
+async def async_select_or_reject(
+    context: "Context",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    args: t.Tuple,
+    kwargs: t.Dict[str, t.Any],
+    modfunc: t.Callable[[t.Any], t.Any],
+    lookup_attr: bool,
+) -> "t.AsyncIterator[V]":
+    if value:
+        func = filters.prepare_select_or_reject(
+            context, args, kwargs, modfunc, lookup_attr
+        )
+
+        async for item in auto_aiter(value):
             if func(item):
                 yield item
 
 
 def dualfilter(normal_filter, async_filter):
     wrap_evalctx = False
+
     if getattr(normal_filter, "environmentfilter", False) is True:
 
         def is_async(args):
@@ -43,17 +69,19 @@ def dualfilter(normal_filter, async_filter):
     @wraps(normal_filter)
     def wrapper(*args, **kwargs):
         b = is_async(args)
+
         if wrap_evalctx:
             args = args[1:]
+
         if b:
             return async_filter(*args, **kwargs)
+
         return normal_filter(*args, **kwargs)
 
     if wrap_evalctx:
         wrapper.evalcontextfilter = True
 
     wrapper.asyncfiltervariant = True
-
     return wrapper
 
 
@@ -65,65 +93,123 @@ def asyncfiltervariant(original):
 
 
 @asyncfiltervariant(filters.do_first)
-async def do_first(environment, seq):
+async def do_first(
+    environment: "Environment", seq: "t.Union[t.AsyncIterable[V], t.Iterable[V]]"
+) -> "t.Union[V, Undefined]":
     try:
-        return await auto_aiter(seq).__anext__()
+        return t.cast("V", await auto_aiter(seq).__anext__())
     except StopAsyncIteration:
         return environment.undefined("No first item, sequence was empty.")
 
 
 @asyncfiltervariant(filters.do_groupby)
-async def do_groupby(environment, value, attribute):
+async def do_groupby(
+    environment: "Environment",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    attribute: t.Union[str, int],
+) -> "t.List[t.Tuple[t.Any, t.List[V]]]":
     expr = filters.make_attrgetter(environment, attribute)
     return [
         filters._GroupTuple(key, await auto_to_seq(values))
-        for key, values in filters.groupby(
-            sorted(await auto_to_seq(value), key=expr), expr
-        )
+        for key, values in groupby(sorted(await auto_to_seq(value), key=expr), expr)
     ]
 
 
 @asyncfiltervariant(filters.do_join)
-async def do_join(eval_ctx, value, d="", attribute=None):
+async def do_join(
+    eval_ctx: "EvalContext",
+    value: t.Union[t.AsyncIterable, t.Iterable],
+    d: str = "",
+    attribute: t.Optional[t.Union[str, int]] = None,
+) -> str:
     return filters.do_join(eval_ctx, await auto_to_seq(value), d, attribute)
 
 
 @asyncfiltervariant(filters.do_list)
-async def do_list(value):
+async def do_list(value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]") -> "t.List[V]":
     return await auto_to_seq(value)
 
 
 @asyncfiltervariant(filters.do_reject)
-async def do_reject(*args, **kwargs):
-    return async_select_or_reject(args, kwargs, lambda x: not x, False)
+async def do_reject(
+    context: "Context",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> "t.AsyncIterator[V]":
+    return async_select_or_reject(context, value, args, kwargs, lambda x: not x, False)
 
 
 @asyncfiltervariant(filters.do_rejectattr)
-async def do_rejectattr(*args, **kwargs):
-    return async_select_or_reject(args, kwargs, lambda x: not x, True)
+async def do_rejectattr(
+    context: "Context",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> "t.AsyncIterator[V]":
+    return async_select_or_reject(context, value, args, kwargs, lambda x: not x, True)
 
 
 @asyncfiltervariant(filters.do_select)
-async def do_select(*args, **kwargs):
-    return async_select_or_reject(args, kwargs, lambda x: x, False)
+async def do_select(
+    context: "Context",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> "t.AsyncIterator[V]":
+    return async_select_or_reject(context, value, args, kwargs, lambda x: x, False)
 
 
 @asyncfiltervariant(filters.do_selectattr)
-async def do_selectattr(*args, **kwargs):
-    return async_select_or_reject(args, kwargs, lambda x: x, True)
+async def do_selectattr(
+    context: "Context",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> "t.AsyncIterator[V]":
+    return async_select_or_reject(context, value, args, kwargs, lambda x: x, True)
+
+
+@typing.overload
+def do_map(
+    context: "Context",
+    value: t.Union[t.AsyncIterable, t.Iterable],
+    name: str,
+    *args: t.Any,
+    **kwargs: t.Any,
+) -> t.Iterable:
+    ...
+
+
+@typing.overload
+def do_map(
+    context: "Context",
+    value: t.Union[t.AsyncIterable, t.Iterable],
+    *,
+    attribute: str = ...,
+    default: t.Optional[t.Any] = None,
+) -> t.Iterable:
+    ...
 
 
 @asyncfiltervariant(filters.do_map)
-async def do_map(*args, **kwargs):
-    seq, func = filters.prepare_map(args, kwargs)
-    if seq:
-        async for item in auto_aiter(seq):
+async def do_map(context, value, *args, **kwargs):
+    if value:
+        func = filters.prepare_map(context, args, kwargs)
+
+        async for item in auto_aiter(value):
             yield await auto_await(func(item))
 
 
 @asyncfiltervariant(filters.do_sum)
-async def do_sum(environment, iterable, attribute=None, start=0):
+async def do_sum(
+    environment: "Environment",
+    iterable: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    attribute: t.Optional[t.Union[str, int]] = None,
+    start: "V" = 0,  # type: ignore
+) -> "V":
     rv = start
+
     if attribute is not None:
         func = filters.make_attrgetter(environment, attribute)
     else:
@@ -133,11 +219,16 @@ async def do_sum(environment, iterable, attribute=None, start=0):
 
     async for item in auto_aiter(iterable):
         rv += func(item)
+
     return rv
 
 
 @asyncfiltervariant(filters.do_slice)
-async def do_slice(value, slices, fill_with=None):
+async def do_slice(
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    slices: int,
+    fill_with: t.Optional[t.Any] = None,
+) -> "t.Iterator[t.List[V]]":
     return filters.do_slice(await auto_to_seq(value), slices, fill_with)
 
 

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -319,7 +319,7 @@ class Environment:
         self.keep_trailing_newline = keep_trailing_newline
 
         # runtime information
-        self.undefined = undefined
+        self.undefined: t.Type[Undefined] = undefined
         self.optimized = optimized
         self.finalize = finalize
         self.autoescape = autoescape

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -20,6 +20,9 @@ from .utils import missing
 from .utils import Namespace  # noqa: F401
 from .utils import object_type_repr
 
+if t.TYPE_CHECKING:
+    from .environment import Environment
+
 # these variables are exported to the template runtime
 exported = [
     "LoopContext",
@@ -186,7 +189,7 @@ class Context(metaclass=ContextMeta):
     def __init__(self, environment, parent, name, blocks, globals=None):
         self.parent = parent
         self.vars = {}
-        self.environment = environment
+        self.environment: "Environment" = environment
         self.eval_ctx = EvalContext(self.environment, name)
         self.exported_vars = set()
         self.name = name

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -1,33 +1,32 @@
 """Built-in template tests used with the ``is`` operator."""
 import operator
-import re
+import typing as t
 from collections import abc
 from numbers import Number
 
 from .runtime import Undefined
 from .utils import environmentfunction
 
-number_re = re.compile(r"^-?\d+(\.\d+)?$")
-regex_type = type(number_re)
-test_callable = callable
+if t.TYPE_CHECKING:
+    from .environment import Environment
 
 
-def test_odd(value):
+def test_odd(value: int) -> bool:
     """Return true if the variable is odd."""
     return value % 2 == 1
 
 
-def test_even(value):
+def test_even(value: int) -> bool:
     """Return true if the variable is even."""
     return value % 2 == 0
 
 
-def test_divisibleby(value, num):
+def test_divisibleby(value: int, num: int) -> bool:
     """Check if a variable is divisible by a number."""
     return value % num == 0
 
 
-def test_defined(value):
+def test_defined(value: t.Any) -> bool:
     """Return true if the variable is defined:
 
     .. sourcecode:: jinja
@@ -44,13 +43,13 @@ def test_defined(value):
     return not isinstance(value, Undefined)
 
 
-def test_undefined(value):
+def test_undefined(value: t.Any) -> bool:
     """Like :func:`defined` but the other way round."""
     return isinstance(value, Undefined)
 
 
 @environmentfunction
-def test_filter(env, value):
+def test_filter(env: "Environment", value: str) -> bool:
     """Check if a filter exists by name. Useful if a filter may be
     optionally available.
 
@@ -68,7 +67,7 @@ def test_filter(env, value):
 
 
 @environmentfunction
-def test_test(env, value):
+def test_test(env: "Environment", value: str) -> bool:
     """Check if a test exists by name. Useful if a test may be
     optionally available.
 
@@ -89,12 +88,12 @@ def test_test(env, value):
     return value in env.tests
 
 
-def test_none(value):
+def test_none(value: t.Any) -> bool:
     """Return true if the variable is none."""
     return value is None
 
 
-def test_boolean(value):
+def test_boolean(value: t.Any) -> bool:
     """Return true if the object is a boolean value.
 
     .. versionadded:: 2.11
@@ -102,7 +101,7 @@ def test_boolean(value):
     return value is True or value is False
 
 
-def test_false(value):
+def test_false(value: t.Any) -> bool:
     """Return true if the object is False.
 
     .. versionadded:: 2.11
@@ -110,7 +109,7 @@ def test_false(value):
     return value is False
 
 
-def test_true(value):
+def test_true(value: t.Any) -> bool:
     """Return true if the object is True.
 
     .. versionadded:: 2.11
@@ -119,7 +118,7 @@ def test_true(value):
 
 
 # NOTE: The existing 'number' test matches booleans and floats
-def test_integer(value):
+def test_integer(value: t.Any) -> bool:
     """Return true if the object is an integer.
 
     .. versionadded:: 2.11
@@ -128,7 +127,7 @@ def test_integer(value):
 
 
 # NOTE: The existing 'number' test matches booleans and integers
-def test_float(value):
+def test_float(value: t.Any) -> bool:
     """Return true if the object is a float.
 
     .. versionadded:: 2.11
@@ -136,22 +135,22 @@ def test_float(value):
     return isinstance(value, float)
 
 
-def test_lower(value):
+def test_lower(value: str) -> bool:
     """Return true if the variable is lowercased."""
     return str(value).islower()
 
 
-def test_upper(value):
+def test_upper(value: str) -> bool:
     """Return true if the variable is uppercased."""
     return str(value).isupper()
 
 
-def test_string(value):
+def test_string(value: t.Any) -> bool:
     """Return true if the object is a string."""
     return isinstance(value, str)
 
 
-def test_mapping(value):
+def test_mapping(value: t.Any) -> bool:
     """Return true if the object is a mapping (dict etc.).
 
     .. versionadded:: 2.6
@@ -159,12 +158,12 @@ def test_mapping(value):
     return isinstance(value, abc.Mapping)
 
 
-def test_number(value):
+def test_number(value: t.Any) -> bool:
     """Return true if the variable is a number."""
     return isinstance(value, Number)
 
 
-def test_sequence(value):
+def test_sequence(value: t.Any) -> bool:
     """Return true if the variable is a sequence. Sequences are variables
     that are iterable.
     """
@@ -173,10 +172,11 @@ def test_sequence(value):
         value.__getitem__
     except Exception:
         return False
+
     return True
 
 
-def test_sameas(value, other):
+def test_sameas(value: t.Any, other: t.Any) -> bool:
     """Check if an object points to the same memory address than another
     object:
 
@@ -189,21 +189,22 @@ def test_sameas(value, other):
     return value is other
 
 
-def test_iterable(value):
+def test_iterable(value: t.Any) -> bool:
     """Check if it's possible to iterate over an object."""
     try:
         iter(value)
     except TypeError:
         return False
+
     return True
 
 
-def test_escaped(value):
+def test_escaped(value: t.Any) -> bool:
     """Check if the value is escaped."""
     return hasattr(value, "__html__")
 
 
-def test_in(value, seq):
+def test_in(value: t.Any, seq: t.Container) -> bool:
     """Check if value is in seq.
 
     .. versionadded:: 2.10
@@ -232,7 +233,7 @@ TESTS = {
     "number": test_number,
     "sequence": test_sequence,
     "iterable": test_iterable,
-    "callable": test_callable,
+    "callable": callable,
     "sameas": test_sameas,
     "escaped": test_escaped,
     "in": test_in,

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -195,7 +195,13 @@ _http_re = re.compile(
 _email_re = re.compile(r"^\S+@\w[\w.-]*\.\w+$")
 
 
-def urlize(text, trim_url_limit=None, rel=None, target=None, extra_schemes=None):
+def urlize(
+    text: str,
+    trim_url_limit: t.Optional[int] = None,
+    rel: t.Optional[str] = None,
+    target: t.Optional[str] = None,
+    extra_schemes: t.Optional[t.Iterable[str]] = None,
+) -> str:
     """Convert URLs in text into clickable links.
 
     This may not recognize links in some situations. Usually, a more
@@ -359,11 +365,8 @@ def generate_lorem_ipsum(n=5, html=True, min=20, max=100):
     return Markup("\n".join(f"<p>{escape(x)}</p>" for x in result))
 
 
-def url_quote(obj, charset="utf-8", for_qs=False):
+def url_quote(obj: t.Any, charset: str = "utf-8", for_qs: bool = False) -> str:
     """Quote a string for use in a URL using the given charset.
-
-    This function is misnamed, it is a wrapper around
-    :func:`urllib.parse.quote`.
 
     :param obj: String or bytes to quote. Other types are converted to
         string then encoded to bytes using the given charset.
@@ -610,7 +613,9 @@ def select_autoescape(
     return autoescape
 
 
-def htmlsafe_json_dumps(obj, dumps=None, **kwargs):
+def htmlsafe_json_dumps(
+    obj: t.Any, dumps: t.Optional[t.Callable[..., str]] = None, **kwargs: t.Any
+) -> Markup:
     """Serialize an object to a string of JSON with :func:`json.dumps`,
     then replace HTML-unsafe characters with Unicode escapes and mark
     the result safe with :class:`~markupsafe.Markup`.


### PR DESCRIPTION
Add type annotations to filter and test functions. #1255 started adding annotations for filters, but had a number of missing or less accurate annotations. I'm not sure how useful this is, but I wanted to be thorough.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- closes #1255 