### PR TITLE
ext.i18n policy to fallback to untranslated string when interpolation fails

### DIFF
--- a/src/jinja2/defaults.py
+++ b/src/jinja2/defaults.py
@@ -45,4 +45,5 @@ DEFAULT_POLICIES: t.Dict[str, t.Any] = {
     "json.dumps_function": None,
     "json.dumps_kwargs": {"sort_keys": True},
     "ext.i18n.trimmed": False,
+    "ext.i18n.newstyle_fallback_interpolation": False,
 }

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -52,6 +52,7 @@ newstyle_i18n_templates = {
     "novars.html": "{% trans %}%(hello)s{% endtrans %}",
     "vars.html": "{% trans %}{{ foo }}%(foo)s{% endtrans %}",
     "explicitvars.html": '{% trans foo="42" %}%(foo)s{% endtrans %}',
+    "broken_interpolation.html": "{% trans %}Username: {{ username }}{% endtrans %}",
 }
 
 
@@ -66,6 +67,7 @@ languages = {
         "Apple": {None: "Apfel", "fruit": "Apple"},
         "%(num)s apple": {None: "%(num)s Apfel", "fruit": "%(num)s Apple"},
         "%(num)s apples": {None: "%(num)s Äpfel", "fruit": "%(num)s Apples"},
+        "Username: %(username)s": "Nutzername: %(user_name)",
     }
 }
 
@@ -144,6 +146,14 @@ newstyle_i18n_env = Environment(
     loader=DictLoader(newstyle_i18n_templates), extensions=["jinja2.ext.i18n"]
 )
 newstyle_i18n_env.install_gettext_callables(  # type: ignore
+    gettext, ngettext, newstyle=True, pgettext=pgettext, npgettext=npgettext
+)
+
+newstyle_i18n_env_fallback = Environment(
+    loader=DictLoader(newstyle_i18n_templates), extensions=["jinja2.ext.i18n"]
+)
+newstyle_i18n_env_fallback.policies["ext.i18n.newstyle_fallback_interpolation"] = True
+newstyle_i18n_env_fallback.install_gettext_callables(  # type: ignore
     gettext, ngettext, newstyle=True, pgettext=pgettext, npgettext=npgettext
 )
 
@@ -609,6 +619,13 @@ class TestNewstyleInternationalization:
         tmpl = newstyle_i18n_env.get_template("npgettext_block")
         assert tmpl.render(LANGUAGE="de", apples=1) == "1 Apple"
         assert tmpl.render(LANGUAGE="de", apples=5) == "5 Apples"
+
+    def test_broken_translation_interpolation(self):
+        tmpl = newstyle_i18n_env.get_template("broken_interpolation.html")
+        with pytest.raises(KeyError):
+            tmpl.render(LANGUAGE="de", username="NewUser")
+        tmpl = newstyle_i18n_env_fallback.get_template("broken_interpolation.html")
+        assert tmpl.render(LANGUAGE="de", username="NewUser") == "Username: NewUser"
 
 
 class TestAutoEscape:


### PR DESCRIPTION
Implements `ext.i18n.newstyle_fallback_interpolation` policy which can be set to `True` to gracefully fallback to untranslated strings if an interpolation error occurs due to incorrectly or out-of-date named variables in translations.

- fixes #1763 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
