### PR TITLE
Eliminating undefined parameters entirely by `NeverUndefined`

### DIFF
--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -25,8 +25,8 @@ from .loaders import PrefixLoader as PrefixLoader
 from .runtime import ChainableUndefined as ChainableUndefined
 from .runtime import DebugUndefined as DebugUndefined
 from .runtime import make_logging_undefined as make_logging_undefined
-from .runtime import StrictUndefined as StrictUndefined
 from .runtime import NeverUndefined as NeverUndefined
+from .runtime import StrictUndefined as StrictUndefined
 from .runtime import Undefined as Undefined
 from .utils import clear_caches as clear_caches
 from .utils import is_undefined as is_undefined

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -26,6 +26,7 @@ from .runtime import ChainableUndefined as ChainableUndefined
 from .runtime import DebugUndefined as DebugUndefined
 from .runtime import make_logging_undefined as make_logging_undefined
 from .runtime import StrictUndefined as StrictUndefined
+from .runtime import NeverUndefined as NeverUndefined
 from .runtime import Undefined as Undefined
 from .utils import clear_caches as clear_caches
 from .utils import is_undefined as is_undefined

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -1052,3 +1052,19 @@ del (
     DebugUndefined.__slots__,
     StrictUndefined.__slots__,
 )
+
+class NeverUndefined(StrictUndefined):
+    def __init__(self, *args, **kwargs):
+        # ARGS: ("parameter 'myvar2' was not provided",)
+        # KWARGS: {'name': 'myvar2'}
+        if len(args) == 1:
+            info = args[0]
+        elif "name" in kwargs.keys():
+            info = f"Undefined variable '{kwargs['name']}"
+        else:
+            infoList = ["Not allowing any undefined variable."]
+            infoList.append(f"ARGS: {args}")
+            infoList.append(f"KWARGS: {kwargs}")
+            info = "\n".join(infoList)
+
+        raise Exception(info)

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -1053,6 +1053,7 @@ del (
     StrictUndefined.__slots__,
 )
 
+
 class NeverUndefined(StrictUndefined):
     def __init__(self, *args, **kwargs):
         # ARGS: ("parameter 'myvar2' was not provided",)


### PR DESCRIPTION
This pull request is done by changing two files in the source code directory. It integrates the `NeverUndefined` class and make it usable by:

```python
import jinja2
# access by: jinja2.NeverUndefined
```
This will raise exception for the following template, while `StrictUndefined` will not:

```jinja2
{% macro test(a, b, c) %}
a macro with three parameters but not used
{%endmacro%}

{{test()}}
```


- fixes #1923

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
