### PR TITLE
Allow to customize some behaviors of Lexer, so that Extension instances get can the raw block begin and end info.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Add the property ``ignore_raw_begin_end_tokens`` to Lexer, as an option to keep
+    the raw_begin, raw_end tokens in the token stream. :pr:`1962`
+-   Add the ``lexer_provider`` property to Environment, so to allow inject your
+    customized Lexer instances for different use cases (e.g. testing). :pr:`1962`
+
 
 
 Version 3.1.3

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -474,6 +474,9 @@ class Lexer:
     Multiple environments can share the same lexer.
     """
 
+    # Whether to ignore the raw_begin, raw_end tokens
+    ignore_raw_begin_end_tokens = True
+
     def __init__(self, environment: "Environment") -> None:
         # shortcuts
         e = re.escape
@@ -629,9 +632,11 @@ class Lexer:
                 token = TOKEN_BLOCK_BEGIN
             elif token == TOKEN_LINESTATEMENT_END:
                 token = TOKEN_BLOCK_END
-            # we are not interested in those tokens in the parser
             elif token in (TOKEN_RAW_BEGIN, TOKEN_RAW_END):
-                continue
+                if self.ignore_raw_begin_end_tokens:
+                    continue
+                else:
+                    value = value_str
             elif token == TOKEN_DATA:
                 value = self._normalize_newlines(value_str)
             elif token == "keyword":

--- a/src/jinja2/parser.py
+++ b/src/jinja2/parser.py
@@ -1025,6 +1025,8 @@ class Parser:
                     else:
                         body.append(rv)
                     self.stream.expect("block_end")
+                elif token.type in ("raw_begin", "raw_end"):
+                    next(self.stream)
                 else:
                     raise AssertionError("internal parsing error")
 


### PR DESCRIPTION
**Problem:**
Currently, the "data" tokens don't have the information about if the "data" is inside the raw/endraw block, or not. This limit the Extension object's ability to treat the "data" tokens differently. I'm developing a jinja extension which is limited by this.

**Feature Request:**

Allow Lexer to optionally choose to emit the raw_begin and raw_end tokens, v.s. ignore them (current behaviors)
Allow Environment to switch the lexer provider, so that you can inject your customized Lexer instances. For example, a customized one when an Extension is added, or when it's in testing.

**Fixes**
1. Allow token_begin and token_end in stream to enable Extensions to treat "data" tokens differently
2. Add the lexer_provider attrib to Environment, so to allow provide custom lexer in different use cases (e.g. testing)

**Test Plan:**
1. Run `pytest`


- fixes #1962


**Checklist:**

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.