### PR TITLE
2.11.x | Fix range for MarkupSafe to stay below 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-    install_requires=["MarkupSafe>=0.23"],
+    install_requires=["MarkupSafe >= 0.23, < 2.1"],
     extras_require={"i18n": ["Babel>=0.8"]},
     entry_points={"babel.extractors": ["jinja2 = jinja2.ext:babel_extract[i18n]"]},
 )


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->
MarkupSafe 2.1.0 has a breaking change
> Remove soft_unicode, which was previously deprecated. Use soft_str instead. [#261](https://github.com/pallets/markupsafe/pull/261)

Jinja 2.11.x requires MarkupSafe >= 0.23. This allows it to pick up the latest version of MarkupSafe with the breaking change. This PR fixes the range of MarkupSafe to stay below 2.1.0.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1587
<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
