### PR TITLE
Fix: Autoescape does not work well across blocks/inheritance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,19 @@
 .. currentmodule:: jinja2
 
+Unreleased
+
+-   Fix compiler. As compiled jinja blocks does not have info about
+    parent template scopes like autoescape, due to which it is ignoring those inherited
+    properties. So we made blocks compilation volatile, so that it will figure correct
+    property during rendering time. :issue:`1898`
+
+-   Fix NodeParser error. Ideally child templates body should contain blocks as first
+    child. because only blocks in child template are going to be replaced with
+    blocks in main template. So each node in child template body is inspected to
+    identify first block node and moving it into the template body.
+    These blocks will seamlessly placed in the main template body. :issue:`1898`
+
+
 Version 3.1.3
 -------------
 

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -920,6 +920,9 @@ class CodeGenerator(NodeVisitor):
             # interesting issues with identifier tracking.
             block_frame = Frame(eval_ctx)
             block_frame.block_frame = True
+            # during compile time we are not aware of parent template configuration,
+            # so it's better to decide child blocks configuration at runtime.
+            block_frame.eval_ctx.volatile = True
             undeclared = find_undeclared(block.body, ("self", "super"))
             if "self" in undeclared:
                 ref = block_frame.symbols.declare_parameter("self")
@@ -1406,7 +1409,7 @@ class CodeGenerator(NodeVisitor):
 
             if pass_arg is None:
 
-                def finalize(value: t.Any) -> t.Any:
+                def finalize(value: t.Any) -> t.Any:  # noqa: F811
                     return default(env_finalize(value))
 
             else:
@@ -1414,7 +1417,7 @@ class CodeGenerator(NodeVisitor):
 
                 if pass_arg == "environment":
 
-                    def finalize(value: t.Any) -> t.Any:
+                    def finalize(value: t.Any) -> t.Any:  # noqa: F811
                         return default(env_finalize(self.environment, value))
 
         self._finalize = self._FinalizeInfo(finalize, src)


### PR DESCRIPTION
**Issue**: 
       As compiled Jinja Blocks does not have info about parent template scopes like autoescape, 
       due to which it is ignoring those inherited properties. 

**Fix**:  
      Fixed the compiler. We made blocks compilation volatile so that it will figure out the correct
      property during rendering time.

**Issue**: 
    Ideally, the child template body should contain blocks as the first child. because only blocks in the
    child template will be replaced with the blocks in the main template. 
    but whenever the developers write blocks inside other Scoped Nodes, the block is compiled as a part of scoped Node 
    code by the Jinja compiler. Once the child template is compiled, then the Jinja compiler complies all blocks separately 
    as well.
    Due to this behaviour blocks were compiled multiple times. once when they are part of a scoped node's body and again 
    when all blocks are compiled. This behaviour leads to unexpected results

**Fix**:
     Fixed Node Parser. So each node in the child template body is inspected to
    identify the first block node and move it into the template body. (to avoid multiple parsing of blocks.)
    These blocks will be seamlessly placed in the main template body. 
    Because outer scoped nodes of blocks do not make any scene for the child template as only data inside
     blocks will be replaced in the main template.

- fixes #1898


Checklist:

- [x ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x ] Add or update relevant docs, in the docs folder and in code.
- [x ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x ] Add `.. versionchanged::` entries in any relevant code docs.
- [ x] Run `pre-commit` hooks and fix any issues.
- [x ] Run `pytest` and `tox`, no tests failed.
