### PR TITLE
Support Windows UNC paths in loaders

### DIFF
--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -3,6 +3,7 @@ sources.
 """
 import importlib.util
 import os
+import pathlib
 import posixpath
 import sys
 import typing as t
@@ -198,7 +199,8 @@ class FileSystemLoader(BaseLoader):
         for searchpath in self.searchpath:
             # Use posixpath even on Windows to avoid "drive:" or UNC
             # segments breaking out of the search directory.
-            filename = posixpath.join(searchpath, *pieces)
+            # Normalize path separators after that using pathlib.
+            filename = str(pathlib.Path(posixpath.join(searchpath, *pieces)))
 
             if os.path.isfile(filename):
                 break
@@ -333,10 +335,12 @@ class PackageLoader(BaseLoader):
         self, environment: "Environment", template: str
     ) -> t.Tuple[str, str, t.Optional[t.Callable[[], bool]]]:
         # Use posixpath even on Windows to avoid "drive:" or UNC
-        # segments breaking out of the search directory. Use normpath to
-        # convert Windows altsep to sep.
-        p = os.path.normpath(
-            posixpath.join(self._template_root, *split_template_path(template))
+        # segments breaking out of the search directory.
+        # Normalize path separators after that using pathlib.
+        p = str(
+            pathlib.Path(
+                posixpath.join(self._template_root, *split_template_path(template))
+            )
         )
         up_to_date: t.Optional[t.Callable[[], bool]]
 


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

Replace `os.path.normpath` with `str(pathlib.Path())` which correctly fixes path separators when UNC path is provided.

Tested that this code doesn't escape search dir, e.g.:
```
>>> str(pathlib.Path(posixpath.join("C:\\abc", "e:d\\ef")))
'C:\\abc\\e:d\\ef'
>>> str(pathlib.Path(posixpath.join("\\\\?\\C:\\abc", "e:d\\ef")))
'\\\\?\\C:\\abc\\e:d\\ef'
```
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1675 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
