### PR TITLE
Fix `nl2br` example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -700,10 +700,10 @@ enabled before escaping the input and marking the output safe.
             br = Markup(br)
 
         result = "\n\n".join(
-            f"<p>{br.join(p.splitlines())}<\p>"
+            f"<p>{br.join(p.splitlines())}</p>"
             for p in re.split(r"(?:\r\n|\r(?!\n)|\n){2,}", value)
         )
-        return Markup(result) if autoescape else result
+        return Markup(result) if eval_ctx.autoescape else result
 
 
 .. _writing-tests:


### PR DESCRIPTION
The `<\p>` end tag was invalid and `autoescape` was not defined.


<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
