### PR TITLE
Pass context to test when using select

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ Unreleased
     contain the templates directory. :issue:`1705`
 -   Improve annotations for methods returning copies. :pr:`1880`
 -   ``urlize`` does not add ``mailto:`` to values like `@a@b`. :pr:`1870`
+-   Tests decorated with `@pass_context`` can be used with the ``|select``
+    filter. :issue:`1624`
 
 
 Version 3.1.4

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1780,7 +1780,7 @@ def prepare_select_or_reject(
         args = args[1 + off :]
 
         def func(item: t.Any) -> t.Any:
-            return context.environment.call_test(name, item, args, kwargs)
+            return context.environment.call_test(name, item, args, kwargs, context)
 
     except LookupError:
         func = bool  # type: ignore

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -737,6 +737,18 @@ End"""
         )
         assert tmpl.render() == "hellohellohello"
 
+    def test_pass_context_with_select(self, env):
+        @pass_context
+        def is_foo(ctx, s):
+            assert ctx is not None
+            return s == "foo"
+
+        env.tests["foo"] = is_foo
+        tmpl = env.from_string(
+            "{% for x in ['one', 'foo'] | select('foo') %}{{ x }}{% endfor %}"
+        )
+        assert tmpl.render() == "foo"
+
 
 @pytest.mark.parametrize("unicode_char", ["\N{FORM FEED}", "\x85"])
 def test_unicode_whitespace(env, unicode_char):


### PR DESCRIPTION
This bugfix allows `pass_context` to be used by tests in combination with `select`, which was previously failing because `select` did not pass the context object, and thus the context would remain `None`. 

Fixes #1624.

Regarding the request for updating `CHANGES.rst`: should I add a new version number (i.e. 3.1.3) to the document for this bugfix? I'm assuming that `3.1.x` is the correct target branch for this PR, but I wasn't entirely sure.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
