### PR TITLE
Added linebreak option for indent filter.

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -810,7 +810,11 @@ def do_urlize(
 
 
 def do_indent(
-    s: str, width: t.Union[int, str] = 4, first: bool = False, blank: bool = False
+    s: str,
+    width: t.Union[int, str] = 4,
+    first: bool = False,
+    blank: bool = False,
+    CRLF: bool = False,
 ) -> str:
     """Return a copy of the string with each line indented by 4 spaces. The
     first line and blank lines are not indented by default.
@@ -818,6 +822,7 @@ def do_indent(
     :param width: Number of spaces, or a string, to indent by.
     :param first: Don't skip indenting the first line.
     :param blank: Don't skip indenting empty lines.
+    :param CRLF: Use CRLF line breaks. The default is LF line breaks.
 
     .. versionchanged:: 3.0
         ``width`` can be a string.
@@ -831,8 +836,10 @@ def do_indent(
         indention = width
     else:
         indention = " " * width
-
-    newline = "\n"
+    if CRLF:
+        newline = "\r\n"
+    else:
+        newline = "\n"
 
     if isinstance(s, Markup):
         indention = Markup(indention)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -161,14 +161,22 @@ class TestFilter:
         text = "\n".join(["", "foo bar", '"baz"', ""])
         if markup:
             text = Markup(text)
-        t = env.from_string("{{ foo|indent(2, false, false) }}")
+        t = env.from_string("{{ foo|indent(2, false, false, false) }}")
         assert t.render(foo=text) == '\n  foo bar\n  "baz"\n'
-        t = env.from_string("{{ foo|indent(2, false, true) }}")
+        t = env.from_string("{{ foo|indent(2, false, false, true) }}")
+        assert t.render(foo=text) == '\r\n  foo bar\r\n  "baz"\r\n'
+        t = env.from_string("{{ foo|indent(2, false, true, false) }}")
         assert t.render(foo=text) == '\n  foo bar\n  "baz"\n  '
-        t = env.from_string("{{ foo|indent(2, true, false) }}")
+        t = env.from_string("{{ foo|indent(2, false, true, true) }}")
+        assert t.render(foo=text) == '\r\n  foo bar\r\n  "baz"\r\n  '
+        t = env.from_string("{{ foo|indent(2, true, false, false) }}")
         assert t.render(foo=text) == '  \n  foo bar\n  "baz"\n'
-        t = env.from_string("{{ foo|indent(2, true, true) }}")
+        t = env.from_string("{{ foo|indent(2, true, false, true) }}")
+        assert t.render(foo=text) == '  \r\n  foo bar\r\n  "baz"\r\n'
+        t = env.from_string("{{ foo|indent(2, true, true, false) }}")
         assert t.render(foo=text) == '  \n  foo bar\n  "baz"\n  '
+        t = env.from_string("{{ foo|indent(2, true, true, true) }}")
+        assert t.render(foo=text) == '  \r\n  foo bar\r\n  "baz"\r\n  '
 
     def test_indent(self, env):
         self._test_indent_multiline_template(env)


### PR DESCRIPTION
This change addresses the line break limitation with indent filter, which only supports line feed (LF). The change adds support for multiline template values that use carriage return line feed (CRLF) -- a standard for Windows text files. To enable this feature, a boolean flag is made available.

https://github.com/pallets/jinja/issues/2016

fixes #2016 

👋 This is my first time contributing, please advise if an entry to CHANGES.rst should be added and which version it should be associated (e.g. 3.2.0).