### PR TITLE
update markupsafe minimum version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.0.1
 
 Unreleased
 
+-   Update MarkupSafe dependency to >= 2.0.
+
 
 Version 3.0.0
 -------------

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Jinja2",
-    install_requires=["MarkupSafe>=2.0.0rc2"],
+    install_requires=["MarkupSafe>=2.0"],
     extras_require={"i18n": ["Babel>=2.7"]},
 )


### PR DESCRIPTION
Forgot to do this for 3.0.0, but nothing actually changed since the last MarkupSafe release candidate, so it's not immediately important.