### PR TITLE
Tests: Make "Traceback did not match" an actual f-string

### DIFF
--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -25,7 +25,7 @@ class TestDebug:
         m = re.search(expected_tb.strip(), "".join(tb))
         assert (
             m is not None
-        ), "Traceback did not match:\n\n{''.join(tb)}\nexpected:\n{expected_tb}"
+        ), f"Traceback did not match:\n\n{''.join(tb)}\nexpected:\n{expected_tb}"
 
     def test_runtime_error(self, fs_env):
         def test():


### PR DESCRIPTION
Otherwise the failure looks like this:

    >       assert (
                m is not None
            ), "Traceback did not match:\n\n{''.join(tb)}\nexpected:\n{expected_tb}"
    E       AssertionError: Traceback did not match:
    E         
    E         {''.join(tb)}
    E         expected:
    E         {expected_tb}
    E       assert None is not None

I have not done the checklist thing, as most of it does not apply to fixing a representation of a failed test.
