### PR TITLE
Allow `Environment.from_string()` to take a filename for the loaded template

### DIFF
--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -1093,6 +1093,7 @@ class Environment:
         source: t.Union[str, nodes.Template],
         globals: t.Optional[t.MutableMapping[str, t.Any]] = None,
         template_class: t.Optional[t.Type["Template"]] = None,
+        filename: t.Optional[str] = None,
     ) -> "Template":
         """Load a template from a source string without using
         :attr:`loader`.
@@ -1104,10 +1105,13 @@ class Environment:
             cached, its globals are updated with any new items.
         :param template_class: Return an instance of this
             :class:`Template` class.
+        :param filename: The estimated filename of the template on
+            the file system. If the template came from a database or
+            memory this can be omitted
         """
         gs = self.make_globals(globals)
         cls = template_class or self.template_class
-        return cls.from_code(self, self.compile(source), gs, None)
+        return cls.from_code(self, self.compile(source, None, filename), gs, None)
 
     def make_globals(
         self, d: t.Optional[t.MutableMapping[str, t.Any]]


### PR DESCRIPTION
I currently use `Environment.from_string()` to dynamically load template files, and I would like to be able to set the correct file name on them so the generated tracebacks are much more helpful in identifying the source file (rather than the tracebacks saying the file was `<template>`). The reason I am not using a `Loader` is twofold: none of these files ever need to be rendered twice, and `Loader` is blocking (i.e. not async).

Please look at the PR as an example of the approach itself. If you think this is something that would be approved, I'll finish up the tests and documentation.

## To do
- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
