### PR TITLE
Markup and escape should be imported from markupsafe

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -609,27 +609,9 @@ functions to a Jinja environment.
 
 .. autofunction:: jinja2.environmentfunction
 
-.. function:: escape(s)
-
-    Convert the characters ``&``, ``<``, ``>``, ``'``, and ``"`` in string `s`
-    to HTML-safe sequences.  Use this if you need to display text that might
-    contain such characters in HTML.  This function will not escaped objects
-    that do have an HTML representation such as already escaped data.
-
-    The return value is a :class:`Markup` string.
-
 .. autofunction:: jinja2.clear_caches
 
 .. autofunction:: jinja2.is_undefined
-
-.. autoclass:: jinja2.Markup([string])
-    :members: escape, unescape, striptags
-
-.. admonition:: Note
-
-    The Jinja :class:`Markup` class is compatible with at least Pylons and
-    Genshi.  It's expected that more template engines and framework will pick
-    up the `__html__` concept soon.
 
 
 Exceptions

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -2,9 +2,6 @@
 non-XML syntax that supports inline expressions and an optional
 sandboxed environment.
 """
-from markupsafe import escape
-from markupsafe import Markup
-
 from .bccache import BytecodeCache
 from .bccache import FileSystemBytecodeCache
 from .bccache import MemcachedBytecodeCache
@@ -36,8 +33,10 @@ from .runtime import Undefined
 from .utils import clear_caches
 from .utils import contextfunction
 from .utils import environmentfunction
+from .utils import escape
 from .utils import evalcontextfunction
 from .utils import is_undefined
+from .utils import Markup
 from .utils import pass_context
 from .utils import pass_environment
 from .utils import pass_eval_context

--- a/tests/test_asyncfilters.py
+++ b/tests/test_asyncfilters.py
@@ -1,10 +1,10 @@
 from collections import namedtuple
 
 import pytest
+from markupsafe import Markup
 
 from jinja2 import Environment
 from jinja2.asyncsupport import auto_aiter
-from jinja2.utils import Markup
 
 
 async def make_aiter(iter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,9 +2,9 @@ import random
 from collections import namedtuple
 
 import pytest
+from markupsafe import Markup
 
 from jinja2 import Environment
-from jinja2 import Markup
 from jinja2 import StrictUndefined
 from jinja2 import TemplateRuntimeError
 from jinja2 import UndefinedError

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -613,7 +613,7 @@ class TestBug:
         assert tmpl.render(values=[]) == "0"
 
     def test_markup_and_chainable_undefined(self):
-        from jinja2 import Markup
+        from markupsafe import Markup
         from jinja2.runtime import ChainableUndefined
 
         assert str(Markup(ChainableUndefined())) == ""

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,7 +1,7 @@
 import pytest
+from markupsafe import escape
 
 from jinja2 import Environment
-from jinja2 import escape
 from jinja2.exceptions import SecurityError
 from jinja2.exceptions import TemplateRuntimeError
 from jinja2.exceptions import TemplateSyntaxError

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,7 +1,7 @@
 import pytest
+from markupsafe import Markup
 
 from jinja2 import Environment
-from jinja2 import Markup
 from jinja2 import TemplateAssertionError
 from jinja2 import TemplateRuntimeError
 


### PR DESCRIPTION
These were still left over from Jinja's early days. Noticed they were still exported and documented, so now the Jinja versions show deprecation warnings pointing to markupsafe.