### PR TITLE
omit curdir from PackageLoader root path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Version 3.0.2
     ``StrictUndefined`` for the ``in`` operator. :issue:`1448`
 -   Imported macros have access to the current template globals in async
     environments. :issue:`1494`
+-   ``PackageLoader`` will not include a current directory (.) path
+    segment. This allows loading templates from the root of a zip
+    import. :issue:`1467`
 
 
 Version 3.0.1

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -270,12 +270,14 @@ class PackageLoader(BaseLoader):
         package_path: "str" = "templates",
         encoding: str = "utf-8",
     ) -> None:
+        package_path = os.path.normpath(package_path).rstrip(os.path.sep)
+
+        # normpath preserves ".", which isn't valid in zip paths.
         if package_path == os.path.curdir:
             package_path = ""
         elif package_path[:2] == os.path.curdir + os.path.sep:
             package_path = package_path[2:]
 
-        package_path = os.path.normpath(package_path).rstrip(os.path.sep)
         self.package_path = package_path
         self.package_name = package_name
         self.encoding = encoding

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -339,6 +339,17 @@ def test_package_zip_list(package_zip_loader):
     assert package_zip_loader.list_templates() == ["foo/test.html", "test.html"]
 
 
+@pytest.mark.parametrize("package_path", ["", ".", "./"])
+def test_package_zip_omit_curdir(package_zip_loader, package_path):
+    """PackageLoader should not add or include "." or "./" in the root
+    path, it is invalid in zip paths.
+    """
+    loader = PackageLoader("t_pack", package_path)
+    assert loader.package_path == ""
+    source, _, _ = loader.get_source(None, "templates/foo/test.html")
+    assert source.rstrip() == "FOO"
+
+
 def test_pep_451_import_hook():
     class ImportHook(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         def find_spec(self, name, path=None, target=None):


### PR DESCRIPTION
`PackageLoader` removes the current directory path segment *after* calling `normpath`. This fixes compatibility with loading from the root of zip imports.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1467 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
