### PR TITLE
Fix async sort filter

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -383,7 +383,7 @@ def do_dictsort(
 
 
 @pass_environment
-def do_sort(
+def sync_do_sort(
     environment: "Environment",
     value: "t.Iterable[V]",
     reverse: bool = False,
@@ -436,6 +436,20 @@ def do_sort(
         environment, attribute, postprocess=ignore_case if not case_sensitive else None
     )
     return sorted(value, key=key_func, reverse=reverse)
+
+
+@async_variant(sync_do_sort)  # type: ignore
+async def do_sort(
+    environment: "Environment",
+    value: "t.Union[t.AsyncIterable[V], t.Iterable[V]]",
+    reverse: bool = False,
+    case_sensitive: bool = False,
+    attribute: t.Optional[t.Union[str, int]] = None,
+) -> "t.List[V]":
+    key_func = make_multi_attrgetter(
+        environment, attribute, postprocess=ignore_case if not case_sensitive else None
+    )
+    return sorted(await auto_to_list(value), key=key_func, reverse=reverse)
 
 
 @pass_environment

--- a/tests/test_async_filters.py
+++ b/tests/test_async_filters.py
@@ -218,6 +218,12 @@ def test_simple_map(env_async, items):
     assert tmpl.render(items=items) == "6"
 
 
+@mark_dualiter("items", lambda: list("1423"))
+def test_simple_map_sort(env_async, items):
+    tmpl = env_async.from_string('{{ items()|map("int")|sort }}')
+    assert tmpl.render(items=items) == "[1, 2, 3, 4]"
+
+
 def test_map_sum(env_async):  # async map + async filter
     tmpl = env_async.from_string('{{ [[1,2], [3], [4,5,6]]|map("sum")|list }}')
     assert tmpl.render() == "[3, 3, 15]"


### PR DESCRIPTION
This PR fixes an issue when rendering templates in async mode and combining map and sort. It's implemented using the same type of workaround that the `list` filter seems to already be using.

fixes #2081

I haven't contributed to Jinja before and I'm unsure about what an entry should look like in CHANGES.rst if there's no upcoming version listed there.