### PR TITLE
Fix MarkupSafe Version (Latest Version has breaking changes)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Jinja2",
-    install_requires=["MarkupSafe>=2.0"],
+    install_requires=["MarkupSafe==2.0.1"],
     extras_require={"i18n": ["Babel>=2.7"]},
 )


### PR DESCRIPTION
Latest Installation of Jinja 2 results in breaking many CI/CD Apps with the error 
ImportError: cannot import name 'soft_unicode' from 'markupsafe'


hardcoding markup safe version to fix this issue
