### PR TITLE
use asyncio.run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Unreleased
     extensions shows more relevant context. :issue:`1429`
 -   Fixed calling deprecated ``jinja2.Markup`` without an argument.
     Use ``markupsafe.Markup`` instead. :issue:`1438`
+-   Calling sync ``render`` for an async template uses ``asyncio.run``
+    on Python >= 3.7. This fixes a deprecation that Python 3.10
+    introduces. :issue:`1443`
 
 
 Version 3.0.0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -513,12 +513,12 @@ handle async and sync code in an asyncio event loop. This has the
 following implications:
 
 -   Template rendering requires an event loop to be available to the
-    current thread. :func:`asyncio.get_event_loop` must return an event
-    loop.
+    current thread. :func:`asyncio.get_running_loop` must return an
+    event loop.
 -   The compiled code uses ``await`` for functions and attributes, and
     uses ``async for`` loops. In order to support using both async and
     sync functions in this context, a small wrapper is placed around
-    all calls and access, which add overhead compared to purely async
+    all calls and access, which adds overhead compared to purely async
     code.
 -   Sync methods and filters become wrappers around their corresponding
     async implementations where needed. For example, ``render`` invokes

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import pytest
 
@@ -13,9 +14,17 @@ from jinja2.exceptions import UndefinedError
 from jinja2.nativetypes import NativeEnvironment
 
 
-def run(coro):
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(coro)
+if sys.version_info < (3, 7):
+
+    def run(coro):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(coro)
+
+
+else:
+
+    def run(coro):
+        return asyncio.run(coro)
 
 
 def test_basic_async():


### PR DESCRIPTION
Python 3.10 shows a deprecation warning when using `asyncio.get_event_loop` while not in an event loop, which is the case when running the sync `render` method for an async template. Use `asyncio.run` instead, which manages running in an event loop.

`generate` is no longer particularly useful when called on an async template, as calling `run` over and over again would create new loops and be inefficient. So it collects the entire render then yields it item by item so that it's still a generator. `generate` already doesn't seem particularly useful, as only very simple templates without blocks or other internal buffers will actually yield one statement at a time.

I think we should deprecate calling `render` and `generate` if the template is async. It's a blocking call in async mode, and it doesn't really make sense to render an async environment from sync code, as you'd have to manage everything manually for that to be useful. It also requires ignoring some type errors. Users should call `render_async` from a running loop when using an async environment.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1443 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
