### PR TITLE
use `posixpath.join` when loading template names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Unreleased
 -   The ``groupby`` filter is case-insensitive by default, matching
     other comparison filters. Added the ``case_sensitive`` parameter to
     control this. :issue:`1463`
+-   Windows drive-relative path segments in template names will not
+    result in ``FileSystemLoader`` and ``PackageLoader`` loading from
+    drive-relative paths. :pr:`1621`
 
 
 Version 3.0.3

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,6 +3,7 @@ import importlib.machinery
 import importlib.util
 import os
 import platform
+import posixpath
 import shutil
 import sys
 import tempfile
@@ -303,7 +304,7 @@ def package_dir_loader(monkeypatch):
 def test_package_dir_source(package_dir_loader, template, expect):
     source, name, up_to_date = package_dir_loader.get_source(None, template)
     assert source.rstrip() == expect
-    assert name.endswith(os.path.join(*split_template_path(template)))
+    assert name.endswith(posixpath.join(*split_template_path(template)))
     assert up_to_date()
 
 
@@ -325,7 +326,7 @@ def package_file_loader(monkeypatch):
 def test_package_file_source(package_file_loader, template, expect):
     source, name, up_to_date = package_file_loader.get_source(None, template)
     assert source.rstrip() == expect
-    assert name.endswith(os.path.join(*split_template_path(template)))
+    assert name.endswith(posixpath.join(*split_template_path(template)))
     assert up_to_date()
 
 
@@ -348,7 +349,7 @@ def package_zip_loader(monkeypatch):
 def test_package_zip_source(package_zip_loader, template, expect):
     source, name, up_to_date = package_zip_loader.get_source(None, template)
     assert source.rstrip() == expect
-    assert name.endswith(os.path.join(*split_template_path(template)))
+    assert name.endswith(posixpath.join(*split_template_path(template)))
     assert up_to_date is None
 
 


### PR DESCRIPTION
Similar to an issue with Werkzeug and Flask's `send_file` and `safe_join`, `FileSystemLoader` and `PackageLoader` should use `posixpath.join` instead of `os.path.join`, so that on Windows "drive:" and UNC segments cannot break out of the search directory.