### PR TITLE
sandbox disallows `clear` and `pop` on mutable sequence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Unreleased
     objects. :issue:`2025`
 -   Fix `copy`/`pickle` support for the internal ``missing`` object.
     :issue:`2027`
+-   Sandbox does not allow ``clear`` and ``pop`` on known mutable sequence
+    types. :issue:`2032`
 
 
 Version 3.1.4

--- a/src/jinja2/sandbox.py
+++ b/src/jinja2/sandbox.py
@@ -60,7 +60,9 @@ _mutable_spec: t.Tuple[t.Tuple[t.Type[t.Any], t.FrozenSet[str]], ...] = (
     ),
     (
         abc.MutableSequence,
-        frozenset(["append", "reverse", "insert", "sort", "extend", "remove"]),
+        frozenset(
+            ["append", "clear", "pop", "reverse", "insert", "sort", "extend", "remove"]
+        ),
     ),
     (
         deque,

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -58,6 +58,8 @@ class TestSandbox:
     def test_immutable_environment(self, env):
         env = ImmutableSandboxedEnvironment()
         pytest.raises(SecurityError, env.from_string("{{ [].append(23) }}").render)
+        pytest.raises(SecurityError, env.from_string("{{ [].clear() }}").render)
+        pytest.raises(SecurityError, env.from_string("{{ [1].pop() }}").render)
         pytest.raises(SecurityError, env.from_string("{{ {1:2}.clear() }}").render)
 
     def test_restricted(self, env):


### PR DESCRIPTION
This PR adds the attributes `clear` and `pop` on `MutableSequence` to the default `modifies_known_mutable` check used by `ImmutableSandboxedEnvironment`.

fixes #2032

Let me know if I should add an entry to CHANGES.rst. I didn't see any previous mention of `ImmutableSandboxedEnvironment` in there so I wasn't sure if I should.