### PR TITLE
Inaccurate documentation: Math section's modulo and floor division description

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1356,11 +1356,11 @@ but exists for completeness' sake.  The following operators are supported:
     ``{{ 1 / 2 }}`` is ``{{ 0.5 }}``.
 
 ``//``
-    Divide two numbers and return the truncated integer result.
+    Divide two numbers and floor the result (round off to the greatest integer less than or equal to the division with ``/``).
     ``{{ 20 // 7 }}`` is ``2``.
 
 ``%``
-    Calculate the remainder of an integer division.  ``{{ 11 % 7 }}`` is ``4``.
+    Calculate the modulo of an integer division.  ``{{ 11 % 7 }}`` is ``4``.
 
 ``*``
     Multiply the left operand with the right one.  ``{{ 2 * 2 }}`` would


### PR DESCRIPTION
Until now the [documentation](https://jinja.palletsprojects.com/en/3.1.x/templates/#math) states that ``%`` is the remainder operator and ``//`` truncates the float to an integer (integer division). While this is true for positive numbers it is not for negative numbers: In Python ``%`` stands for the modulo operator and ``//`` is a floor division (rounding the result off instead of truncating the float to an integer).

Some explanation on floor / integer division (example: -23 / 22 = 1.04545....):
* Integer division means truncating the float remainder (i.e. removing the decimal places): int(-23 / 22) = -1
* Floor division rounds the result off to the greatest integer smaller than or equal to the float result: floor(-23 / 22) = -2

Some explanation on modulo/remainder operator:
* -23 rem 22 is expected to be -1 as int(-23 / 22) = -1 => -23 - (-1*22) = -1 (you could say 22 fits -1 times into -23 and therefore -1 is still missing/remaining)
* -23 mod 22 on the other hand is expected to be 21 as floor(-23 / 22) = -2 => -23 - (-2*22) = 21 (basically the remainder wrapped to positive numbers, you can think of it as a remainder function which uses floor division instead of integer division)