### PR TITLE
Add option to preserve comments when parsing templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Add the ``preserve_comments`` parameter to ``Environment.parse`` to preserve comments in template ASTs. :pr:`2037`
 
 
 Version 3.1.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
--   Add the ``preserve_comments`` parameter to ``Environment.parse`` to preserve comments in template ASTs. :pr:`2037`
+-   Preserve comments in ASTs when parsing templates with ``Environment.parse``. :pr:`2037`
 
 
 Version 3.1.5

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -600,6 +600,7 @@ class Environment:
         source: str,
         name: t.Optional[str] = None,
         filename: t.Optional[str] = None,
+        preserve_comments: bool = False,
     ) -> nodes.Template:
         """Parse the sourcecode and return the abstract syntax tree.  This
         tree of nodes is used by the compiler to convert the template into
@@ -610,15 +611,21 @@ class Environment:
         this gives you a good overview of the node tree generated.
         """
         try:
-            return self._parse(source, name, filename)
+            return self._parse(source, name, filename, preserve_comments)
         except TemplateSyntaxError:
             self.handle_exception(source=source)
 
     def _parse(
-        self, source: str, name: t.Optional[str], filename: t.Optional[str]
+        self,
+        source: str,
+        name: t.Optional[str],
+        filename: t.Optional[str],
+        preserve_comments: bool = False,
     ) -> nodes.Template:
         """Internal parsing function used by `parse` and `compile`."""
-        return Parser(self, source, name, filename).parse()
+        return Parser(
+            self, source, name, filename, preserve_comments=preserve_comments
+        ).parse()
 
     def lex(
         self,
@@ -663,12 +670,13 @@ class Environment:
         name: t.Optional[str],
         filename: t.Optional[str] = None,
         state: t.Optional[str] = None,
+        preserve_comments: bool = False,
     ) -> TokenStream:
         """Called by the parser to do the preprocessing and filtering
         for all the extensions.  Returns a :class:`~jinja2.lexer.TokenStream`.
         """
         source = self.preprocess(source, name, filename)
-        stream = self.lexer.tokenize(source, name, filename, state)
+        stream = self.lexer.tokenize(source, name, filename, state, preserve_comments)
 
         for ext in self.iter_extensions():
             stream = ext.filter_stream(stream)  # type: ignore

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -609,6 +609,9 @@ class Environment:
 
         If you are :ref:`developing Jinja extensions <writing-extensions>`
         this gives you a good overview of the node tree generated.
+
+        .. versionchanged:: 3.2
+            Added `preserve_comments` parameter.
         """
         try:
             return self._parse(source, name, filename, preserve_comments)

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -600,7 +600,6 @@ class Environment:
         source: str,
         name: t.Optional[str] = None,
         filename: t.Optional[str] = None,
-        preserve_comments: bool = False,
     ) -> nodes.Template:
         """Parse the sourcecode and return the abstract syntax tree.  This
         tree of nodes is used by the compiler to convert the template into
@@ -609,12 +608,9 @@ class Environment:
 
         If you are :ref:`developing Jinja extensions <writing-extensions>`
         this gives you a good overview of the node tree generated.
-
-        .. versionchanged:: 3.2
-            Added `preserve_comments` parameter.
         """
         try:
-            return self._parse(source, name, filename, preserve_comments)
+            return self._parse(source, name, filename)
         except TemplateSyntaxError:
             self.handle_exception(source=source)
 
@@ -623,12 +619,9 @@ class Environment:
         source: str,
         name: t.Optional[str],
         filename: t.Optional[str],
-        preserve_comments: bool = False,
     ) -> nodes.Template:
         """Internal parsing function used by `parse` and `compile`."""
-        return Parser(
-            self, source, name, filename, preserve_comments=preserve_comments
-        ).parse()
+        return Parser(self, source, name, filename).parse()
 
     def lex(
         self,
@@ -673,13 +666,12 @@ class Environment:
         name: t.Optional[str],
         filename: t.Optional[str] = None,
         state: t.Optional[str] = None,
-        preserve_comments: bool = False,
     ) -> TokenStream:
         """Called by the parser to do the preprocessing and filtering
         for all the extensions.  Returns a :class:`~jinja2.lexer.TokenStream`.
         """
         source = self.preprocess(source, name, filename)
-        stream = self.lexer.tokenize(source, name, filename, state, preserve_comments)
+        stream = self.lexer.tokenize(source, name, filename, state)
 
         for ext in self.iter_extensions():
             stream = ext.filter_stream(stream)  # type: ignore

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -615,10 +615,7 @@ class Environment:
             self.handle_exception(source=source)
 
     def _parse(
-        self,
-        source: str,
-        name: t.Optional[str],
-        filename: t.Optional[str],
+        self, source: str, name: t.Optional[str], filename: t.Optional[str]
     ) -> nodes.Template:
         """Internal parsing function used by `parse` and `compile`."""
         return Parser(self, source, name, filename).parse()

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -146,22 +146,7 @@ operator_re = re.compile(
     f"({'|'.join(re.escape(x) for x in sorted(operators, key=lambda x: -len(x)))})"
 )
 
-comment_tokens = frozenset(
-    [
-        TOKEN_COMMENT_BEGIN,
-        TOKEN_COMMENT,
-        TOKEN_COMMENT_END,
-        TOKEN_LINECOMMENT_BEGIN,
-        TOKEN_LINECOMMENT_END,
-        TOKEN_LINECOMMENT,
-    ]
-)
-ignored_tokens = frozenset(
-    [
-        TOKEN_WHITESPACE,
-        *comment_tokens,
-    ]
-)
+ignored_tokens = frozenset([TOKEN_WHITESPACE])
 ignore_if_empty = frozenset(
     [TOKEN_WHITESPACE, TOKEN_DATA, TOKEN_COMMENT, TOKEN_LINECOMMENT]
 )
@@ -612,37 +597,22 @@ class Lexer:
         name: t.Optional[str] = None,
         filename: t.Optional[str] = None,
         state: t.Optional[str] = None,
-        preserve_comments: bool = False,
     ) -> TokenStream:
-        """Calls tokeniter + tokenize and wraps it in a token stream.
-
-        .. versionchanged:: 3.2
-            Added `preserve_comments` parameter.
-        """
+        """Calls tokeniter + tokenize and wraps it in a token stream."""
         stream = self.tokeniter(source, name, filename, state)
-        return TokenStream(
-            self.wrap(stream, name, filename, preserve_comments), name, filename
-        )
+        return TokenStream(self.wrap(stream, name, filename), name, filename)
 
     def wrap(
         self,
         stream: t.Iterable[t.Tuple[int, str, str]],
         name: t.Optional[str] = None,
         filename: t.Optional[str] = None,
-        preserve_comments: bool = False,
     ) -> t.Iterator[Token]:
         """This is called with the stream as returned by `tokenize` and wraps
         every token in a :class:`Token` and converts the value.
-
-        .. versionchanged:: 3.2
-            Added `preserve_comments` parameter.
         """
-        ignored = ignored_tokens
-        if preserve_comments:
-            ignored -= comment_tokens
-
         for lineno, token, value_str in stream:
-            if token in ignored:
+            if token in ignored_tokens:
                 continue
 
             value: t.Any = value_str

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -614,7 +614,11 @@ class Lexer:
         state: t.Optional[str] = None,
         preserve_comments: bool = False,
     ) -> TokenStream:
-        """Calls tokeniter + tokenize and wraps it in a token stream."""
+        """Calls tokeniter + tokenize and wraps it in a token stream.
+
+        .. versionchanged:: 3.2
+            Added `preserve_comments` parameter.
+        """
         stream = self.tokeniter(source, name, filename, state)
         return TokenStream(
             self.wrap(stream, name, filename, preserve_comments), name, filename
@@ -629,6 +633,9 @@ class Lexer:
     ) -> t.Iterator[Token]:
         """This is called with the stream as returned by `tokenize` and wraps
         every token in a :class:`Token` and converts the value.
+
+        .. versionchanged:: 3.2
+            Added `preserve_comments` parameter.
         """
         ignored = ignored_tokens
         if preserve_comments:

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -715,6 +715,13 @@ class CondExpr(Expr):
         return self.expr2.as_const(eval_ctx)
 
 
+class Comment(Stmt):
+    """A template comment."""
+
+    fields = ("data",)
+    data: str
+
+
 def args_as_const(
     node: t.Union["_FilterTestCommon", "Call"], eval_ctx: t.Optional[EvalContext]
 ) -> t.Tuple[t.List[t.Any], t.Dict[t.Any, t.Any]]:

--- a/src/jinja2/parser.py
+++ b/src/jinja2/parser.py
@@ -57,9 +57,12 @@ class Parser:
         name: t.Optional[str] = None,
         filename: t.Optional[str] = None,
         state: t.Optional[str] = None,
+        preserve_comments: bool = False,
     ) -> None:
         self.environment = environment
-        self.stream = environment._tokenize(source, name, filename, state)
+        self.stream = environment._tokenize(
+            source, name, filename, state, preserve_comments
+        )
         self.name = name
         self.filename = filename
         self.closed = False
@@ -1025,6 +1028,11 @@ class Parser:
                     else:
                         body.append(rv)
                     self.stream.expect("block_end")
+                elif token.type == "comment_begin":
+                    flush_data()
+                    next(self.stream)
+                    body.append(nodes.Comment(next(self.stream).value))
+                    self.stream.expect("comment_end")
                 else:
                     raise AssertionError("internal parsing error")
 

--- a/src/jinja2/parser.py
+++ b/src/jinja2/parser.py
@@ -57,12 +57,9 @@ class Parser:
         name: t.Optional[str] = None,
         filename: t.Optional[str] = None,
         state: t.Optional[str] = None,
-        preserve_comments: bool = False,
     ) -> None:
         self.environment = environment
-        self.stream = environment._tokenize(
-            source, name, filename, state, preserve_comments
-        )
+        self.stream = environment._tokenize(source, name, filename, state)
         self.name = name
         self.filename = filename
         self.closed = False
@@ -318,10 +315,13 @@ class Parser:
         # with whitespace data
         if node.required:
             for body_node in node.body:
-                if not isinstance(body_node, nodes.Output) or any(
-                    not isinstance(output_node, nodes.TemplateData)
-                    or not output_node.data.isspace()
-                    for output_node in body_node.nodes
+                if not isinstance(body_node, (nodes.Output, nodes.Comment)) or (
+                    isinstance(body_node, nodes.Output)
+                    and any(
+                        not isinstance(output_node, nodes.TemplateData)
+                        or not output_node.data.isspace()
+                        for output_node in body_node.nodes
+                    )
                 ):
                     self.fail("Required blocks can only contain comments or whitespace")
 

--- a/tests/test_lexnparse.py
+++ b/tests/test_lexnparse.py
@@ -314,6 +314,28 @@ and bar comment #}
         )
         assert_error("{% unknown_tag %}", "Encountered unknown tag 'unknown_tag'.")
 
+    def test_comment_preservation(self, env):
+        ast = env.parse("{# foo #}{{ bar }}", preserve_comments=True)
+        assert len(ast.body) == 2
+        assert isinstance(ast.body[0], nodes.Comment)
+        assert ast.body[0].data == " foo "
+
+        ast = env.parse("{# foo #}{{ bar }}", preserve_comments=False)
+        assert len(ast.body) == 1
+        assert not isinstance(ast.body[0], nodes.Comment)
+
+    def test_line_comment_preservation(self, env):
+        env = Environment(line_comment_prefix="#")
+
+        ast = env.parse("# foo\n{{ bar }}", preserve_comments=True)
+        assert len(ast.body) == 2
+        assert isinstance(ast.body[0], nodes.Comment)
+        assert ast.body[0].data == " foo"
+
+        ast = env.parse("# foo\n{{ bar }}", preserve_comments=False)
+        assert len(ast.body) == 1
+        assert not isinstance(ast.body[0], nodes.Comment)
+
 
 class TestSyntax:
     def test_call(self, env):

--- a/tests/test_lexnparse.py
+++ b/tests/test_lexnparse.py
@@ -315,26 +315,17 @@ and bar comment #}
         assert_error("{% unknown_tag %}", "Encountered unknown tag 'unknown_tag'.")
 
     def test_comment_preservation(self, env):
-        ast = env.parse("{# foo #}{{ bar }}", preserve_comments=True)
+        ast = env.parse("{# foo #}{{ bar }}")
         assert len(ast.body) == 2
         assert isinstance(ast.body[0], nodes.Comment)
         assert ast.body[0].data == " foo "
 
-        ast = env.parse("{# foo #}{{ bar }}", preserve_comments=False)
-        assert len(ast.body) == 1
-        assert not isinstance(ast.body[0], nodes.Comment)
-
     def test_line_comment_preservation(self, env):
         env = Environment(line_comment_prefix="#")
-
-        ast = env.parse("# foo\n{{ bar }}", preserve_comments=True)
+        ast = env.parse("# foo\n{{ bar }}")
         assert len(ast.body) == 2
         assert isinstance(ast.body[0], nodes.Comment)
         assert ast.body[0].data == " foo"
-
-        ast = env.parse("# foo\n{{ bar }}", preserve_comments=False)
-        assert len(ast.body) == 1
-        assert not isinstance(ast.body[0], nodes.Comment)
 
 
 class TestSyntax:


### PR DESCRIPTION
~~Add the `preserve_comments` parameter to `Environment.parse` to preserve comments in template ASTs.~~

Create a new `Comment` node, and always preserve those in ASTs obtained from `Environment.parse`.

Fixes #1967.

- [x] Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
