### PR TITLE
Fix custom filter example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -669,8 +669,8 @@ Now it can be used in templates:
 
 .. sourcecode:: jinja
 
-    {{ article.pub_date|datetimeformat }}
-    {{ article.pub_date|datetimeformat("%B %Y") }}
+    {{ article.pub_date|datetime_format }}
+    {{ article.pub_date|datetime_format("%B %Y") }}
 
 Some decorators are available to tell Jinja to pass extra information to
 the filter. The object is passed as the first argument, making the value


### PR DESCRIPTION
Filter name used in templates must match a key in the filters map.