### PR TITLE
[#1927] Raise exception on invalid input in indent

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -824,6 +824,11 @@ def do_indent(
         indention = Markup(indention)
         newline = Markup(newline)
 
+    if not isinstance(s, str):
+        raise FilterArgumentError(
+            f"argument to indent must be a string or Markup, got {s}"
+        )
+
     s += newline  # this quirk is necessary for splitlines method
 
     if blank:

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -823,8 +823,7 @@ def do_indent(
     if isinstance(s, Markup):
         indention = Markup(indention)
         newline = Markup(newline)
-
-    if not isinstance(s, str):
+    elif not isinstance(s, str):
         raise FilterArgumentError(
             f"argument to indent must be a string or Markup, got {s}"
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -8,6 +8,7 @@ from jinja2 import Environment
 from jinja2 import StrictUndefined
 from jinja2 import TemplateRuntimeError
 from jinja2 import UndefinedError
+from jinja2.exceptions import FilterArgumentError
 from jinja2.exceptions import TemplateAssertionError
 
 
@@ -178,6 +179,12 @@ class TestFilter:
         assert t.render() == "    jinja"
         t = env.from_string('{{ "jinja"|indent(blank=true) }}')
         assert t.render() == "jinja"
+
+    def test_indent_dict(self, env):
+        self._test_indent_multiline_template(env)
+        t = env.from_string("{{ mydict|indent }}")
+        with pytest.raises(FilterArgumentError):
+            t.render(mydict={"foo": "bar"})
 
     def test_indent_markup_input(self, env):
         """


### PR DESCRIPTION
Before this change, the indent filter would raise a confusing error like the following if an unexpected input type was sent e.g. a dict:

```
unsupported operand type(s) for +=: 'dict' and 'str'"
```

This updates the code to fail gracefully and adds a new test.


- fixes #1927

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
