### PR TITLE
fix: `tojson` filter now respects `autoescape`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Fixed `autoescape=False` not working for builtin filter `tojson`.
+    :issue:`1934`
 
 
 Version 3.1.3

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1,4 +1,5 @@
 """Built-in template filters used with the ``|`` operator."""
+import json
 import math
 import random
 import re
@@ -1680,9 +1681,9 @@ async def do_rejectattr(
 @pass_eval_context
 def do_tojson(
     eval_ctx: "EvalContext", value: t.Any, indent: t.Optional[int] = None
-) -> Markup:
+) -> t.Union[str, Markup]:
     """Serialize an object to a string of JSON, and mark it safe to
-    render in HTML. This filter is only for use in HTML documents.
+    render in HTML if autoescape.
 
     The returned string is safe to render in HTML documents and
     ``<script>`` tags. The exception is in HTML attributes that are
@@ -1702,6 +1703,12 @@ def do_tojson(
     if indent is not None:
         kwargs = kwargs.copy()
         kwargs["indent"] = indent
+
+    if not eval_ctx.autoescape:
+        if dumps is None:
+            dumps = json.dumps
+
+        return dumps(value, **kwargs)
 
     return htmlsafe_json_dumps(value, dumps=dumps, **kwargs)
 

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1708,7 +1708,7 @@ def do_tojson(
         if dumps is None:
             dumps = json.dumps
 
-        return dumps(value, **kwargs)
+        return soft_str(dumps(value, **kwargs))
 
     return htmlsafe_json_dumps(value, dumps=dumps, **kwargs)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -812,6 +812,12 @@ class TestFilter:
         assert tmpl.render(users=users) == "jane"
 
     def test_json_dump(self):
+        env = Environment(autoescape=False)
+        t = env.from_string("{{ x|tojson }}")
+        assert t.render(x={"foo": "bar"}) == '{"foo": "bar"}'
+        assert t.render(x="\"ba&r'") == '"\\"ba&r\'"'
+        assert t.render(x="<bar>") == '"<bar>"'
+
         env = Environment(autoescape=True)
         t = env.from_string("{{ x|tojson }}")
         assert t.render(x={"foo": "bar"}) == '{"foo": "bar"}'


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->
1. `tojson` filter now checks and respects `autoescape` setting, extends its usage to non-HTML documents
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1934

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
