### PR TITLE
don't apply `urlize` to `@a@b`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Don't ``mailto:``-``urlize()`` addresses in the form ``@a@b``. :pr:`1870`
 
 
 Version 3.1.3

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -324,6 +324,7 @@ def urlize(
         elif (
             "@" in middle
             and not middle.startswith("www.")
+            and not middle.startswith("@")
             and ":" not in middle
             and _email_re.match(middle)
         ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,6 +141,14 @@ class TestEscapeUrlizeTarget:
             "http://example.org</a>"
         )
 
+    def test_urlize_mail_mastodon(self):
+        fr = "nabijaczleweli@nabijaczleweli.xyz\n@eater@cijber.social\n"
+        to = (
+            '<a href="mailto:nabijaczleweli@nabijaczleweli.xyz">'
+            "nabijaczleweli@nabijaczleweli.xyz</a>\n@eater@cijber.social\n"
+        )
+        assert urlize(fr) == to
+
 
 class TestLoremIpsum:
     def test_lorem_ipsum_markup(self):


### PR DESCRIPTION
This chases https://lists.sr.ht/~sircmpwn/sr.ht-dev/%3Clelaromu5mjgibe6jywrc2iwoikon2piwo2h34rcsyjhbyge5y%40fdtowru7pv5e%3E and thus https://101010.pl/@mcc@mastodon.social/110742090990556162

It's a common way to spell both "a user of some site" but also universal in the mastodon world. None of these are valid e-mail addresses (especially since urlize makes `@eater@cijber.social` into `<a href="mailto:@eater@cijber.social">@eater@cijber.social</a>` which straight-up just isn't really a valid e-mail address anyway).

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code. – I don't think this is needed, since `@a@b` isn't really a valid email anyway and it was erroneously accepted
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs. – Likewise
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
