### PR TITLE
Start adding indent_blocks to the lexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/_build/
 *.pyo
 *.egg-info/
 *.egg
+*.swp
 build/
 dist/
 .DS_Store

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.1.0
 
 Unreleased
 
+-   Add the `indent_blocks` environment parameter. :issue:`178`
+
 
 Version 3.0.2
 -------------

--- a/src/jinja2/defaults.py
+++ b/src/jinja2/defaults.py
@@ -21,6 +21,7 @@ LINE_STATEMENT_PREFIX: t.Optional[str] = None
 LINE_COMMENT_PREFIX: t.Optional[str] = None
 TRIM_BLOCKS = False
 LSTRIP_BLOCKS = False
+INDENT_BLOCKS = False
 NEWLINE_SEQUENCE: "te.Literal['\\n', '\\r\\n', '\\r']" = "\n"
 KEEP_TRAILING_NEWLINE = False
 

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -29,6 +29,7 @@ from .defaults import KEEP_TRAILING_NEWLINE
 from .defaults import LINE_COMMENT_PREFIX
 from .defaults import LINE_STATEMENT_PREFIX
 from .defaults import LSTRIP_BLOCKS
+from .defaults import INDENT_BLOCKS
 from .defaults import NEWLINE_SEQUENCE
 from .defaults import TRIM_BLOCKS
 from .defaults import VARIABLE_END_STRING
@@ -260,6 +261,13 @@ class Environment:
         `enable_async`
             If set to true this enables async template execution which
             allows using async functions and generators.
+
+        `indent_blocks`
+            If this is set to ``True`` block contents are automatically
+            indented so that the first line of the content aligns with the
+            indentation level of the starting block. Defaults to ``False``.
+
+            .. versionadded:: 3.1
     """
 
     #: if this environment is sandboxed.  Modifying this variable won't make
@@ -312,6 +320,7 @@ class Environment:
         auto_reload: bool = True,
         bytecode_cache: t.Optional["BytecodeCache"] = None,
         enable_async: bool = False,
+        indent_blocks: bool = INDENT_BLOCKS,
     ):
         # !!Important notice!!
         #   The constructor accepts quite a few arguments that should be
@@ -335,6 +344,7 @@ class Environment:
         self.line_comment_prefix = line_comment_prefix
         self.trim_blocks = trim_blocks
         self.lstrip_blocks = lstrip_blocks
+        self.indent_blocks = indent_blocks
         self.newline_sequence = newline_sequence
         self.keep_trailing_newline = keep_trailing_newline
 
@@ -401,6 +411,7 @@ class Environment:
         cache_size: int = missing,
         auto_reload: bool = missing,
         bytecode_cache: t.Optional["BytecodeCache"] = missing,
+        indent_blocks: bool = missing,
     ) -> "Environment":
         """Create a new overlay environment that shares all the data with the
         current environment except for cache and the overridden attributes.
@@ -1179,6 +1190,7 @@ class Template:
         finalize: t.Optional[t.Callable[..., t.Any]] = None,
         autoescape: t.Union[bool, t.Callable[[t.Optional[str]], bool]] = False,
         enable_async: bool = False,
+        indent_blocks: bool = INDENT_BLOCKS,
     ) -> t.Any:  # it returns a `Template`, but this breaks the sphinx build...
         env = get_spontaneous_environment(
             cls.environment_class,  # type: ignore
@@ -1204,6 +1216,7 @@ class Template:
             False,
             None,
             enable_async,
+            indent_blocks,
         )
         return env.from_string(source, template_class=cls)
 

--- a/src/jinja2/ext.py
+++ b/src/jinja2/ext.py
@@ -846,6 +846,7 @@ def babel_extract(
         defaults.NEWLINE_SEQUENCE,
         getbool(options, "keep_trailing_newline", defaults.KEEP_TRAILING_NEWLINE),
         tuple(extensions),
+        indent_blocks=getbool(options, "indent_blocks", defaults.INDENT_BLOCKS),
         cache_size=0,
         auto_reload=False,
     )

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -852,3 +852,16 @@ def escape(s: t.Any) -> str:
         stacklevel=2,
     )
     return markupsafe.escape(s)
+
+
+def indent_to(text: str, indent: int) -> str:
+    """Indent or dedent a text to match the given indentation level
+    (excluding empty lines and spaces at the end of the text)."""
+    current_indent = re.match(' +', text)
+    change = indent - (current_indent.end() if current_indent else 0)
+    if not change:
+        return text
+    if change > 0:
+        return re.sub('(^|\n)(?!\n| *$)', f'\\1{" " * change}', text)
+    else:
+        return re.sub(f'(^|\n) {{0,{-change}}}', '\\1', text)


### PR DESCRIPTION
We're adding a new `indent_blocks` environment parameter which automatically indents/dedents block contents. This allows us to add indentation to code block contents (which helps readability) while making sure that the output is also indented nicely.

- fixes #178

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
