### PR TITLE
Update pylons url in documentation

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -91,4 +91,4 @@ this add this to ``config/environment.py``:
 
     config['pylons.strict_c'] = True
 
-.. _Pylons: https://pylonshq.com/
+.. _Pylons: https://pylonsproject.org/


### PR DESCRIPTION
Pylons uses a new homepage for a long time.
Only docs had changed. 