### PR TITLE
Change github link in contributing.rst to ssh

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -92,7 +92,7 @@ First time setup
 
     .. code-block:: text
 
-        $ git remote add fork https://github.com/{username}/jinja
+        $ git remote add fork git@github.com:{username}/jinja.git
 
 -   Create a virtualenv.
 


### PR DESCRIPTION
Changes the link in contributing.rst to reflect github's move to ssh.

fixes #1916 
