### PR TITLE
don't apply `urlize` to `@a@b`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Unreleased
 -   ``PackageLoader`` shows a clearer error message when the package does not
     contain the templates directory. :issue:`1705`
 -   Improve annotations for methods returning copies. :pr:`1880`
+-   ``urlize`` does not add ``mailto:`` to values like `@a@b`. :pr:`1870`
 
 
 Version 3.1.4

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -333,6 +333,8 @@ def urlize(
         elif (
             "@" in middle
             and not middle.startswith("www.")
+            # ignore values like `@a@b`
+            and not middle.startswith("@")
             and ":" not in middle
             and _email_re.match(middle)
         ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,6 +142,14 @@ class TestEscapeUrlizeTarget:
             "http://example.org</a>"
         )
 
+    def test_urlize_mail_mastodon(self):
+        fr = "nabijaczleweli@nabijaczleweli.xyz\n@eater@cijber.social\n"
+        to = (
+            '<a href="mailto:nabijaczleweli@nabijaczleweli.xyz">'
+            "nabijaczleweli@nabijaczleweli.xyz</a>\n@eater@cijber.social\n"
+        )
+        assert urlize(fr) == to
+
 
 class TestLoremIpsum:
     def test_lorem_ipsum_markup(self):


### PR DESCRIPTION
Don't apply `urlize` to values like `@a@b`.

continues #1870 