### PR TITLE
Add pathlike support to stream dump

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Add support for ``pathlib.Path`` and ``os.Pathlike`` objects to
+    ``TemplateStream.dump``. :issue:`2039`
 
 
 Version 3.1.5


### PR DESCRIPTION
## Adds support for Path and Pathlike objects to `TemplateStream.dump`. 

### My understanding of the existing code is:
1. Strings are treated as file paths
2. Other valid objects implement a `write(value: bytes) -> None` or `writelines(Iterable[bytes]) -> None` method.
3. Invalid objects raise an `AttributeError`, e.g. `AttributeError: 'NoneType' object has no attribute 'write'`

### My change would modify the behavior to:
1. Any object that the builtin `open` can handle as a file path is a valid file path. This includes the requested `pathlib.Path` and PathLike objects.
2. This functionality is unchanged.
3. Invalid objects still raise an `AttributeError` with a slightly more informative message `AttributeError: 'NoneType' object has no attribute 'write' or 'writelines'`

### Possible Breaking Changes (No tests guarantee this functionality):
1. Any object that isn't a string but `open` is capable of handling. 
2. Any equality checks on the error message for the `AttributeError`

This does not address #1983 the only changes to the typing is the inclusion of the full set of types that `open` implements. 

fixes #2039 

### Desired Feedback
1. This is my first PR for a pallets project. Any feedback is welcome. 
2. The tests are very comprehensive, and may be too much for the code base. Happy to scale them back in any way. 