### PR TITLE
PackageLoader works with single module file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
     :issue:`1514`
 -   Revert change to ``hash(Node)`` behavior. Nodes are hashed by id
     again :issue:`1521`
+-   ``PackageLoader`` works when the package is a single module file.
+    :issue:`1512`
 
 
 Version 3.0.2

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -297,10 +297,18 @@ class PackageLoader(BaseLoader):
             self._archive = loader.archive
             pkgdir = next(iter(spec.submodule_search_locations))  # type: ignore
             template_root = os.path.join(pkgdir, package_path)
-        elif spec.submodule_search_locations:
-            # This will be one element for regular packages and multiple
-            # for namespace packages.
-            for root in spec.submodule_search_locations:
+        else:
+            roots: t.List[str] = []
+
+            # One element for regular packages, multiple for namespace
+            # packages, or None for single module file.
+            if spec.submodule_search_locations:
+                roots.extend(spec.submodule_search_locations)
+            # A single module file, use the parent directory instead.
+            elif spec.origin is not None:
+                roots.append(os.path.dirname(spec.origin))
+
+            for root in roots:
                 root = os.path.join(root, package_path)
 
                 if os.path.isdir(root):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -314,6 +314,28 @@ def test_package_dir_list(package_dir_loader):
 
 
 @pytest.fixture()
+def package_file_loader(monkeypatch):
+    monkeypatch.syspath_prepend(Path(__file__).parent / "res")
+    return PackageLoader("__init__")
+
+
+@pytest.mark.parametrize(
+    ("template", "expect"), [("foo/test.html", "FOO"), ("test.html", "BAR")]
+)
+def test_package_file_source(package_file_loader, template, expect):
+    source, name, up_to_date = package_file_loader.get_source(None, template)
+    assert source.rstrip() == expect
+    assert name.endswith(os.path.join(*split_template_path(template)))
+    assert up_to_date()
+
+
+def test_package_file_list(package_file_loader):
+    templates = package_file_loader.list_templates()
+    assert "foo/test.html" in templates
+    assert "test.html" in templates
+
+
+@pytest.fixture()
 def package_zip_loader(monkeypatch):
     package_zip = (Path(__file__) / ".." / "res" / "package.zip").resolve()
     monkeypatch.syspath_prepend(package_zip)


### PR DESCRIPTION
If the package is actually a single module file, `spec.submodule_search_locations` is `None`. `spec.origin` refers to the imported file, use the parent directory in that case. fixes #1512