### PR TITLE
Add case_sensitive parameter to groupby() filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Unreleased
 -   Add ``items`` filter. :issue:`1561`
 -   Subscriptions (``[0]``, etc.) can be used after filters, tests, and
     calls when the environment is in async mode. :issue:`1573`
+-   The ``groupby`` filter is case-insensitive by default, matching
+    other comparison filters. Added the ``case_sensitive`` parameter to
+    control this. :issue:`1463`
 
 
 Version 3.0.3

--- a/tests/test_async_filters.py
+++ b/tests/test_async_filters.py
@@ -57,6 +57,26 @@ def test_groupby(env_async, items):
     ]
 
 
+@pytest.mark.parametrize(
+    ("case_sensitive", "expect"),
+    [
+        (False, "a: 1, 3\nb: 2\n"),
+        (True, "A: 3\na: 1\nb: 2\n"),
+    ],
+)
+def test_groupby_case(env_async, case_sensitive, expect):
+    tmpl = env_async.from_string(
+        "{% for k, vs in data|groupby('k', case_sensitive=cs) %}"
+        "{{ k }}: {{ vs|join(', ', attribute='v') }}\n"
+        "{% endfor %}"
+    )
+    out = tmpl.render(
+        data=[{"k": "a", "v": 1}, {"k": "b", "v": 2}, {"k": "A", "v": 3}],
+        cs=case_sensitive,
+    )
+    assert out == expect
+
+
 @mark_dualiter("items", lambda: [("a", 1), ("a", 2), ("b", 1)])
 def test_groupby_tuple_index(env_async, items):
     tmpl = env_async.from_string(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -619,6 +619,25 @@ class TestFilter:
         )
         assert out == "NY: emma, john\nWA: smith\n"
 
+    @pytest.mark.parametrize(
+        ("case_sensitive", "expect"),
+        [
+            (False, "a: 1, 3\nb: 2\n"),
+            (True, "A: 3\na: 1\nb: 2\n"),
+        ],
+    )
+    def test_groupby_case(self, env, case_sensitive, expect):
+        tmpl = env.from_string(
+            "{% for k, vs in data|groupby('k', case_sensitive=cs) %}"
+            "{{ k }}: {{ vs|join(', ', attribute='v') }}\n"
+            "{% endfor %}"
+        )
+        out = tmpl.render(
+            data=[{"k": "a", "v": 1}, {"k": "b", "v": 2}, {"k": "A", "v": 3}],
+            cs=case_sensitive,
+        )
+        assert out == expect
+
     def test_filtertag(self, env):
         tmpl = env.from_string(
             "{% filter upper|replace('FOO', 'foo') %}foobar{% endfilter %}"


### PR DESCRIPTION
This is a quick implementation test to add support for case-insensitive sorting inside the `groupby()` filter, intended to verify the approach.

Changes:

- Add `case_sensitive` parameter to `sync_do_groupby()`.
- Ignore case when sorting in `sync_do_groupby()` if `case_sensitive=False`

Open questions:

1. Is this approach correct?
2. Should async groupby (`async def do_groupby`) also be changed?
3. Should the default value for `case_sensitive` parameter be `False` for backwards compatibility, or `True` to align with the `sort()` filter behavior?

- fixes #1463 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
