### PR TITLE
Add contains test

### DIFF
--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -207,10 +207,19 @@ def test_escaped(value: t.Any) -> bool:
 
 def test_in(value: t.Any, seq: t.Container[t.Any]) -> bool:
     """Check if value is in seq.
+    Opposite of the 'in' test, allowing use as a test in filters like 'selectattr'
+
+    .. versionadded:: ??
+    """
+    return value in seq
+
+
+def test_contains(value: t.Any, seq: t.Container[t.Any]) -> bool:
+    """Check if seq is in value.
 
     .. versionadded:: 2.10
     """
-    return value in seq
+    return seq in value
 
 
 TESTS = {
@@ -238,6 +247,7 @@ TESTS = {
     "sameas": test_sameas,
     "escaped": test_escaped,
     "in": test_in,
+    "contains": test_contains,
     "==": operator.eq,
     "eq": operator.eq,
     "equalto": operator.eq,

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -209,6 +209,22 @@ class TestTestsCase:
         )
         assert tmpl.render() == "True|True|False|True|False|True|False|True|False"
 
+    def test_contains(self, env):
+        tmpl = env.from_string(
+            '{{ "foo" is contains "o" }}|'
+            '{{ "foo" is contains "foo" }}|'
+            '{{ "foo" is contains "b" }}|'
+            "{{ ((1, 2)) is contains 1 }}|"
+            "{{ ((1, 2)) is contains 3 }}|"
+            "{{ [1, 2] is contains 1 }}|"
+            "{{ [1, 2] is contains 3 }}|"
+            '{{ {"foo": 1} is contains "foo" }}|'
+            '{{ {"bar": 1} is contains "baz" }}|'
+            '{{ [{"foo": "bar"}, {"foo": "fighter"}] | '
+            'selectattr("foo", "contains", "ba") | list | length }}'
+        )
+        assert tmpl.render() == "True|True|False|True|False|True|False|True|False|1"
+
 
 def test_name_undefined(env):
     with pytest.raises(TemplateAssertionError, match="No test named 'f'"):


### PR DESCRIPTION
This update adds the 'contains' test which is to be used as the opposite of the 'in' test. Especially useful with the 'selectattr' and 'map' filters.

fixes #1766 