### PR TITLE
Maintenance: resolve flake8-bugbear B036 errors

### DIFF
--- a/src/jinja2/debug.py
+++ b/src/jinja2/debug.py
@@ -143,7 +143,7 @@ def fake_traceback(  # type: ignore
     # the new traceback without this frame.
     try:
         exec(code, globals, locals)
-    except BaseException:
+    except BaseException:  # noqa: B036
         return sys.exc_info()[2].tb_next  # type: ignore
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -255,7 +255,7 @@ class TestModuleLoader:
             import gc
 
             gc.collect()
-        except BaseException:
+        except ModuleNotFoundError:
             pass
 
         assert name not in sys.modules


### PR DESCRIPTION
Resolves two B036 errors reported by recent versions of the `flake8-bugbear` plugin for `flake8`.

- Ignores one error report in case 1-of-2 where the exception is intentionally not re-raised.
- Adjusts the exception handler base class in case 2-of-2 where the exception handler was introduced to handle the non-existence of an imported module. 
- fixes #1941

Checklist:

- [ ] ~~Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~~
- [ ] ~~Add or update relevant docs, in the docs folder and in code.~~
- [ ] ~~Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.~~
- [ ] ~~Add `.. versionchanged::` entries in any relevant code docs.~~
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed (note: `tox` tested Python versions 3.11.8, 3.12.2).
