### PR TITLE
Use `object.__hash__` for `Node.__hash__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
     when parsing values on Python 3.10. :pr:`1537`
 -   Improve async performance by avoiding checks for common types.
     :issue:`1514`
+-   Revert change to ``hash(Node)`` behavior. Nodes are hashed by id
+    again :issue:`1521`
 
 
 Version 3.0.2

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -241,8 +241,7 @@ class Node(metaclass=NodeType):
 
         return tuple(self.iter_fields()) == tuple(other.iter_fields())
 
-    def __hash__(self) -> int:
-        return hash(tuple(self.iter_fields()))
+    __hash__ = object.__hash__
 
     def __repr__(self) -> str:
         args_str = ", ".join(f"{a}={getattr(self, a, None)!r}" for a in self.fields)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,3 @@
+def test_template_hash(env):
+    template = env.parse("hash test")
+    hash(template)


### PR DESCRIPTION
This fixes a regression in commit 60293416db69782fd048a7820667afa4ae7c423b that
changed the `__hash__` implementation of Node from the default pointer
hash, to a hash based on the node fields.

Since these fields contain list objects, they are not hashable, making
every call to `Node.__hash__` fail.

This breaks some third-party usage such as in `django-compressor`
(See: https://github.com/django-compressor/django-compressor/issues/1060)

This change reverts the hash method back to using `object.__hash__` as
the hash implementation.

- fixes #1521


Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
