### PR TITLE
Fix typo on filter name

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -666,8 +666,8 @@ Now it can be used in templates:
 
 .. sourcecode:: jinja
 
-    {{ article.pub_date|datetimeformat }}
-    {{ article.pub_date|datetimeformat("%B %Y") }}
+    {{ article.pub_date|datetime_format }}
+    {{ article.pub_date|datetime_format("%B %Y") }}
 
 Some decorators are available to tell Jinja to pass extra information to
 the filter. The object is passed as the first argument, making the value


### PR DESCRIPTION
Hi everyone!

I was studying Jinja and Flask with @JefersonViana , and noticed a typo in the docs about custom filters.

I hope there is no need for creating an issue for this.

Let me know if you think that there is a better solution.