### PR TITLE
ignore internal asyncio warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,8 @@ babel.extractors =
 testpaths = tests
 filterwarnings =
     error
+    # Python 3.9 raises a deprecation from internal asyncio code.
+    ignore:The loop argument:DeprecationWarning:asyncio[.]base_events:542
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
From https://github.com/pallets/jinja/pull/1495#issuecomment-923165800, seems that CPython forgot to address some deprecations to the asyncio API internally, and it's now causing issues in user code that doesn't appear to do anything wrong. Added an ignore for the message.