### PR TITLE
Fix pickleability of filters decorated with @async_variant

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Unreleased
     ``{% trans "title" %}``. :issue:`1430`
 -   Update valid identifier characters from Python 3.6 to 3.7.
     :pr:`1571`
+-   Filters and tests decorated with ``@async_variant`` are pickleable.
+    :pr:`1612`
 
 
 Version 3.0.3

--- a/src/jinja2/async_utils.py
+++ b/src/jinja2/async_utils.py
@@ -1,5 +1,6 @@
 import inspect
 import typing as t
+from functools import WRAPPER_ASSIGNMENTS
 from functools import wraps
 
 from .utils import _PassArg
@@ -23,7 +24,15 @@ def async_variant(normal_func):  # type: ignore
             def is_async(args: t.Any) -> bool:
                 return t.cast(bool, args[0].environment.is_async)
 
-        @wraps(normal_func)
+        # Take the doc and annotations from the sync function, but the
+        # name from the async function. Pallets-Sphinx-Themes
+        # build_function_directive expects __wrapped__ to point to the
+        # sync function.
+        async_func_attrs = ("__module__", "__name__", "__qualname__")
+        normal_func_attrs = tuple(set(WRAPPER_ASSIGNMENTS).difference(async_func_attrs))
+
+        @wraps(normal_func, assigned=normal_func_attrs)
+        @wraps(async_func, assigned=async_func_attrs, updated=())
         def wrapper(*args, **kwargs):  # type: ignore
             b = is_async(args)
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,6 @@
+import pickle
+
+
+def test_environment(env):
+    env = pickle.loads(pickle.dumps(env))
+    assert env.from_string("x={{ x }}").render(x=42) == "x=42"


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1612 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [n/a] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [n/a] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
