### PR TITLE
fix deprecated `Markup` subclass

### DIFF
--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -833,14 +833,14 @@ class Namespace:
 
 
 class Markup(markupsafe.Markup):
-    def __init__(self, *args, **kwargs):
+    def __new__(cls, base, encoding=None, errors="strict"):
         warnings.warn(
             "'jinja2.Markup' is deprecated and will be removed in Jinja"
             " 3.1. Import 'markupsafe.Markup' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(*args, **kwargs)
+        return super().__new__(cls, base, encoding, errors)
 
 
 def escape(s):


### PR DESCRIPTION
`str` subclass must override `__new__` instead of `__init__`.

<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1400

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
