### PR TITLE
add parens around `auto_await` for filters and calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Unreleased
 -   Filters and tests decorated with ``@async_variant`` are pickleable.
     :pr:`1612`
 -   Add ``items`` filter. :issue:`1561`
+-   Subscriptions (``[0]``, etc.) can be used after filters, tests, and
+    calls when the environment is in async mode. :issue:`1573`
 
 
 Version 3.0.3

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1755,7 +1755,7 @@ class CodeGenerator(NodeVisitor):
         self, node: t.Union[nodes.Filter, nodes.Test], frame: Frame, is_filter: bool
     ) -> t.Iterator[None]:
         if self.environment.is_async:
-            self.write("await auto_await(")
+            self.write("(await auto_await(")
 
         if is_filter:
             self.write(f"{self.filters[node.name]}(")
@@ -1790,7 +1790,7 @@ class CodeGenerator(NodeVisitor):
         self.write(")")
 
         if self.environment.is_async:
-            self.write(")")
+            self.write("))")
 
     @optimizeconst
     def visit_Filter(self, node: nodes.Filter, frame: Frame) -> None:
@@ -1842,7 +1842,7 @@ class CodeGenerator(NodeVisitor):
         self, node: nodes.Call, frame: Frame, forward_caller: bool = False
     ) -> None:
         if self.environment.is_async:
-            self.write("await auto_await(")
+            self.write("(await auto_await(")
         if self.environment.sandboxed:
             self.write("environment.call(context, ")
         else:
@@ -1858,7 +1858,7 @@ class CodeGenerator(NodeVisitor):
         self.signature(node, frame, extra_kwargs)
         self.write(")")
         if self.environment.is_async:
-            self.write(")")
+            self.write("))")
 
     def visit_Keyword(self, node: nodes.Keyword, frame: Frame) -> None:
         self.write(node.key + "=")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -642,3 +642,19 @@ def test_native_list_async(async_native_env):
         assert rv == [0, 1, 2]
 
     asyncio.run(_test())
+
+
+def test_getitem_after_filter():
+    env = Environment(enable_async=True)
+    env.filters["add_each"] = lambda v, x: [i + x for i in v]
+    t = env.from_string("{{ (a|add_each(2))[1:] }}")
+    out = t.render(a=range(3))
+    assert out == "[3, 4]"
+
+
+def test_getitem_after_call():
+    env = Environment(enable_async=True)
+    env.globals["add_each"] = lambda v, x: [i + x for i in v]
+    t = env.from_string("{{ add_each(a, 2)[1:] }}")
+    out = t.render(a=range(3))
+    assert out == "[3, 4]"


### PR DESCRIPTION
The compiler doesn't add parentheses around the `await auto_await(...)` expression when visiting filters and tests. If a subscription is used after the call, the compiler will produce code that tries to subscript the coroutine instead of the awaited result. This adds surrounding parentheses, which matches other similar situations.

fixes #1573 