### PR TITLE
replace http with https in docs

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -123,7 +123,7 @@ The usage of the ``i18n`` extension for template designers is covered in
 :ref:`the template documentation <i18n-in-templates>`.
 
 .. _gettext: https://docs.python.org/3/library/gettext.html
-.. _Babel: http://babel.pocoo.org/
+.. _Babel: https://babel.pocoo.org/
 
 
 Whitespace Trimming

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,4 +60,4 @@ These distributions will not be installed automatically.
 
 -   `Babel`_ provides translation support in templates.
 
-.. _Babel: http://babel.pocoo.org/
+.. _Babel: https://babel.pocoo.org/

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -21,7 +21,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )
 


### PR DESCRIPTION
Replace http:// with https:// in external links in docs.
\* This is a recreated PR due to conflict in rebasing in #1487 .

- fixes #1486