### PR TITLE
fix loop scoping bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 3.0.2
 
 Unreleased
 
+-   Fix a loop scoping bug that caused assignments in nested loops
+    to still be referenced outside of it. :issue:`1427`
+
 
 Version 3.0.1
 -------------

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1290,6 +1290,11 @@ class CodeGenerator(NodeVisitor):
             self.write(", loop)")
             self.end_write(frame)
 
+        # at the end of the iteration, clear any assignments made in the
+        # loop from the top level
+        if self._assign_stack:
+            self._assign_stack[-1].difference_update(loop_frame.symbols.stores)
+
     def visit_If(self, node: nodes.If, frame: Frame) -> None:
         if_frame = frame.soft()
         self.writeline("if ", node)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -746,6 +746,13 @@ End"""
         tmpl = env.get_template("base")
         assert tmpl.render() == "42 y"
 
+    def test_nested_loop_scoping(self, env):
+        tmpl = env.from_string(
+            "{% set output %}{% for x in [1,2,3] %}hello{% endfor %}"
+            "{% endset %}{{ output }}"
+        )
+        assert tmpl.render() == "hellohellohello"
+
 
 @pytest.mark.parametrize("unicode_char", ["\N{FORM FEED}", "\x85"])
 def test_unicode_whitespace(env, unicode_char):


### PR DESCRIPTION
fixes #1427 

changes in f524bcce0cf295941fe665cbcb6846e7e9f39df5 caused assignments in nested loops to still be referenced after the end of the iteration. now, all variables assigned in loops will be cleared from the top level so that jinja won't attempt to resolve them outside of the loop.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
