### PR TITLE
remove deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Unreleased
 -   Remove previously deprecated code. :pr:`1544`
 
     -   ``WithExtension`` and ``AutoEscapeExtension`` are built-in now.
+    -   ``contextfilter`` and ``contextfunction`` are replaced by
+        ``pass_context``. ``evalcontextfilter`` and
+        ``evalcontextfunction`` are replaced by ``pass_eval_context``.
+        ``environmentfilter`` and ``environmentfunction`` are replaced
+        by ``pass_environment``.
 
 
 Version 3.0.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
         ``evalcontextfunction`` are replaced by ``pass_eval_context``.
         ``environmentfilter`` and ``environmentfunction`` are replaced
         by ``pass_environment``.
+    -   ``Markup`` and ``escape`` should be imported from MarkupSafe.
 
 
 Version 3.0.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Version 3.1.0
 
 Unreleased
 
+-   Drop support for Python 3.6. :pr:`1534`
+-   Remove previously deprecated code. :pr:`1544`
+
+    -   ``WithExtension`` and ``AutoEscapeExtension`` are built-in now.
+
 
 Version 3.0.3
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Unreleased
     -   Legacy resolve mode for ``Context`` subclasses is no longer
         supported. Override ``resolve_or_missing`` instead of
         ``resolve``.
+    -   ``unicode_urlencode`` is renamed to ``url_quote``.
 
 
 Version 3.0.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Unreleased
     -   ``Markup`` and ``escape`` should be imported from MarkupSafe.
     -   Compiled templates from very old Jinja versions may need to be
         recompiled.
+    -   Legacy resolve mode for ``Context`` subclasses is no longer
+        supported. Override ``resolve_or_missing`` instead of
+        ``resolve``.
 
 
 Version 3.0.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Unreleased
         ``environmentfilter`` and ``environmentfunction`` are replaced
         by ``pass_environment``.
     -   ``Markup`` and ``escape`` should be imported from MarkupSafe.
+    -   Compiled templates from very old Jinja versions may need to be
+        recompiled.
 
 
 Version 3.0.3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -597,18 +597,6 @@ functions to a Jinja environment.
 
 .. autofunction:: jinja2.pass_environment
 
-.. autofunction:: jinja2.contextfilter
-
-.. autofunction:: jinja2.evalcontextfilter
-
-.. autofunction:: jinja2.environmentfilter
-
-.. autofunction:: jinja2.contextfunction
-
-.. autofunction:: jinja2.evalcontextfunction
-
-.. autofunction:: jinja2.environmentfunction
-
 .. autofunction:: jinja2.clear_caches
 
 .. autofunction:: jinja2.is_undefined

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ attrs==21.2.0
     # via pytest
 babel==2.9.1
     # via sphinx
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 certifi==2021.10.8
     # via requests
@@ -28,15 +28,15 @@ filelock==3.3.2
     # via
     #   tox
     #   virtualenv
-identify==2.3.3
+identify==2.3.5
     # via pre-commit
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
@@ -52,7 +52,7 @@ packaging==21.2
     #   pytest
     #   sphinx
     #   tox
-pallets-sphinx-themes==2.0.1
+pallets-sphinx-themes==2.0.2
     # via -r requirements/docs.in
 pep517==0.12.0
     # via pip-tools
@@ -88,7 +88,7 @@ six==1.16.0
     #   virtualenv
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.0
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,9 +16,9 @@ docutils==0.17.1
     # via sphinx
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
@@ -26,7 +26,7 @@ packaging==21.2
     # via
     #   pallets-sphinx-themes
     #   sphinx
-pallets-sphinx-themes==2.0.1
+pallets-sphinx-themes==2.0.2
     # via -r requirements/docs.in
 pygments==2.10.0
     # via sphinx
@@ -38,7 +38,7 @@ requests==2.26.0
     # via sphinx
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.0
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -14,9 +14,6 @@ from .exceptions import TemplateRuntimeError as TemplateRuntimeError
 from .exceptions import TemplatesNotFound as TemplatesNotFound
 from .exceptions import TemplateSyntaxError as TemplateSyntaxError
 from .exceptions import UndefinedError as UndefinedError
-from .filters import contextfilter
-from .filters import environmentfilter
-from .filters import evalcontextfilter
 from .loaders import BaseLoader as BaseLoader
 from .loaders import ChoiceLoader as ChoiceLoader
 from .loaders import DictLoader as DictLoader
@@ -31,10 +28,7 @@ from .runtime import make_logging_undefined as make_logging_undefined
 from .runtime import StrictUndefined as StrictUndefined
 from .runtime import Undefined as Undefined
 from .utils import clear_caches as clear_caches
-from .utils import contextfunction
-from .utils import environmentfunction
 from .utils import escape
-from .utils import evalcontextfunction
 from .utils import is_undefined as is_undefined
 from .utils import Markup
 from .utils import pass_context as pass_context

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -28,9 +28,7 @@ from .runtime import make_logging_undefined as make_logging_undefined
 from .runtime import StrictUndefined as StrictUndefined
 from .runtime import Undefined as Undefined
 from .utils import clear_caches as clear_caches
-from .utils import escape
 from .utils import is_undefined as is_undefined
-from .utils import Markup
 from .utils import pass_context as pass_context
 from .utils import pass_environment as pass_environment
 from .utils import pass_eval_context as pass_eval_context

--- a/src/jinja2/ext.py
+++ b/src/jinja2/ext.py
@@ -2,7 +2,6 @@
 import pprint
 import re
 import typing as t
-import warnings
 
 from markupsafe import Markup
 
@@ -597,28 +596,6 @@ class LoopControlExtension(Extension):
         return nodes.Continue(lineno=token.lineno)
 
 
-class WithExtension(Extension):
-    def __init__(self, environment: Environment) -> None:
-        super().__init__(environment)
-        warnings.warn(
-            "The 'with' extension is deprecated and will be removed in"
-            " Jinja 3.1. This is built in now.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-
-class AutoEscapeExtension(Extension):
-    def __init__(self, environment: Environment) -> None:
-        super().__init__(environment)
-        warnings.warn(
-            "The 'autoescape' extension is deprecated and will be"
-            " removed in Jinja 3.1. This is built in now.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-
 class DebugExtension(Extension):
     """A ``{% debug %}`` tag that dumps the available variables,
     filters, and tests.
@@ -874,6 +851,4 @@ def babel_extract(
 i18n = InternationalizationExtension
 do = ExprStmtExtension
 loopcontrols = LoopControlExtension
-with_ = WithExtension
-autoescape = AutoEscapeExtension
 debug = DebugExtension

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -4,7 +4,6 @@ import random
 import re
 import typing
 import typing as t
-import warnings
 from collections import abc
 from itertools import chain
 from itertools import groupby
@@ -42,58 +41,6 @@ if t.TYPE_CHECKING:
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 K = t.TypeVar("K")
 V = t.TypeVar("V")
-
-
-def contextfilter(f: F) -> F:
-    """Pass the context as the first argument to the decorated function.
-
-    .. deprecated:: 3.0
-        Will be removed in Jinja 3.1. Use :func:`~jinja2.pass_context`
-        instead.
-    """
-    warnings.warn(
-        "'contextfilter' is renamed to 'pass_context', the old name"
-        " will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return pass_context(f)
-
-
-def evalcontextfilter(f: F) -> F:
-    """Pass the eval context as the first argument to the decorated
-    function.
-
-    .. deprecated:: 3.0
-        Will be removed in Jinja 3.1. Use
-        :func:`~jinja2.pass_eval_context` instead.
-
-    .. versionadded:: 2.4
-    """
-    warnings.warn(
-        "'evalcontextfilter' is renamed to 'pass_eval_context', the old"
-        " name will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return pass_eval_context(f)
-
-
-def environmentfilter(f: F) -> F:
-    """Pass the environment as the first argument to the decorated
-    function.
-
-    .. deprecated:: 3.0
-        Will be removed in Jinja 3.1. Use
-        :func:`~jinja2.pass_environment` instead.
-    """
-    warnings.warn(
-        "'environmentfilter' is renamed to 'pass_environment', the old"
-        " name will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return pass_environment(f)
 
 
 def ignore_case(value: V) -> V:

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -161,27 +161,6 @@ class Context:
     :class:`Undefined` object for missing variables.
     """
 
-    _legacy_resolve_mode: t.ClassVar[bool] = False
-
-    def __init_subclass__(cls) -> None:
-        if "resolve_or_missing" in cls.__dict__:
-            # If the subclass overrides resolve_or_missing it opts in to
-            # modern mode no matter what.
-            cls._legacy_resolve_mode = False
-        elif "resolve" in cls.__dict__ or cls._legacy_resolve_mode:
-            # If the subclass overrides resolve, or if its base is
-            # already in legacy mode, warn about legacy behavior.
-            import warnings
-
-            warnings.warn(
-                "Overriding 'resolve' is deprecated and will not have"
-                " the expected behavior in Jinja 3.1. Override"
-                " 'resolve_or_missing' instead ",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            cls._legacy_resolve_mode = True
-
     def __init__(
         self,
         environment: "Environment",
@@ -239,15 +218,6 @@ class Context:
 
         :param key: The variable name to look up.
         """
-        if self._legacy_resolve_mode:
-            if key in self.vars:
-                return self.vars[key]
-
-            if key in self.parent:
-                return self.parent[key]
-
-            return self.environment.undefined(name=key)
-
         rv = self.resolve_or_missing(key)
 
         if rv is missing:
@@ -265,14 +235,6 @@ class Context:
 
         :param key: The variable name to look up.
         """
-        if self._legacy_resolve_mode:
-            rv = self.resolve(key)
-
-            if isinstance(rv, Undefined):
-                return missing
-
-            return rv
-
         if key in self.vars:
             return self.vars[key]
 

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -89,18 +89,6 @@ def str_join(seq: t.Iterable[t.Any]) -> str:
     return concat(map(str, seq))
 
 
-def unicode_join(seq: t.Iterable[t.Any]) -> str:
-    import warnings
-
-    warnings.warn(
-        "This template must be recompiled with at least Jinja 3.0, or"
-        " it will fail in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return str_join(seq)
-
-
 def new_context(
     environment: "Environment",
     template_name: t.Optional[str],

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -417,18 +417,6 @@ def url_quote(obj: t.Any, charset: str = "utf-8", for_qs: bool = False) -> str:
     return rv
 
 
-def unicode_urlencode(obj: t.Any, charset: str = "utf-8", for_qs: bool = False) -> str:
-    import warnings
-
-    warnings.warn(
-        "'unicode_urlencode' has been renamed to 'url_quote'. The old"
-        " name will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return url_quote(obj, charset=charset, for_qs=for_qs)
-
-
 @abc.MutableMapping.register
 class LRUCache:
     """A simple LRU Cache implementation."""

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -84,72 +84,7 @@ class _PassArg(enum.Enum):
         if hasattr(obj, "jinja_pass_arg"):
             return obj.jinja_pass_arg  # type: ignore
 
-        for prefix in "context", "eval_context", "environment":
-            squashed = prefix.replace("_", "")
-
-            for name in f"{squashed}function", f"{squashed}filter":
-                if getattr(obj, name, False) is True:
-                    warnings.warn(
-                        f"{name!r} is deprecated and will stop working"
-                        f" in Jinja 3.1. Use 'pass_{prefix}' instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                    return cls[prefix]
-
         return None
-
-
-def contextfunction(f: F) -> F:
-    """Pass the context as the first argument to the decorated function.
-
-    .. deprecated:: 3.0
-        Will be removed in Jinja 3.1. Use :func:`~jinja2.pass_context`
-        instead.
-    """
-    warnings.warn(
-        "'contextfunction' is renamed to 'pass_context', the old name"
-        " will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return pass_context(f)
-
-
-def evalcontextfunction(f: F) -> F:
-    """Pass the eval context as the first argument to the decorated
-    function.
-
-    .. deprecated:: 3.0
-        Will be removed in Jinja 3.1. Use
-        :func:`~jinja2.pass_eval_context` instead.
-
-    .. versionadded:: 2.4
-    """
-    warnings.warn(
-        "'evalcontextfunction' is renamed to 'pass_eval_context', the"
-        " old name will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return pass_eval_context(f)
-
-
-def environmentfunction(f: F) -> F:
-    """Pass the environment as the first argument to the decorated
-    function.
-
-    .. deprecated:: 3.0
-        Will be removed in Jinja 3.1. Use
-        :func:`~jinja2.pass_environment` instead.
-    """
-    warnings.warn(
-        "'environmentfunction' is renamed to 'pass_environment', the"
-        " old name will be removed in Jinja 3.1.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return pass_environment(f)
 
 
 def internalcode(f: F) -> F:

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 import typing as t
-import warnings
 from collections import abc
 from collections import deque
 from random import choice
@@ -766,24 +765,3 @@ class Namespace:
 
     def __repr__(self) -> str:
         return f"<Namespace {self.__attrs!r}>"
-
-
-class Markup(markupsafe.Markup):
-    def __new__(cls, base="", encoding=None, errors="strict"):  # type: ignore
-        warnings.warn(
-            "'jinja2.Markup' is deprecated and will be removed in Jinja"
-            " 3.1. Import 'markupsafe.Markup' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return super().__new__(cls, base, encoding, errors)
-
-
-def escape(s: t.Any) -> str:
-    warnings.warn(
-        "'jinja2.escape' is deprecated and will be removed in Jinja"
-        " 3.1. Import 'markupsafe.escape' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return markupsafe.escape(s)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -591,23 +591,6 @@ class TestBug:
         env = MyEnvironment(loader=loader)
         assert env.get_template("test").render(foobar="test") == "test"
 
-    def test_legacy_custom_context(self, env):
-        from jinja2.runtime import Context, missing
-
-        with pytest.deprecated_call():
-
-            class MyContext(Context):
-                def resolve(self, name):
-                    if name == "foo":
-                        return 42
-                    return super().resolve(name)
-
-        x = MyContext(env, parent={"bar": 23}, name="foo", blocks={})
-        assert x._legacy_resolve_mode
-        assert x.resolve_or_missing("foo") == 42
-        assert x.resolve_or_missing("bar") == 23
-        assert x.resolve_or_missing("baz") is missing
-
     def test_recursive_loop_bug(self, env):
         tmpl = env.from_string(
             "{%- for value in values recursive %}1{% else %}0{% endfor -%}"


### PR DESCRIPTION
* `WithExtension` and `AutoEscapeExtension` are built-in.
* `contextfilter`, `evalcontextfilter`, `environmentfilter`, `contextfunction`, `evalcontextfunction`, and `environmentfunction` have been replaced by `pass_context`, `pass_eval_context`, and `pass_environment`.
* Remove old `unicode_join` runtime function. Very old compiled templates may need to be recompiled.
* `Context` subclasses must override `resolve_or_missing` instead of `resolve`, legacy mode is removed.
* `unicode_urlencode` renamed to `url_quote`.
* Update Pallets-Sphinx-Themes to use new `pass_context`.