### PR TITLE
Add additional examples for selectattr and rejectattr

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1638,6 +1638,7 @@ def sync_do_rejectattr(
 
         {{ users|rejectattr("is_active") }}
         {{ users|rejectattr("email", "none") }}
+        {{ users|rejectattr("email", "eq", "foo@bar.invalid") }}
 
     Similar to a generator comprehension such as:
 
@@ -1645,6 +1646,7 @@ def sync_do_rejectattr(
 
         (u for user in users if not user.is_active)
         (u for user in users if not test_none(user.email))
+        (u for user in users if user.email != "foo@bar.invalid")
 
     .. versionadded:: 2.7
     """

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1598,6 +1598,7 @@ def sync_do_selectattr(
 
         {{ users|selectattr("is_active") }}
         {{ users|selectattr("email", "none") }}
+        {{ users|selectattr("email", "eq", "foo@bar.invalid") }}
 
     Similar to a generator comprehension such as:
 
@@ -1605,6 +1606,7 @@ def sync_do_selectattr(
 
         (u for user in users if user.is_active)
         (u for user in users if test_none(user.email))
+        (u for user in users if user.email == "foo@bar.invalid")
 
     .. versionadded:: 2.7
     """

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1518,7 +1518,7 @@ def sync_do_select(
     .. sourcecode:: jinja
 
         {{ numbers|select("odd") }}
-        {{ numbers|select("odd") }}
+        {{ numbers|select("even") }}
         {{ numbers|select("divisibleby", 3) }}
         {{ numbers|select("lessthan", 42) }}
         {{ strings|select("equalto", "mystring") }}


### PR DESCRIPTION
(I haven't opened a ticket because this is a small docs-only change.)

I was trying to filter a list of dictionaries with Jinja, and it wasn't immediately obvious from the documentation.

I found [the docs for `selectattr`](https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.selectattr), and the example

```
{{ users|selectattr("email", "none") }}
```

made me think maybe it was looking for users where `user.email` was equal to the string `"none"`; I didn't realise that `"none"` is the name of a builtin test.

I got my code working, but I figured I might not be the only person confused by this, so I've suggested an example of how to use `selectattr` and the `"eq"` filter to filter by attribute value.

(Note also that I was initially looking at the version 2.9 docs, which don't include the equivalent generator comprehension – I completely missed the banner. I think the additional example is still helpful.)