### PR TITLE
Template globals not accessible within imported macros

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Version 3.0.2
     names. :issue:`1452, 1453`
 -   Revert an unintended change that caused ``Undefined`` to act like
     ``StrictUndefined`` for the ``in`` operator. :issue:`1448`
+-   Imported macros have access to the current template globals in async
+    environments. :issue:`1494`
 
 
 Version 3.0.1

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1090,10 +1090,8 @@ class CodeGenerator(NodeVisitor):
             self.write(
                 f"{f_name}(context.get_all(), True, {self.dump_local_context(frame)})"
             )
-        elif self.environment.is_async:
-            self.write("_get_default_module_async()")
         else:
-            self.write("_get_default_module(context)")
+            self.write(f"_get_default_module{self.choose_async('_async')}(context)")
 
     def visit_Import(self, node: nodes.Import, frame: Frame) -> None:
         """Visit regular imports."""

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -189,6 +189,29 @@ class TestAsyncImports:
         assert m.variable == 42
         assert not hasattr(m, "notthere")
 
+    def test_import_with_globals(self, test_env_async):
+        t = test_env_async.from_string(
+            '{% import "module" as m %}{{ m.test() }}', globals={"foo": 42}
+        )
+        assert t.render() == "[42|23]"
+
+        t = test_env_async.from_string('{% import "module" as m %}{{ m.test() }}')
+        assert t.render() == "[|23]"
+
+    def test_import_with_globals_override(self, test_env_async):
+        t = test_env_async.from_string(
+            '{% set foo = 41 %}{% import "module" as m %}{{ m.test() }}',
+            globals={"foo": 42},
+        )
+        assert t.render() == "[42|23]"
+
+    def test_from_import_with_globals(self, test_env_async):
+        t = test_env_async.from_string(
+            '{% from "module" import test %}{{ test() }}',
+            globals={"foo": 42},
+        )
+        assert t.render() == "[42|23]"
+
 
 class TestAsyncIncludes:
     def test_context_include(self, test_env_async):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -99,45 +99,27 @@ class TestImports:
             t.render()
 
     def test_import_with_globals(self, test_env):
-        env = Environment(
-            loader=DictLoader(
-                {
-                    "macros": "{% macro test() %}foo: {{ foo }}{% endmacro %}",
-                    "test": "{% import 'macros' as m %}{{ m.test() }}",
-                    "test1": "{% import 'macros' as m %}{{ m.test() }}",
-                }
-            )
+        t = test_env.from_string(
+            '{% import "module" as m %}{{ m.test() }}', globals={"foo": 42}
         )
-        tmpl = env.get_template("test", globals={"foo": "bar"})
-        assert tmpl.render() == "foo: bar"
+        assert t.render() == "[42|23]"
 
-        tmpl = env.get_template("test1")
-        assert tmpl.render() == "foo: "
+        t = test_env.from_string('{% import "module" as m %}{{ m.test() }}')
+        assert t.render() == "[|23]"
 
     def test_import_with_globals_override(self, test_env):
-        env = Environment(
-            loader=DictLoader(
-                {
-                    "macros": "{% set foo = '42' %}{% macro test() %}"
-                    "foo: {{ foo }}{% endmacro %}",
-                    "test": "{% from 'macros' import test %}{{ test() }}",
-                }
-            )
+        t = test_env.from_string(
+            '{% set foo = 41 %}{% import "module" as m %}{{ m.test() }}',
+            globals={"foo": 42},
         )
-        tmpl = env.get_template("test", globals={"foo": "bar"})
-        assert tmpl.render() == "foo: 42"
+        assert t.render() == "[42|23]"
 
     def test_from_import_with_globals(self, test_env):
-        env = Environment(
-            loader=DictLoader(
-                {
-                    "macros": "{% macro testing() %}foo: {{ foo }}{% endmacro %}",
-                    "test": "{% from 'macros' import testing %}{{ testing() }}",
-                }
-            )
+        t = test_env.from_string(
+            '{% from "module" import test %}{{ test() }}',
+            globals={"foo": 42},
         )
-        tmpl = env.get_template("test", globals={"foo": "bar"})
-        assert tmpl.render() == "foo: bar"
+        assert t.render() == "[42|23]"
 
 
 class TestIncludes:


### PR DESCRIPTION
* Pass context to `_get_default_module_async` to provide template globals to imports.
* Added tests.
* Refactored existing and new import global tests to use existing fixtures.
* Copied `CHANGES.rst` entry from #1241 since it best described the fix.

Relevant issues and PRs:

- One-liner, relies on the fix in PR #1241
- fixes #1494

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
