### PR TITLE
Update legacy doctype in docs/tricks

### DIFF
--- a/docs/tricks.rst
+++ b/docs/tricks.rst
@@ -26,7 +26,7 @@ basic skeleton is added to the file so that if it's indeed rendered with
 `standalone` set to `True` a very basic HTML skeleton is added::
 
     {% if not standalone %}{% extends 'default.html' %}{% endif -%}
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+    <!DOCTYPE html>
     <title>{% block title %}The Page Title{% endblock %}</title>
     <link rel="stylesheet" href="style.css" type="text/css">
     {% block body %}


### PR DESCRIPTION
HTML 5 is the future, now.
