### PR TITLE
Tests: Adapt expected traceback regexes for Python 3.11.0a1

### DIFF
--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -36,9 +36,11 @@ class TestDebug:
             test,
             r"""
   File ".*?broken.html", line 2, in (top-level template code|<module>)
-    \{\{ fail\(\) \}\}
+    \{\{ fail\(\) \}\}(
+    \^{12})?
   File ".*debug?.pyc?", line \d+, in <lambda>
-    tmpl\.render\(fail=lambda: 1 / 0\)
+    tmpl\.render\(fail=lambda: 1 / 0\)(
+                             ~~\^~~)?
 ZeroDivisionError: (int(eger)? )?division (or modulo )?by zero
 """,
         )
@@ -66,7 +68,8 @@ to be closed is 'for'.
             test,
             r"""
   File ".*debug.pyc?", line \d+, in test
-    raise TemplateSyntaxError\("wtf", 42\)
+    raise TemplateSyntaxError\("wtf", 42\)(
+    \^{36})?
 (jinja2\.exceptions\.)?TemplateSyntaxError: wtf
   line 42""",
         )


### PR DESCRIPTION
Fixes https://github.com/pallets/jinja/issues/1526

Before:

      File ".../broken.html", line 2, in <module>
        {{ fail() }}
      File ".../test_debug.py", line 32, in <lambda>
        tmpl.render(fail=lambda: 1 / 0)
    ZeroDivisionError: division by zero

After:

      File ".../broken.html", line 2, in <module>
        {{ fail() }}
        ^^^^^^^^^^^^
      File ".../test_debug.py", line 32, in <lambda>
        tmpl.render(fail=lambda: 1 / 0)
                                 ~~^~~
    ZeroDivisionError: division by zero

<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] ~Add tests that demonstrate the correct behavior of the change~ this is in tests
- [x] ~Add or update relevant docs, in the docs folder and in code~ this is in tests and too early to declare Python 3.11 support in docs
- [x] ~Add an entry in `CHANGES.rst` summarizing the change and linking to the issue~ added but then removed per review
- [x] ~Add `.. versionchanged::` entries in any relevant code docs~ this is in tests
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
