### PR TITLE
Fix nl2br example in documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -697,10 +697,10 @@ enabled before escaping the input and marking the output safe.
             br = Markup(br)
 
         result = "\n\n".join(
-            f"<p>{br.join(p.splitlines())}<\p>"
+            f"<p>{br.join(p.splitlines())}</p>"
             for p in re.split(r"(?:\r\n|\r(?!\n)|\n){2,}", value)
         )
-        return Markup(result) if autoescape else result
+        return Markup(result) if eval_ctx.autoescape else result
 
 
 .. _writing-tests:


### PR DESCRIPTION
The `nl2br` filter example in the documentation does not work as is, and I needed to make some changes to make it work.

This PR fixes the previously reported https://github.com/pallets/jinja/issues/1769 issue and supersedes the proposed fix (https://github.com/pallets/jinja/pull/1770) as it also fixes the typo in the closing `</p>` tag.

fixes #1769