### PR TITLE
Fix Race conditions in FileSystemBytecodeCache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Add parameters to ``Environment.overlay`` to match ``__init__``.
     :issue:`1645`
+-   Handle race condition in ``FileSystemBytecodeCache``. :issue:`1654`
 
 
 Version 3.1.1


### PR DESCRIPTION
Fix race conditions in FileSystemBytecodeCache.  See https://github.com/pallets/jinja/issues/1654 for a detailed description of the race conditions.

- fixes #1654

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [n/a] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
