### PR TITLE
Fix typo in templates docs

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -1778,7 +1778,7 @@ It's possible to translate strings in expressions with these functions:
 
 -   ``_(message)``: Alias for ``gettext``.
 -   ``gettext(message)``: Translate a message.
--   ``ngettext(singluar, plural, n)``: Translate a singular or plural
+-   ``ngettext(singular, plural, n)``: Translate a singular or plural
     message based on a count variable.
 -   ``pgettext(context, message)``: Like ``gettext()``, but picks the
     translation based on the context string.


### PR DESCRIPTION
This fixes a minor typo in the parameters to ngettext in the templates docs.

I left out changes.rst from this as it's just a single word, and I don't think it necessarily justifies a changelog entry