### PR TITLE
Ensure that name and filename are strings

### DIFF
--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -310,8 +310,8 @@ class CodeGenerator(NodeVisitor):
         if stream is None:
             stream = StringIO()
         self.environment = environment
-        self.name = name
-        self.filename = filename
+        self.name = str(name)
+        self.filename = str(filename)
         self.stream = stream
         self.created_block_context = False
         self.defer_init = defer_init

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -310,8 +310,8 @@ class CodeGenerator(NodeVisitor):
         if stream is None:
             stream = StringIO()
         self.environment = environment
-        self.name = str(name)
-        self.filename = str(filename)
+        self.name = name
+        self.filename = filename
         self.stream = stream
         self.created_block_context = False
         self.defer_init = defer_init

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -123,6 +123,8 @@ class BaseLoader:
         # first we try to get the source for this template together
         # with the filename and the uptodate function.
         source, filename, uptodate = self.get_source(environment, name)
+        name = str(name)
+        filename = str(filename)
 
         # try to load the code from the bytecode cache if there is a
         # bytecode cache configured.


### PR DESCRIPTION
Prevent "name 'PosixPath' is not defined" when the argument to `get_template` is a `pathlib.Path` instance.

```python
from pathlib import Path
env.get_template(Path('t.html'))
```

`f'{name!r}'` compiles to

```python
name = PosixPath('t.html')
```

which results in the exception "name 'PosixPath' is not defined"
