### PR TITLE
Update typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Version 3.0.1
 
 Unreleased
 
--   Update MarkupSafe dependency to >= 2.0.
+-   Update MarkupSafe dependency to >= 2.0. :pr:`1418`
+-   Mark top-level names as exported so type checking understands
+    imports in user projects. :issue:`1426`
 
 
 Version 3.0.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 -   Update MarkupSafe dependency to >= 2.0. :pr:`1418`
 -   Mark top-level names as exported so type checking understands
     imports in user projects. :issue:`1426`
+-   Fix some types that weren't available in Python 3.6.0. :issue:`1433`
 
 
 Version 3.0.0

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -2,44 +2,44 @@
 non-XML syntax that supports inline expressions and an optional
 sandboxed environment.
 """
-from .bccache import BytecodeCache
-from .bccache import FileSystemBytecodeCache
-from .bccache import MemcachedBytecodeCache
-from .environment import Environment
-from .environment import Template
-from .exceptions import TemplateAssertionError
-from .exceptions import TemplateError
-from .exceptions import TemplateNotFound
-from .exceptions import TemplateRuntimeError
-from .exceptions import TemplatesNotFound
-from .exceptions import TemplateSyntaxError
-from .exceptions import UndefinedError
+from .bccache import BytecodeCache as BytecodeCache
+from .bccache import FileSystemBytecodeCache as FileSystemBytecodeCache
+from .bccache import MemcachedBytecodeCache as MemcachedBytecodeCache
+from .environment import Environment as Environment
+from .environment import Template as Template
+from .exceptions import TemplateAssertionError as TemplateAssertionError
+from .exceptions import TemplateError as TemplateError
+from .exceptions import TemplateNotFound as TemplateNotFound
+from .exceptions import TemplateRuntimeError as TemplateRuntimeError
+from .exceptions import TemplatesNotFound as TemplatesNotFound
+from .exceptions import TemplateSyntaxError as TemplateSyntaxError
+from .exceptions import UndefinedError as UndefinedError
 from .filters import contextfilter
 from .filters import environmentfilter
 from .filters import evalcontextfilter
-from .loaders import BaseLoader
-from .loaders import ChoiceLoader
-from .loaders import DictLoader
-from .loaders import FileSystemLoader
-from .loaders import FunctionLoader
-from .loaders import ModuleLoader
-from .loaders import PackageLoader
-from .loaders import PrefixLoader
-from .runtime import ChainableUndefined
-from .runtime import DebugUndefined
-from .runtime import make_logging_undefined
-from .runtime import StrictUndefined
-from .runtime import Undefined
-from .utils import clear_caches
+from .loaders import BaseLoader as BaseLoader
+from .loaders import ChoiceLoader as ChoiceLoader
+from .loaders import DictLoader as DictLoader
+from .loaders import FileSystemLoader as FileSystemLoader
+from .loaders import FunctionLoader as FunctionLoader
+from .loaders import ModuleLoader as ModuleLoader
+from .loaders import PackageLoader as PackageLoader
+from .loaders import PrefixLoader as PrefixLoader
+from .runtime import ChainableUndefined as ChainableUndefined
+from .runtime import DebugUndefined as DebugUndefined
+from .runtime import make_logging_undefined as make_logging_undefined
+from .runtime import StrictUndefined as StrictUndefined
+from .runtime import Undefined as Undefined
+from .utils import clear_caches as clear_caches
 from .utils import contextfunction
 from .utils import environmentfunction
 from .utils import escape
 from .utils import evalcontextfunction
-from .utils import is_undefined
+from .utils import is_undefined as is_undefined
 from .utils import Markup
-from .utils import pass_context
-from .utils import pass_environment
-from .utils import pass_eval_context
-from .utils import select_autoescape
+from .utils import pass_context as pass_context
+from .utils import pass_environment as pass_environment
+from .utils import pass_eval_context as pass_eval_context
+from .utils import select_autoescape as select_autoescape
 
 __version__ = "3.0.1.dev0"

--- a/src/jinja2/bccache.py
+++ b/src/jinja2/bccache.py
@@ -210,7 +210,7 @@ class FileSystemBytecodeCache(BytecodeCache):
         self.pattern = pattern
 
     def _get_default_cache_dir(self) -> str:
-        def _unsafe_dir() -> t.NoReturn:
+        def _unsafe_dir() -> "te.NoReturn":
             raise RuntimeError(
                 "Cannot determine safe temp directory.  You "
                 "need to explicitly provide one."

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -23,6 +23,7 @@ from .utils import concat
 from .visitor import NodeVisitor
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
     from .environment import Environment
 
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
@@ -376,7 +377,7 @@ class CodeGenerator(NodeVisitor):
 
     # -- Various compilation helpers
 
-    def fail(self, msg: str, lineno: int) -> t.NoReturn:
+    def fail(self, msg: str, lineno: int) -> "te.NoReturn":
         """Fail with a :exc:`TemplateAssertionError`."""
         raise TemplateAssertionError(msg, lineno, self.name, self.filename)
 

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -915,7 +915,7 @@ class Environment:
 
         return names
 
-    def handle_exception(self, source: t.Optional[str] = None) -> t.NoReturn:
+    def handle_exception(self, source: t.Optional[str] = None) -> "te.NoReturn":
         """Exception handling helper.  This is used internally to either raise
         rewritten exceptions or return a rendered traceback for the template.
         """

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -14,6 +14,7 @@ from .exceptions import TemplateSyntaxError
 from .utils import LRUCache
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
     from .environment import Environment
 
 # cache for the lexers. Exists in order to be able to have multiple
@@ -259,7 +260,7 @@ class Failure:
         self.message = message
         self.error_class = cls
 
-    def __call__(self, lineno: int, filename: str) -> t.NoReturn:
+    def __call__(self, lineno: int, filename: str) -> "te.NoReturn":
         raise self.error_class(self.message, lineno, filename)
 
 
@@ -326,7 +327,7 @@ class TokenStream:
         filename: t.Optional[str],
     ):
         self._iter = iter(generator)
-        self._pushed: t.Deque[Token] = deque()
+        self._pushed: "te.Deque[Token]" = deque()
         self.name = name
         self.filename = filename
         self.closed = False

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -12,6 +12,7 @@ from markupsafe import Markup
 from .utils import _PassArg
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
     from .environment import Environment
 
 _NodeBound = t.TypeVar("_NodeBound", bound="Node")
@@ -1196,7 +1197,7 @@ class ScopedEvalContextModifier(EvalContextModifier):
 
 
 # make sure nobody creates custom nodes
-def _failing_new(*args: t.Any, **kwargs: t.Any) -> t.NoReturn:
+def _failing_new(*args: t.Any, **kwargs: t.Any) -> "te.NoReturn":
     raise TypeError("can't create custom node types")
 
 

--- a/src/jinja2/parser.py
+++ b/src/jinja2/parser.py
@@ -76,7 +76,7 @@ class Parser:
         msg: str,
         lineno: t.Optional[int] = None,
         exc: t.Type[TemplateSyntaxError] = TemplateSyntaxError,
-    ) -> t.NoReturn:
+    ) -> "te.NoReturn":
         """Convenience method that raises `exc` with the message, passed
         line number or last line number as well as the current name and
         filename.
@@ -90,7 +90,7 @@ class Parser:
         name: t.Optional[str],
         end_token_stack: t.List[t.Tuple[str, ...]],
         lineno: t.Optional[int],
-    ) -> t.NoReturn:
+    ) -> "te.NoReturn":
         expected: t.Set[str] = set()
         for exprs in end_token_stack:
             expected.update(map(describe_token_expr, exprs))
@@ -125,7 +125,9 @@ class Parser:
 
         self.fail(" ".join(message), lineno)
 
-    def fail_unknown_tag(self, name: str, lineno: t.Optional[int] = None) -> t.NoReturn:
+    def fail_unknown_tag(
+        self, name: str, lineno: t.Optional[int] = None
+    ) -> "te.NoReturn":
         """Called if the parser encounters an unknown tag.  Tries to fail
         with a human readable error message that could help to identify
         the problem.
@@ -136,7 +138,7 @@ class Parser:
         self,
         end_tokens: t.Optional[t.Tuple[str, ...]] = None,
         lineno: t.Optional[int] = None,
-    ) -> t.NoReturn:
+    ) -> "te.NoReturn":
         """Like fail_unknown_tag but for end of template situations."""
         stack = list(self._end_token_stack)
         if end_tokens is not None:

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -894,7 +894,9 @@ class Undefined:
         )
 
     @internalcode
-    def _fail_with_undefined_error(self, *args: t.Any, **kwargs: t.Any) -> t.NoReturn:
+    def _fail_with_undefined_error(
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> "te.NoReturn":
         """Raise an :exc:`UndefinedError` when operations are performed
         on the undefined value.
         """
@@ -985,7 +987,7 @@ def make_logging_undefined(
 
         def _fail_with_undefined_error(  # type: ignore
             self, *args: t.Any, **kwargs: t.Any
-        ) -> t.NoReturn:
+        ) -> "te.NoReturn":
             try:
                 super()._fail_with_undefined_error(*args, **kwargs)
             except self._undefined_exception as e:

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -14,6 +14,9 @@ from urllib.parse import quote_from_bytes
 
 import markupsafe
 
+if t.TYPE_CHECKING:
+    import typing_extensions as te
+
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
 # special singleton representing missing values for the runtime
@@ -503,7 +506,7 @@ class LRUCache:
     def __init__(self, capacity: int) -> None:
         self.capacity = capacity
         self._mapping: t.Dict[t.Any, t.Any] = {}
-        self._queue: t.Deque[t.Any] = deque()
+        self._queue: "te.Deque[t.Any]" = deque()
         self._postinit()
 
     def _postinit(self) -> None:


### PR DESCRIPTION
- Mark top-level names as exported. fixes #1426
- Fix some types that weren't available in Python 3.6.0. fixes #1433