### PR TITLE
make unique filter async aware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
     :pr:`1960`
 -   The runtime uses the correct ``concat`` function for the current environment
     when calling block references. :issue:`1701`
+-   Make ``|unique`` async-aware, allowing it to be used after another
+    async-aware filter. :issue:`1781`
 
 
 Version 3.1.4

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -438,7 +438,7 @@ def do_sort(
 
 
 @pass_environment
-def do_unique(
+def sync_do_unique(
     environment: "Environment",
     value: "t.Iterable[V]",
     case_sensitive: bool = False,
@@ -468,6 +468,18 @@ def do_unique(
         if key not in seen:
             seen.add(key)
             yield item
+
+
+@async_variant(sync_do_unique)  # type: ignore
+async def do_unique(
+    environment: "Environment",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    case_sensitive: bool = False,
+    attribute: t.Optional[t.Union[str, int]] = None,
+) -> "t.Iterator[V]":
+    return sync_do_unique(
+        environment, await auto_to_list(value), case_sensitive, attribute
+    )
 
 
 def _min_or_max(

--- a/tests/test_async_filters.py
+++ b/tests/test_async_filters.py
@@ -277,6 +277,13 @@ def test_slice(env_async, items):
     )
 
 
+def test_unique_with_async_gen(env_async):
+    items = ["a", "b", "c", "c", "a", "d", "z"]
+    tmpl = env_async.from_string("{{ items|reject('==', 'z')|unique|list }}")
+    out = tmpl.render(items=items)
+    assert out == "['a', 'b', 'c', 'd']"
+
+
 def test_custom_async_filter(env_async, run_async_fn):
     async def customfilter(val):
         return str(val)


### PR DESCRIPTION
unique() filter doesn't work chained after a filter that return an async generator.

This introduces a async variant of the filter transform the async
generator into a list to be able to apply the unique filter.

Fixes #1781

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.