### PR TITLE
Convert rST code block to Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,17 @@ restricting functionality too much.
 
 ## In A Nutshell
 
-.. code-block:: jinja
-
-    {% extends "base.html" %}
-    {% block title %}Members{% endblock %}
-    {% block content %}
-      <ul>
-      {% for user in users %}
-        <li><a href="{{ user.url }}">{{ user.username }}</a></li>
-      {% endfor %}
-      </ul>
-    {% endblock %}
-
+```jinja
+{% extends "base.html" %}
+{% block title %}Members{% endblock %}
+{% block content %}
+  <ul>
+  {% for user in users %}
+    <li><a href="{{ user.url }}">{{ user.username }}</a></li>
+  {% endfor %}
+  </ul>
+{% endblock %}
+```
 
 ## Donate
 


### PR DESCRIPTION
The README has a `.md` suffix, which tells me it's a Markdown file, yet it uses a reStructuredText code block. This doesn't render as a code block on GitHub, or on [PyPI](https://pypi.org/project/Jinja2/3.1.4/).