### PR TITLE
Update CHANGES.rst to reflect breaking change in 2.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -425,6 +425,7 @@ Version 2.9
 
 Released 2017-01-07, codename Derivation
 
+-   BREAKING - Behavior for variables set inside a loop have changed. See issue:`641`
 -   Change cache key definition in environment. This fixes a performance
     regression introduced in 2.8.
 -   Added support for ``generator_stop`` on supported Python versions


### PR DESCRIPTION
Updating CHANGES.rst to reflect breaking behavior to help folks track down issues on update. 
Otherwise old projects that get updated just start failing with no clear reason from the CHANGES.rst

Nothing to test as this is just a documentation update