### PR TITLE
fix deprecated `Markup` subclass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 -   Fix some types that weren't available in Python 3.6.0. :issue:`1433`
 -   The deprecation warning for unneeded ``autoescape`` and ``with_``
     extensions shows more relevant context. :issue:`1429`
+-   Fixed calling deprecated ``jinja2.Markup`` without an argument.
+    Use ``markupsafe.Markup`` instead. :issue:`1438`
 
 
 Version 3.0.0

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -834,7 +834,7 @@ class Namespace:
 
 
 class Markup(markupsafe.Markup):
-    def __new__(cls, base, encoding=None, errors="strict"):  # type: ignore
+    def __new__(cls, base="", encoding=None, errors="strict"):  # type: ignore
         warnings.warn(
             "'jinja2.Markup' is deprecated and will be removed in Jinja"
             " 3.1. Import 'markupsafe.Markup' instead.",


### PR DESCRIPTION
re-apply #1439 to 3.0.x branch