### PR TITLE
make compile_templates deterministic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Fix a loop scoping bug that caused assignments in nested loops
     to still be referenced outside of it. :issue:`1427`
+-   Make ``compile_templates`` deterministic for filter and import
+    names. :issue:`1452, 1453`
 
 
 Version 3.0.1

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -556,7 +556,7 @@ class CodeGenerator(NodeVisitor):
             visitor.tests,
             "tests",
         ):
-            for name in names:
+            for name in sorted(names):
                 if name not in id_map:
                     id_map[name] = self.temporary_identifier()
 

--- a/src/jinja2/idtracking.py
+++ b/src/jinja2/idtracking.py
@@ -149,7 +149,7 @@ class Symbols:
         node: t.Optional["Symbols"] = self
 
         while node is not None:
-            for name in node.stores:
+            for name in sorted(node.stores):
                 if name not in rv:
                     rv[name] = self.find_ref(name)  # type: ignore
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,28 @@
+import os
+import re
+
+from jinja2.environment import Environment
+from jinja2.loaders import DictLoader
+
+
+def test_filters_deterministic(tmp_path):
+    src = "".join(f"{{{{ {i}|filter{i} }}}}" for i in range(10))
+    env = Environment(loader=DictLoader({"foo": src}))
+    env.filters.update(dict.fromkeys((f"filter{i}" for i in range(10)), lambda: None))
+    env.compile_templates(tmp_path, zip=None)
+    name = os.listdir(tmp_path)[0]
+    content = (tmp_path / name).read_text("utf8")
+    expect = [f"filters['filter{i}']" for i in range(10)]
+    found = re.findall(r"filters\['filter\d']", content)
+    assert found == expect
+
+
+def test_import_as_with_context_deterministic(tmp_path):
+    src = "\n".join(f'{{% import "bar" as bar{i} with context %}}' for i in range(10))
+    env = Environment(loader=DictLoader({"foo": src}))
+    env.compile_templates(tmp_path, zip=None)
+    name = os.listdir(tmp_path)[0]
+    content = (tmp_path / name).read_text("utf8")
+    expect = [f"'bar{i}': " for i in range(10)]
+    found = re.findall(r"'bar\d': ", content)[:10]
+    assert found == expect


### PR DESCRIPTION
Python3 doesn't keep insertion order for set(), so this sorts some
places for deterministic output for compiled template.

- fixes #1452
- fixes #1453

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
