### PR TITLE
improve annotations for methods returning copies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Unreleased
     searched. :issue:`1661`
 -   ``PackageLoader`` shows a clearer error message when the package does not
     contain the templates directory. :issue:`1705`
+-   Improve annotations for methods returning copies. :pr:`1880`
 
 
 Version 3.1.4

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -216,7 +216,7 @@ class Frame:
         # or compile time.
         self.soft_frame = False
 
-    def copy(self) -> "Frame":
+    def copy(self) -> "te.Self":
         """Create a copy of the current one."""
         rv = object.__new__(self.__class__)
         rv.__dict__.update(self.__dict__)
@@ -229,7 +229,7 @@ class Frame:
             return Frame(self.eval_ctx, level=self.symbols.level + 1)
         return Frame(self.eval_ctx, self)
 
-    def soft(self) -> "Frame":
+    def soft(self) -> "te.Self":
         """Return a soft frame.  A soft frame may not be modified as
         standalone thing as it shares the resources with the frame it
         was created of, but it's not a rootlevel frame any longer.

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -123,7 +123,7 @@ def load_extensions(
     return result
 
 
-def _environment_config_check(environment: "Environment") -> "Environment":
+def _environment_config_check(environment: _env_bound) -> _env_bound:
     """Perform a sanity check on the environment."""
     assert issubclass(
         environment.undefined, Undefined
@@ -407,7 +407,7 @@ class Environment:
         auto_reload: bool = missing,
         bytecode_cache: t.Optional["BytecodeCache"] = missing,
         enable_async: bool = missing,
-    ) -> "Environment":
+    ) -> "te.Self":
         """Create a new overlay environment that shares all the data with the
         current environment except for cache and the overridden attributes.
         Extensions cannot be removed for an overlayed environment.  An overlayed

--- a/src/jinja2/ext.py
+++ b/src/jinja2/ext.py
@@ -89,7 +89,7 @@ class Extension:
     def __init__(self, environment: Environment) -> None:
         self.environment = environment
 
-    def bind(self, environment: Environment) -> "Extension":
+    def bind(self, environment: Environment) -> "te.Self":
         """Create a copy of this extension bound to another environment."""
         rv = object.__new__(self.__class__)
         rv.__dict__.update(self.__dict__)

--- a/src/jinja2/idtracking.py
+++ b/src/jinja2/idtracking.py
@@ -3,6 +3,9 @@ import typing as t
 from . import nodes
 from .visitor import NodeVisitor
 
+if t.TYPE_CHECKING:
+    import typing_extensions as te
+
 VAR_LOAD_PARAMETER = "param"
 VAR_LOAD_RESOLVE = "resolve"
 VAR_LOAD_ALIAS = "alias"
@@ -83,7 +86,7 @@ class Symbols:
             )
         return rv
 
-    def copy(self) -> "Symbols":
+    def copy(self) -> "te.Self":
         rv = object.__new__(self.__class__)
         rv.__dict__.update(self.__dict__)
         rv.refs = self.refs.copy()

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -462,7 +462,7 @@ class LRUCache:
     def __getnewargs__(self) -> t.Tuple[t.Any, ...]:
         return (self.capacity,)
 
-    def copy(self) -> "LRUCache":
+    def copy(self) -> "te.Self":
         """Return a shallow copy of the instance."""
         rv = self.__class__(self.capacity)
         rv._mapping.update(self._mapping)


### PR DESCRIPTION
These methods always return a new object of the same type as the object they are bound to, even if this is a subclass. Change the annotations to reflect that.

I have not opened an issue, because it's not a functional bug. It just causes issues with static type checkers.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. (N/A)
- [ ] Add or update relevant docs, in the docs folder and in code.  (N/A)
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs. (N/A)
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
