### PR TITLE
tests: Tweak to work with markupsafe 2.1.4

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -98,7 +98,7 @@ class TestFilter:
             "example</a> link</p>\n<p>to a webpage</p> "
             "<!-- <p>and some commented stuff</p> -->"
         )
-        assert out == "just a small example link to a webpage"
+        assert out.strip() == "just a small example link to a webpage"
 
     def test_filesizeformat(self, env):
         tmpl = env.from_string(


### PR DESCRIPTION
The recent markupsafe release 2.1.4 causes a regression in the jinja2 tests as a newline is present. Use strip to work around this change in behaviour to stop the test suite being affected.
