### PR TITLE
include "examples" directory in the sdist again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ name = "jinja2"
 [tool.flit.sdist]
 include = [
     "docs/",
+    "examples/",
     "requirements/",
     "tests/",
     "CHANGES.md",


### PR DESCRIPTION
When moving to flit from setuptools, the "examples" directory was lost from the source distribution. I'm assuming that this was unintentional, since `pyproject.toml` on the main branch still includes it.

Fixes regression introduced in #1968.
