### PR TITLE
simplify CodeType rewriting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: jinja2
 
+Version 3.0.3
+-------------
+
+Unreleased
+
+-   Fix traceback rewriting internals for Python 3.10 and 3.11.
+    :issue:`1535`
+
+
 Version 3.0.2
 -------------
 


### PR DESCRIPTION
Use `CodeType.replace` to greatly simplify replacing `co_name` on Python 3.8+. Only Python 3.7 needs to use all positional arguments. No longer need to replace `co_filename`, it's already replaced by `compile`. Remove `try/except` block to avoid hiding errors with this code in the future; need to test that modern GAE works with this.

fixes #1334 