### PR TITLE
Only StrictUndefined.__contains__ raises error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,12 @@
 Version 3.0.2
 -------------
 
-Unreleased
-
 -   Fix a loop scoping bug that caused assignments in nested loops
     to still be referenced outside of it. :issue:`1427`
 -   Make ``compile_templates`` deterministic for filter and import
     names. :issue:`1452, 1453`
+-   Revert an unintended change that caused ``Undefined`` to act like
+    ``StrictUndefined`` for the ``in`` operator. :issue:`1448`
 
 
 Version 3.0.1

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -915,7 +915,7 @@ class Undefined:
     __floordiv__ = __rfloordiv__ = _fail_with_undefined_error
     __mod__ = __rmod__ = _fail_with_undefined_error
     __pos__ = __neg__ = _fail_with_undefined_error
-    __call__ = __getitem__ = __contains__ = _fail_with_undefined_error
+    __call__ = __getitem__ = _fail_with_undefined_error
     __lt__ = __le__ = __gt__ = __ge__ = _fail_with_undefined_error
     __int__ = __float__ = __complex__ = _fail_with_undefined_error
     __pow__ = __rpow__ = _fail_with_undefined_error
@@ -1091,6 +1091,7 @@ class StrictUndefined(Undefined):
     __slots__ = ()
     __iter__ = __str__ = __len__ = Undefined._fail_with_undefined_error
     __eq__ = __ne__ = __bool__ = __hash__ = Undefined._fail_with_undefined_error
+    __contains__ = Undefined._fail_with_undefined_error
 
 
 # Remove slots attributes, after the metaclass is applied they are

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -316,7 +316,7 @@ class TestUndefined:
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
         assert env.from_string("{{ not missing }}").render() == "True"
         pytest.raises(UndefinedError, env.from_string("{{ missing - 1}}").render)
-        pytest.raises(UndefinedError, env.from_string("{{ 'foo' in missing }}").render)
+        assert env.from_string("{{ 'foo' in missing }}").render() == "False"
         und1 = Undefined(name="x")
         und2 = Undefined(name="y")
         assert und1 == und2
@@ -375,6 +375,7 @@ class TestUndefined:
         pytest.raises(UndefinedError, env.from_string("{{ missing }}").render)
         pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
         pytest.raises(UndefinedError, env.from_string("{{ missing|list }}").render)
+        pytest.raises(UndefinedError, env.from_string("{{ 'foo' in missing }}").render)
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         pytest.raises(
             UndefinedError, env.from_string("{{ foo.missing }}").render, foo=42


### PR DESCRIPTION
- fixes #1448 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
	- There was no docs added when this was set, so there shouldn't be doc to remove or change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
    - No docstring changed
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
