### PR TITLE
Refactor: factor-out usage of itertools.groupby from generate_identifier_pattern.py script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
+-   Refactor the ``generate_identifier_pattern.py`` script. :issue:`1654`
 
 
 Version 3.1.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Unreleased
 
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
--   Refactor the ``generate_identifier_pattern.py`` script. :issue:`1654`
+-   Refactor the ``generate_identifier_pattern.py`` script. :issue:`1835`
 
 
 Version 3.1.2

--- a/scripts/generate_identifier_pattern.py
+++ b/scripts/generate_identifier_pattern.py
@@ -39,7 +39,7 @@ def represent_groups(groups):
         if len(group) > 2:
             yield f"{group[0]}-{group[-1]}"
         else:
-            yield from group
+            yield group
 
 
 def main():


### PR DESCRIPTION
Refactors the `generate_identifier_pattern.py` script; initially this was done in order to experiment with removal of `itertools.groupby` code that `flake8` pre-commit checks were complaining about (see #1835).

- Resolves #1835 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
  - Please note: I think that the best way to confirm that these changes are correct is to use the script to regenerate `jinja`'s [Unicode identifier regex pattern](https://github.com/pallets/jinja/blob/85e5ad85d10eaf119dc0f17f245118c9f78bb864/src/jinja2/_identifier.py) 
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.