### PR TITLE
Improve the PackageLoader error message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Unreleased
 -   ``Environment.overlay(enable_async)`` is applied correctly. :pr:`2061`
 -   The error message from ``FileSystemLoader`` includes the paths that were
     searched. :issue:`1661`
+-   ``PackageLoader`` shows a clearer error message when the package does not
+    contain the templates directory. :issue:`1705`
 
 
 Version 3.1.4

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -327,7 +327,6 @@ class PackageLoader(BaseLoader):
         assert loader is not None, "A loader was not found for the package."
         self._loader = loader
         self._archive = None
-        template_root = None
 
         if isinstance(loader, zipimport.zipimporter):
             self._archive = loader.archive
@@ -344,18 +343,23 @@ class PackageLoader(BaseLoader):
             elif spec.origin is not None:
                 roots.append(os.path.dirname(spec.origin))
 
+            if not roots:
+                raise ValueError(
+                    f"The {package_name!r} package was not installed in a"
+                    " way that PackageLoader understands."
+                )
+
             for root in roots:
                 root = os.path.join(root, package_path)
 
                 if os.path.isdir(root):
                     template_root = root
                     break
-
-        if template_root is None:
-            raise ValueError(
-                f"PackageLoader could not find a '{package_path}' directory for the "
-                f"{package_name!r} package."
-            )
+            else:
+                raise ValueError(
+                    f"PackageLoader could not find a {package_path!r} directory"
+                    f" in the {package_name!r} package."
+                )
 
         self._template_root = template_root
 

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -353,8 +353,8 @@ class PackageLoader(BaseLoader):
 
         if template_root is None:
             raise ValueError(
-                f"The {package_name!r} package was not installed in a"
-                " way that PackageLoader understands."
+                f"PackageLoader could not find a '{package_path}' directory for the "
+                f"{package_name!r} package."
             )
 
         self._template_root = template_root

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -429,3 +429,8 @@ def test_pep_451_import_hook():
         assert "test.html" in package_loader.list_templates()
     finally:
         sys.meta_path[:] = before
+
+
+def test_package_loader_no_dir() -> None:
+    with pytest.raises(ValueError, match="could not find a 'templates' directory"):
+        PackageLoader("jinja2")


### PR DESCRIPTION
Explain why the `PackageLoader` failed when the `package_path` directory is missing.

- fixes #1705

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
