### PR TITLE
Fix typo in docs/api/#custom-tests

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -751,8 +751,8 @@ Now it can be used in templates:
     {% endif %}
 
 Some decorators are available to tell Jinja to pass extra information to
-the filter. The object is passed as the first argument, making the value
-being filtered the second argument.
+the test. The object is passed as the first argument, making the value
+being tested the second argument.
 
 -   :func:`pass_environment` passes the :class:`Environment`.
 -   :func:`pass_eval_context` passes the :ref:`eval-context`.


### PR DESCRIPTION
fix a typo coming from a remaining copy/paste from api/#custom-filters to api/#custom-tests.

I was not sure if the decorators worked for custom tests like custom filters described just above, but I tested with a dummy example, it seems to work.

Maybe it would be nice to include an example like above with @pass_eval_context for the custom filters to be consistent.
