### PR TITLE
deprecate legacy resolve mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Unreleased
 -   Async support no longer requires Jinja to patch itself. It must
     still be enabled with ``Environment(enable_async=True)``.
     :issue:`1390`
+-   Overriding ``Context.resolve`` is deprecated, override
+    ``resolve_or_missing`` instead. :issue:`1380`
 
 
 Version 2.11.3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -364,7 +364,7 @@ The Context
 -----------
 
 .. autoclass:: jinja2.runtime.Context()
-    :members: resolve, get_exported, get_all
+    :members: get, resolve, resolve_or_missing, get_exported, get_all
 
     .. attribute:: parent
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -594,11 +594,13 @@ class TestBug:
     def test_legacy_custom_context(self, env):
         from jinja2.runtime import Context, missing
 
-        class MyContext(Context):
-            def resolve(self, name):
-                if name == "foo":
-                    return 42
-                return super().resolve(name)
+        with pytest.deprecated_call():
+
+            class MyContext(Context):
+                def resolve(self, name):
+                    if name == "foo":
+                        return 42
+                    return super().resolve(name)
 
         x = MyContext(env, parent={"bar": 23}, name="foo", blocks={})
         assert x._legacy_resolve_mode


### PR DESCRIPTION
Changed the metaclass logic to check if the names were defined on the child class instead of comparing the function objects. `_fast_resolve_mode` was never getting triggered, which suggested comparing the objects wasn't completely reliable anyway. Inlined the `resolve_or_missing` function into both methods.

- fixes #1380 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
