### PR TITLE
Install sphinx 4.1-dev from git

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,12 +36,10 @@ imagesize==1.2.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==2.11.3
+jinja2==3.0.0
     # via sphinx
-markupsafe==1.1.1
-    # via
-    #   jinja2
-    #   sphinx
+markupsafe==2.0.0
+    # via jinja2
 mypy-extensions==0.4.3
     # via mypy
 mypy==0.812
@@ -90,7 +88,7 @@ snowballstemmer==2.1.0
     # via sphinx
 sphinx-issues==1.2.0
     # via -r requirements/docs.in
-sphinx==4.0.1
+git+https://github.com/sphinx-doc/sphinx.git@96dbe5e3
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,4 @@
 Pallets-Sphinx-Themes
-Sphinx
+git+https://github.com/sphinx-doc/sphinx.git@96dbe5e3  # https://github.com/sphinx-doc/sphinx/issues/9216
 sphinx-issues
 sphinxcontrib-log-cabinet

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,12 +18,10 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-jinja2==2.11.3
+jinja2==3.0.0
     # via sphinx
-markupsafe==1.1.1
-    # via
-    #   jinja2
-    #   sphinx
+markupsafe==2.0.0
+    # via jinja2
 packaging==20.9
     # via
     #   pallets-sphinx-themes
@@ -42,7 +40,7 @@ snowballstemmer==2.1.0
     # via sphinx
 sphinx-issues==1.2.0
     # via -r requirements/docs.in
-sphinx==4.0.1
+git+https://github.com/sphinx-doc/sphinx.git@96dbe5e3
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -1178,7 +1178,7 @@ class Template:
         finalize: t.Optional[t.Callable[..., t.Any]] = None,
         autoescape: t.Union[bool, t.Callable[[t.Optional[str]], bool]] = False,
         enable_async: bool = False,
-    ) -> "Template":
+    ) -> t.Any:  # it returns a `Template`, but this breaks the sphinx build...
         env = get_spontaneous_environment(
             cls.environment_class,  # type: ignore
             block_start_string,


### PR DESCRIPTION
Otherwise docs builds are broken due to sphinx-doc/sphinx#9216

The Any type is needed to avoid this odd sphinx warning:

> jinja2/nativetypes.py:docstring of jinja2.nativetypes.NativeTemplate::more than one target found for cross-reference 'Template': jinja2.Template, jinja2.environment.Template, jinja2.nodes.Template