### PR TITLE
fix context for deprecated extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 -   Mark top-level names as exported so type checking understands
     imports in user projects. :issue:`1426`
 -   Fix some types that weren't available in Python 3.6.0. :issue:`1433`
+-   The deprecation warning for unneeded ``autoescape`` and ``with_``
+    extensions shows more relevant context. :issue:`1429`
 
 
 Version 3.0.0

--- a/src/jinja2/ext.py
+++ b/src/jinja2/ext.py
@@ -604,7 +604,7 @@ class WithExtension(Extension):
             "The 'with' extension is deprecated and will be removed in"
             " Jinja 3.1. This is built in now.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
 
@@ -615,7 +615,7 @@ class AutoEscapeExtension(Extension):
             "The 'autoescape' extension is deprecated and will be"
             " removed in Jinja 3.1. This is built in now.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
 


### PR DESCRIPTION
Now it shows the line that created the environment with the extensions, instead of internal code creating the extensions.

- fixes #1429