### PR TITLE
Show how {% filter %} can take filter arguments

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1015,6 +1015,9 @@ template data.  Just wrap the code in the special `filter` section::
         This text becomes uppercase
     {% endfilter %}
 
+Filters that accept arguments can be called like this::
+
+    {% filter center(100) %}Center this{% endfilter %}
 
 .. _assignments:
 


### PR DESCRIPTION
Closes #1732.

This is purely a documentation change.