### PR TITLE
unify/rename context function decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,8 +44,8 @@ Unreleased
 -   Add ``is filter`` and ``is test`` tests to test if a name is a
     registered filter or test. This allows checking if a filter is
     available in a template before using it. Test functions can be
-    decorated with ``@environmentfunction``, ``@evalcontextfunction``,
-    or ``@contextfunction``. :issue:`842`, :pr:`1248`
+    decorated with ``@pass_environment``, ``@pass_eval_context``,
+    or ``@pass_context``. :issue:`842`, :pr:`1248`
 -   Support ``pgettext`` and ``npgettext`` (message contexts) in i18n
     extension. :issue:`441`
 -   The ``|indent`` filter's ``width`` argument can be a string to
@@ -60,6 +60,15 @@ Unreleased
     breaks. Other characters are left unchanged. :issue:`769, 952, 1313`
 -   ``|groupby`` filter takes an optional ``default`` argument.
     :issue:`1359`
+-   The function and filter decorators have been renamed and unified.
+    The old names are deprecated. :issue:`1381`
+
+    -   ``pass_context`` replaces ``contextfunction`` and
+        ``contextfilter``.
+    -   ``pass_eval_context`` replaces ``evalcontextfunction`` and
+        ``evalcontextfilter``
+    -   ``pass_environment`` replaces ``environmentfunction`` and
+        ``environmentfilter``.
 
 
 Version 2.11.3

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -113,12 +113,12 @@ CSS, JavaScript, or configuration files.
 Why is the Context immutable?
 -----------------------------
 
-When writing a :func:`contextfunction` or something similar you may have
-noticed that the context tries to stop you from modifying it.  If you have
-managed to modify the context by using an internal context API you may
-have noticed that changes in the context don't seem to be visible in the
-template.  The reason for this is that Jinja uses the context only as
-primary data source for template variables for performance reasons.
+When writing a :func:`pass_context` function, you may have noticed that
+the context tries to stop you from modifying it. If you have managed to
+modify the context by using an internal context API you may have noticed
+that changes in the context don't seem to be visible in the template.
+The reason for this is that Jinja uses the context only as primary data
+source for template variables for performance reasons.
 
 If you want to modify the context write a function that returns a variable
 instead that one can assign to a variable by using set::

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -38,6 +38,9 @@ from .utils import contextfunction
 from .utils import environmentfunction
 from .utils import evalcontextfunction
 from .utils import is_undefined
+from .utils import pass_context
+from .utils import pass_environment
+from .utils import pass_eval_context
 from .utils import select_autoescape
 
 __version__ = "3.0.0a1"

--- a/src/jinja2/ext.py
+++ b/src/jinja2/ext.py
@@ -25,8 +25,8 @@ from .exceptions import TemplateAssertionError
 from .exceptions import TemplateSyntaxError
 from .nodes import ContextReference
 from .runtime import concat
-from .utils import contextfunction
 from .utils import import_string
+from .utils import pass_context
 
 # I18N functions available in Jinja templates. If the I18N library
 # provides ugettext, it will be assigned to gettext.
@@ -135,13 +135,13 @@ class Extension(metaclass=ExtensionRegistry):
         )
 
 
-@contextfunction
+@pass_context
 def _gettext_alias(__context, *args, **kwargs):
     return __context.call(__context.resolve("gettext"), *args, **kwargs)
 
 
 def _make_new_gettext(func):
-    @contextfunction
+    @pass_context
     def gettext(__context, __string, **variables):
         rv = __context.call(func, __string)
         if __context.eval_ctx.autoescape:
@@ -155,7 +155,7 @@ def _make_new_gettext(func):
 
 
 def _make_new_ngettext(func):
-    @contextfunction
+    @pass_context
     def ngettext(__context, __singular, __plural, __num, **variables):
         variables.setdefault("num", __num)
         rv = __context.call(func, __singular, __plural, __num)
@@ -168,7 +168,7 @@ def _make_new_ngettext(func):
 
 
 def _make_new_pgettext(func):
-    @contextfunction
+    @pass_context
     def pgettext(__context, __string_ctx, __string, **variables):
         variables.setdefault("context", __string_ctx)
         rv = __context.call(func, __string_ctx, __string)
@@ -183,7 +183,7 @@ def _make_new_pgettext(func):
 
 
 def _make_new_npgettext(func):
-    @contextfunction
+    @pass_context
     def npgettext(__context, __string_ctx, __singular, __plural, __num, **variables):
         variables.setdefault("context", __string_ctx)
         variables.setdefault("num", __num)

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -5,7 +5,7 @@ from collections import abc
 from numbers import Number
 
 from .runtime import Undefined
-from .utils import environmentfunction
+from .utils import pass_environment
 
 if t.TYPE_CHECKING:
     from .environment import Environment
@@ -48,7 +48,7 @@ def test_undefined(value: t.Any) -> bool:
     return isinstance(value, Undefined)
 
 
-@environmentfunction
+@pass_environment
 def test_filter(env: "Environment", value: str) -> bool:
     """Check if a filter exists by name. Useful if a filter may be
     optionally available.
@@ -66,7 +66,7 @@ def test_filter(env: "Environment", value: str) -> bool:
     return value in env.filters
 
 
-@environmentfunction
+@pass_environment
 def test_test(env: "Environment", value: str) -> bool:
     """Check if a test exists by name. Useful if a test may be
     optionally available.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,10 +18,10 @@ from jinja2 import Undefined
 from jinja2 import UndefinedError
 from jinja2.compiler import CodeGenerator
 from jinja2.runtime import Context
-from jinja2.utils import contextfunction
 from jinja2.utils import Cycler
-from jinja2.utils import environmentfunction
-from jinja2.utils import evalcontextfunction
+from jinja2.utils import pass_context
+from jinja2.utils import pass_environment
+from jinja2.utils import pass_eval_context
 
 
 class TestExtendedAPI:
@@ -53,7 +53,7 @@ class TestExtendedAPI:
         assert t.render(value=123) == "<int>"
 
     def test_context_finalize(self):
-        @contextfunction
+        @pass_context
         def finalize(context, value):
             return value * context["scale"]
 
@@ -62,7 +62,7 @@ class TestExtendedAPI:
         assert t.render(value=5, scale=3) == "15"
 
     def test_eval_finalize(self):
-        @evalcontextfunction
+        @pass_eval_context
         def finalize(eval_ctx, value):
             return str(eval_ctx.autoescape) + value
 
@@ -71,7 +71,7 @@ class TestExtendedAPI:
         assert t.render(value="<script>") == "True&lt;script&gt;"
 
     def test_env_autoescape(self):
-        @environmentfunction
+        @pass_environment
         def finalize(env, value):
             return " ".join(
                 (env.variable_start_string, repr(value), env.variable_end_string)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -3,10 +3,10 @@ from io import BytesIO
 
 import pytest
 
-from jinja2 import contextfunction
 from jinja2 import DictLoader
 from jinja2 import Environment
 from jinja2 import nodes
+from jinja2 import pass_context
 from jinja2.exceptions import TemplateAssertionError
 from jinja2.ext import Extension
 from jinja2.lexer import count_newlines
@@ -74,14 +74,14 @@ def _get_with_context(value, ctx=None):
     return value
 
 
-@contextfunction
+@pass_context
 def gettext(context, string):
     language = context.get("LANGUAGE", "en")
     value = languages.get(language, {}).get(string, string)
     return _get_with_context(value)
 
 
-@contextfunction
+@pass_context
 def ngettext(context, s, p, n):
     language = context.get("LANGUAGE", "en")
 
@@ -93,14 +93,14 @@ def ngettext(context, s, p, n):
     return _get_with_context(value)
 
 
-@contextfunction
+@pass_context
 def pgettext(context, c, s):
     language = context.get("LANGUAGE", "en")
     value = languages.get(language, {}).get(s, s)
     return _get_with_context(value, c)
 
 
-@contextfunction
+@pass_context
 def npgettext(context, c, s, p, n):
     language = context.get("LANGUAGE", "en")
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 from jinja2 import TemplateAssertionError
 from jinja2 import TemplateNotFound
 from jinja2 import TemplateSyntaxError
-from jinja2.utils import contextfunction
+from jinja2.utils import pass_context
 
 
 class TestCorner:
@@ -298,11 +298,9 @@ class TestBug:
 
         assert e.value.name == "foo/bar.html"
 
-    def test_contextfunction_callable_classes(self, env):
-        from jinja2.utils import contextfunction
-
+    def test_pass_context_callable_class(self, env):
         class CallableClass:
-            @contextfunction
+            @pass_context
             def __call__(self, ctx):
                 return ctx.resolve("hello")
 
@@ -633,8 +631,8 @@ End"""
         )
         assert tmpl.render() == "Start\n1) foo\n2) bar last\nEnd"
 
-    def test_contextfunction_loop_vars(self, env):
-        @contextfunction
+    def test_pass_context_loop_vars(self, env):
+        @pass_context
         def test(ctx):
             return f"{ctx['i']}{ctx['j']}"
 
@@ -653,8 +651,8 @@ End"""
         tmpl.globals["test"] = test
         assert tmpl.render() == "42\n01\n01\n42\n12\n12\n42"
 
-    def test_contextfunction_scoped_loop_vars(self, env):
-        @contextfunction
+    def test_pass_context_scoped_loop_vars(self, env):
+        @pass_context
         def test(ctx):
             return f"{ctx['i']}"
 
@@ -673,8 +671,8 @@ End"""
         tmpl.globals["test"] = test
         assert tmpl.render() == "42\n0\n42\n1\n42"
 
-    def test_contextfunction_in_blocks(self, env):
-        @contextfunction
+    def test_pass_context_in_blocks(self, env):
+        @pass_context
         def test(ctx):
             return f"{ctx['i']}"
 
@@ -691,8 +689,8 @@ End"""
         tmpl.globals["test"] = test
         assert tmpl.render() == "42\n24\n42"
 
-    def test_contextfunction_block_and_loop(self, env):
-        @contextfunction
+    def test_pass_context_block_and_loop(self, env):
+        @pass_context
         def test(ctx):
             return f"{ctx['i']}"
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -56,10 +56,10 @@ def test_iterator_not_advanced_early():
     assert out == "1 [(1, 'a'), (1, 'b')]\n2 [(2, 'c')]\n3 [(3, 'd')]\n"
 
 
-def test_mock_not_contextfunction():
+def test_mock_not_pass_arg_marker():
     """If a callable class has a ``__getattr__`` that returns True-like
     values for arbitrary attrs, it should not be incorrectly identified
-    as a ``contextfunction``.
+    as a ``pass_context`` function.
     """
 
     class Calc:


### PR DESCRIPTION
Functions, including filters, tests, and finalize, all use `pass_context`, `pass_eval_context`, and `pass_environment`. A single variable, `jinja_pass_arg` is set to an enum member. The enum class has a `from_obj` method to check if a given function/callable class has the variable. It also handles showing deprecation warnings for all the other names. It's not a public API (yet), but I also renamed `asyncfiltervariant` to `async_variant`.

- fixes #1381 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
