### PR TITLE
Fix error message for non-existing directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
     ``Template.generate_async``. :pr:`1960`
 -   Avoid leaving async generators unclosed in blocks, includes and extends.
     :pr:`1960`
+-   Fix misleading error message when template does not exist.
+    :pr:`1995`
 
 
 Version 3.1.4

--- a/src/jinja2/loaders.py
+++ b/src/jinja2/loaders.py
@@ -347,10 +347,7 @@ class PackageLoader(BaseLoader):
                     break
 
         if template_root is None:
-            raise ValueError(
-                f"The {package_name!r} package was not installed in a"
-                " way that PackageLoader understands."
-            )
+            raise ValueError("Template directory was not found.")
 
         self._template_root = template_root
 


### PR DESCRIPTION
As described in issue #1995, the error message thrown when the template directory does not exist was very misleading. This is a simple attempt to fix that.

fixes #1995 