### PR TITLE
Reduce async overhead due to auto_await

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     :issue:`1535`
 -   Fix how the native environment treats leading and trailing spaces
     when parsing values on Python 3.10. :pr:`1537`
+-   Improve async performance by avoiding checks for common types.
+    :issue:`1514`
 
 
 Version 3.0.2

--- a/src/jinja2/async_utils.py
+++ b/src/jinja2/async_utils.py
@@ -44,7 +44,14 @@ def async_variant(normal_func):  # type: ignore
     return decorator
 
 
+_common_primitives = {int, float, bool, str, list, dict, tuple, type(None)}
+
+
 async def auto_await(value: t.Union[t.Awaitable["V"], "V"]) -> "V":
+    # Avoid a costly call to isawaitable
+    if type(value) in _common_primitives:
+        return t.cast("V", value)
+
     if inspect.isawaitable(value):
         return await t.cast("t.Awaitable[V]", value)
 


### PR DESCRIPTION
The types of most rendered values tend to be primitives, so we can avoid a costly call to `inspect.isawaitable` for them. This improves performance by at least 15% in my tests.

- fixes #1514

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
