### PR TITLE
deprecate `__version__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Drop support for Python 3.7, 3.8, and 3.9.
 -   Update minimum MarkupSafe version to >= 3.0.
 -   Update minimum Babel version to >= 2.17.
+-   Deprecate the ``__version__`` attribute. Use feature detection or
+    ``importlib.metadata.version("jinja2")`` instead.
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "Jinja2"
+version = "3.2.0.dev"
 description = "A very fast and expressive template engine."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -17,7 +18,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = ["MarkupSafe>=3.0"]
-dynamic = ["version"]
 
 [project.urls]
 Donate = "https://palletsprojects.com/donate"

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -3,6 +3,10 @@ non-XML syntax that supports inline expressions and an optional
 sandboxed environment.
 """
 
+from __future__ import annotations
+
+import typing as t
+
 from .bccache import BytecodeCache as BytecodeCache
 from .bccache import FileSystemBytecodeCache as FileSystemBytecodeCache
 from .bccache import MemcachedBytecodeCache as MemcachedBytecodeCache
@@ -35,4 +39,19 @@ from .utils import pass_environment as pass_environment
 from .utils import pass_eval_context as pass_eval_context
 from .utils import select_autoescape as select_autoescape
 
-__version__ = "3.2.0.dev0"
+
+def __getattr__(name: str) -> t.Any:
+    if name == "__version__":
+        import importlib.metadata
+        import warnings
+
+        warnings.warn(
+            "The `__version__` attribute is deprecated and will be removed in"
+            " Werkzeug 3.3. Use feature detection or"
+            ' `importlib.metadata.version("werkzeug")` instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return importlib.metadata.version("werkzeug")
+
+    raise AttributeError(name)

--- a/uv.lock
+++ b/uv.lock
@@ -313,6 +313,7 @@ wheels = [
 
 [[package]]
 name = "jinja2"
+version = "3.2.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "markupsafe" },


### PR DESCRIPTION
As has been done with the other Pallets projects.

The `__version__` attribute is an old pattern from early in Python packaging. Setuptools eventually made it easier to use the pattern by allowing reading the value from the attribute at build time, and some other build backends have done the same.

However, there's no reason to expose this directly in code anymore. It's usually better to use feature detection (`hasattr`, `try/except`) instead. `importlib.metadata.version("jinja2")` can be used to get the version at runtime in a standard way, if it's really needed.