### PR TITLE
Add missing environment options to the Environment.overlay method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 3.1.2
 
 Unreleased
 
+-   Add parameters to ``Environment.overlay`` to match ``__init__``.
+    :issue:`1645`
+
 
 Version 3.1.1
 -------------

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -393,6 +393,8 @@ class Environment:
         line_comment_prefix: t.Optional[str] = missing,
         trim_blocks: bool = missing,
         lstrip_blocks: bool = missing,
+        newline_sequence: "te.Literal['\\n', '\\r\\n', '\\r']" = missing,
+        keep_trailing_newline: bool = missing,
         extensions: t.Sequence[t.Union[str, t.Type["Extension"]]] = missing,
         optimized: bool = missing,
         undefined: t.Type[Undefined] = missing,
@@ -402,6 +404,7 @@ class Environment:
         cache_size: int = missing,
         auto_reload: bool = missing,
         bytecode_cache: t.Optional["BytecodeCache"] = missing,
+        enable_async: bool = False,
     ) -> "Environment":
         """Create a new overlay environment that shares all the data with the
         current environment except for cache and the overridden attributes.
@@ -413,9 +416,13 @@ class Environment:
         up completely.  Not all attributes are truly linked, some are just
         copied over so modifications on the original environment may not shine
         through.
+
+        .. versionchanged:: 3.1.2
+            Added the ``newline_sequence``,, ``keep_trailing_newline``,
+            and ``enable_async`` parameters to match ``__init__``.
         """
         args = dict(locals())
-        del args["self"], args["cache_size"], args["extensions"]
+        del args["self"], args["cache_size"], args["extensions"], args["enable_async"]
 
         rv = object.__new__(self.__class__)
         rv.__dict__.update(self.__dict__)
@@ -436,6 +443,9 @@ class Environment:
             rv.extensions[key] = value.bind(rv)
         if extensions is not missing:
             rv.extensions.update(load_extensions(rv, extensions))
+
+        if enable_async is not missing:
+            rv.is_async = enable_async
 
         return _environment_config_check(rv)
 

--- a/src/jinja2/visitor.py
+++ b/src/jinja2/visitor.py
@@ -43,8 +43,8 @@ class NodeVisitor:
 
     def generic_visit(self, node: Node, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Called if no explicit visitor function exists for a node."""
-        for node in node.iter_child_nodes():
-            self.visit(node, *args, **kwargs)
+        for child_node in node.iter_child_nodes():
+            self.visit(child_node, *args, **kwargs)
 
 
 class NodeTransformer(NodeVisitor):


### PR DESCRIPTION
This brings the options in sync with the options of the \_\_init\_\_ method.

_Note: Please let me know if we want to be able to edit the 'enable_async' option also. I added this now
to streamline the overlay method options with the \_\_init\_\_ method, but perhaps there's no use-case for
changing this at runtime?_

fixes #1645 

Checklist:

- [   ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
         _There are no tests for previous individual arguments of the .overlay method, only a general test in 
        test_ext.py, so I also didn't add tests specifically for these options. I did test manually to verify the
        options are set on the overlay, but unchanged on the original env. If requested, I can integrate these
        into a seperate dedicated test for these options only_
- [  ] Add or update relevant docs, in the docs folder and in code.
        _No changes required_
- [   ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
        _Looking at the format, this is only needed when a new version is released_
- [   ] Add `.. versionchanged::` entries in any relevant code docs.
        _No docs were changed_
- [ x ] Run `pre-commit` hooks and fix any issues.
         _No issues found_
- [ x ] Run `pytest` and `tox`, no tests failed.
       _Pytest is a success. Please note the following errors are in the output of the tox command, but these
         seem unrelated to the current change_

### Errors in tox output
```
pypy38 create: /home/brouwer/Personal/repositories/jinja/.tox/pypy38
SKIPPED: InterpreterNotFound: pypy3.8
pypy37 create: /home/brouwer/Personal/repositories/jinja/.tox/pypy37
SKIPPED: InterpreterNotFound: pypy3.7
style create: /home/brouwer/Personal/repositories/jinja/.tox/style
style installdeps: pre-commit
style installed: cfgv==3.3.1,distlib==0.3.4,filelock==3.6.0,identify==2.4.12,nodeenv==1.6.0,platformdirs==2.5.1,pre-commit==2.17.0,PyYAML==6.0,six==1.16.0,toml==0.10.2,virtualenv==20.14.0
style run-test-pre: PYTHONHASHSEED='1280065272'
style run-test: commands[0] | pre-commit run --all-files --show-diff-on-failure
pyupgrade................................................................Passed
Reorder python imports...................................................Passed
black....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

src/jinja2/visitor.py:46:13: B020 Found for loop that reassigns the iterable it is iterating with each iterable value.

pip-compile-multi verify.................................................Passed
fix utf-8 byte order marker..............................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
ERROR: InvocationError for command /home/brouwer/Personal/repositories/jinja/.tox/style/bin/pre-commit run --all-files --show-diff-on-failure (exited with code 1)
typing create: /home/brouwer/Personal/repositories/jinja/.tox/typing
```
