### PR TITLE
Use the currently handled exception as UndefinedError.__context__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   When ``Undefined`` is created in an ``except`` block, the handled
+    exception is stored in a new  attribute, ``_undefined_context``,
+    and used as the default ``__context__`` for errors raised by
+    ``_fail_with_undefined_error``.
 
 
 Version 3.1.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
     exception is stored in a new  attribute, ``_undefined_context``,
     and used as the default ``__context__`` for errors raised by
     ``_fail_with_undefined_error``.
+    :issue:`2103`
 
 
 Version 3.1.6

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -289,6 +289,9 @@ others fail.
 The closest to regular Python behavior is the :class:`StrictUndefined` which
 disallows all operations beside testing if it's an undefined object.
 
+When :class:`Undefined` is created in an ``except`` or ``finally`` clause,
+
+
 .. autoclass:: jinja2.Undefined()
 
     .. attribute:: _undefined_hint
@@ -310,6 +313,15 @@ disallows all operations beside testing if it's an undefined object.
 
         The exception that the undefined object wants to raise.  This
         is usually one of :exc:`UndefinedError` or :exc:`SecurityError`.
+
+    .. attribute:: _undefined_context
+
+        The default ``__context__`` for exceptions raised when operations
+        on this undefined value fail.
+
+        When :class:`Undefined` is created while an exception is being
+        handled (for example, inside an ``except``  clause),
+        ``_undefined_context`` is automatically set to the handled exception.
 
     .. method:: _fail_with_undefined_error(\*args, \**kwargs)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -289,7 +289,6 @@ others fail.
 The closest to regular Python behavior is the :class:`StrictUndefined` which
 disallows all operations beside testing if it's an undefined object.
 
-
 .. autoclass:: jinja2.Undefined()
 
     .. attribute:: _undefined_hint

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -289,8 +289,6 @@ others fail.
 The closest to regular Python behavior is the :class:`StrictUndefined` which
 disallows all operations beside testing if it's an undefined object.
 
-When :class:`Undefined` is created in an ``except`` or ``finally`` clause,
-
 
 .. autoclass:: jinja2.Undefined()
 
@@ -315,6 +313,8 @@ When :class:`Undefined` is created in an ``except`` or ``finally`` clause,
         is usually one of :exc:`UndefinedError` or :exc:`SecurityError`.
 
     .. attribute:: _undefined_context
+
+        .. versionadded:: 3.2
 
         The default ``__context__`` for exceptions raised when operations
         on this undefined value fail.

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -473,12 +473,12 @@ class Environment:
                 try:
                     attr = str(argument)
                 except Exception:
-                    pass
+                    return self.undefined(obj=obj, name=argument)
                 else:
                     try:
                         return getattr(obj, attr)
                     except AttributeError:
-                        pass
+                        return self.undefined(obj=obj, name=argument)
             return self.undefined(obj=obj, name=argument)
 
     def getattr(self, obj: t.Any, attribute: str) -> t.Any:
@@ -488,11 +488,10 @@ class Environment:
         try:
             return getattr(obj, attribute)
         except AttributeError:
-            pass
-        try:
-            return obj[attribute]
-        except (TypeError, LookupError, AttributeError):
-            return self.undefined(obj=obj, name=attribute)
+            try:
+                return obj[attribute]
+            except (TypeError, LookupError, AttributeError):
+                return self.undefined(obj=obj, name=attribute)
 
     def _filter_test_common(
         self,

--- a/src/jinja2/runtime.py
+++ b/src/jinja2/runtime.py
@@ -813,6 +813,7 @@ class Undefined:
         "_undefined_obj",
         "_undefined_name",
         "_undefined_exception",
+        "_undefined_context",
     )
 
     def __init__(
@@ -826,6 +827,10 @@ class Undefined:
         self._undefined_obj = obj
         self._undefined_name = name
         self._undefined_exception = exc
+
+        cause: BaseException | None
+        _, cause, _ = sys.exc_info()
+        self._undefined_context = cause
 
     @property
     def _undefined_message(self) -> str:
@@ -856,7 +861,10 @@ class Undefined:
         """Raise an :exc:`UndefinedError` when operations are performed
         on the undefined value.
         """
-        raise self._undefined_exception(self._undefined_message)
+        exception = self._undefined_exception(self._undefined_message)
+        if exception.__context__ is None:
+            exception.__context__ = self._undefined_context
+        raise exception
 
     @internalcode
     def __getattr__(self, name: str) -> t.Any:

--- a/src/jinja2/sandbox.py
+++ b/src/jinja2/sandbox.py
@@ -299,7 +299,7 @@ class SandboxedEnvironment(Environment):
                     try:
                         value = getattr(obj, attr)
                     except AttributeError:
-                        pass
+                        return self.undefined(obj=obj, name=argument)
                     else:
                         fmt = self.wrap_str_format(value)
                         if fmt is not None:
@@ -319,7 +319,7 @@ class SandboxedEnvironment(Environment):
             try:
                 return obj[attribute]
             except (TypeError, LookupError):
-                pass
+                return self.undefined(obj=obj, name=attribute)
         else:
             fmt = self.wrap_str_format(value)
             if fmt is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -256,7 +256,7 @@ class TestStreaming:
 
 @contextlib.contextmanager
 def raises_cause_chain(expected_exception, *expected_chain, **kwargs):
-    """Like ``, but assert a specific __cause__/__context__ chain
+    """Like pytest.raises, but assert a specific __cause__/__context__ chain
 
     Used `with pytest.raises(expected_exception):`, but additional positional
     arguments must match types of exceptions in the __cause__/__context__ chain

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import contextlib
 import shutil
 import tempfile
 from pathlib import Path
@@ -253,6 +254,30 @@ class TestStreaming:
             shutil.rmtree(tmp)
 
 
+@contextlib.contextmanager
+def raises_cause_chain(expected_exception, *expected_chain, **kwargs):
+    """Like ``, but assert a specific __cause__/__context__ chain
+
+    Used `with pytest.raises(expected_exception):`, but additional positional
+    arguments must match types of exceptions in the __cause__/__context__ chain
+    ("The above exception was the direct cause of the following exception" and
+    "During handling of the above exception, another exception occurred" in
+    tracebacks).
+    """
+    with pytest.raises(expected_exception, **kwargs) as info:
+        yield info
+    got_chain = []
+    current = info.value
+    while current:
+        got_chain.append(type(current))
+        current = current.__cause__ or current.__context__
+    try:
+        assert got_chain == [expected_exception, *expected_chain]
+    except AssertionError as exc:
+        raise exc from info.value
+    return info
+
+
 class TestUndefined:
     def test_stopiteration_is_undefined(self):
         def test():
@@ -295,7 +320,8 @@ class TestUndefined:
         logging_undefined = make_logging_undefined(DebugLogger())
         env = Environment(undefined=logging_undefined)
         assert env.from_string("{{ missing }}").render() == ""
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing.attribute }}").render()
         assert env.from_string("{{ missing|list }}").render() == "[]"
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
@@ -311,12 +337,14 @@ class TestUndefined:
     def test_default_undefined(self):
         env = Environment(undefined=Undefined)
         assert env.from_string("{{ missing }}").render() == ""
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing.attribute }}").render()
         assert env.from_string("{{ missing|list }}").render() == "[]"
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
         assert env.from_string("{{ not missing }}").render() == "True"
-        pytest.raises(UndefinedError, env.from_string("{{ missing - 1}}").render)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing - 1}}").render()
         assert env.from_string("{{ 'foo' in missing }}").render() == "False"
         und1 = Undefined(name="x")
         und2 = Undefined(name="y")
@@ -332,7 +360,8 @@ class TestUndefined:
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
         assert env.from_string("{{ not missing }}").render() == "True"
-        pytest.raises(UndefinedError, env.from_string("{{ missing - 1}}").render)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing - 1}}").render()
 
         # The following tests ensure subclass functionality works as expected
         assert env.from_string('{{ missing.bar["baz"] }}').render() == ""
@@ -351,7 +380,8 @@ class TestUndefined:
     def test_debug_undefined(self):
         env = Environment(undefined=DebugUndefined)
         assert env.from_string("{{ missing }}").render() == "{{ missing }}"
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing.attribute }}").render()
         assert env.from_string("{{ missing|list }}").render() == "[]"
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert (
@@ -367,15 +397,21 @@ class TestUndefined:
 
     def test_strict_undefined(self):
         env = Environment(undefined=StrictUndefined)
-        pytest.raises(UndefinedError, env.from_string("{{ missing }}").render)
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
-        pytest.raises(UndefinedError, env.from_string("{{ missing|list }}").render)
-        pytest.raises(UndefinedError, env.from_string("{{ 'foo' in missing }}").render)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing }}").render()
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing.attribute }}").render()
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing|list }}").render()
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ 'foo' in missing }}").render()
         assert env.from_string("{{ missing is not defined }}").render() == "True"
-        pytest.raises(
-            UndefinedError, env.from_string("{{ foo.missing }}").render, foo=42
-        )
-        pytest.raises(UndefinedError, env.from_string("{{ not missing }}").render)
+        with raises_cause_chain(UndefinedError, TypeError, AttributeError):
+            env.from_string("{{ foo.missing }}").render(foo=42)
+        with raises_cause_chain(UndefinedError, AttributeError, TypeError):
+            env.from_string("{{ foo['missing'] }}").render(foo=42)
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ not missing }}").render()
         assert (
             env.from_string('{{ missing|default("default", true) }}').render()
             == "default"
@@ -384,7 +420,8 @@ class TestUndefined:
 
     def test_indexing_gives_undefined(self):
         t = Template("{{ var[42].foo }}")
-        pytest.raises(UndefinedError, t.render, var=0)
+        with raises_cause_chain(UndefinedError, TypeError):
+            t.render(var=0)
 
     def test_none_gives_proper_error(self):
         with pytest.raises(UndefinedError, match="'None' has no attribute 'split'"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,9 @@ from jinja2 import TemplatesNotFound
 from jinja2 import Undefined
 from jinja2 import UndefinedError
 from jinja2.compiler import CodeGenerator
+from jinja2.nativetypes import NativeEnvironment
 from jinja2.runtime import Context
+from jinja2.sandbox import SandboxedEnvironment
 from jinja2.utils import Cycler
 from jinja2.utils import pass_context
 from jinja2.utils import pass_environment
@@ -27,8 +29,6 @@ from jinja2.utils import pass_eval_context
 
 class TestExtendedAPI:
     def test_item_and_attribute(self, env):
-        from jinja2.sandbox import SandboxedEnvironment
-
         for env in Environment(), SandboxedEnvironment():
             tmpl = env.from_string("{{ foo.items()|list }}")
             assert tmpl.render(foo={"items": 42}) == "[('items', 42)]"
@@ -152,7 +152,6 @@ class TestExtendedAPI:
 
     def test_sandbox_max_range(self, env):
         from jinja2.sandbox import MAX_RANGE
-        from jinja2.sandbox import SandboxedEnvironment
 
         env = SandboxedEnvironment()
         t = env.from_string("{% for item in range(total) %}{{ item }}{% endfor %}")
@@ -334,8 +333,9 @@ class TestUndefined:
             "W:Template variable warning: 'missing' is undefined",
         ]
 
-    def test_default_undefined(self):
-        env = Environment(undefined=Undefined)
+    @pytest.mark.parametrize("env_class", [Environment, SandboxedEnvironment])
+    def test_default_undefined(self, env_class):
+        env = env_class(undefined=Undefined)
         assert env.from_string("{{ missing }}").render() == ""
         with raises_cause_chain(UndefinedError):
             env.from_string("{{ missing.attribute }}").render()
@@ -377,8 +377,9 @@ class TestUndefined:
             == "baz"
         )
 
-    def test_debug_undefined(self):
-        env = Environment(undefined=DebugUndefined)
+    @pytest.mark.parametrize("env_class", [Environment, SandboxedEnvironment])
+    def test_debug_undefined(self, env_class):
+        env = env_class(undefined=DebugUndefined)
         assert env.from_string("{{ missing }}").render() == "{{ missing }}"
         with raises_cause_chain(UndefinedError):
             env.from_string("{{ missing.attribute }}").render()
@@ -395,8 +396,9 @@ class TestUndefined:
             == f"{{{{ undefined value printed: {undefined_hint} }}}}"
         )
 
-    def test_strict_undefined(self):
-        env = Environment(undefined=StrictUndefined)
+    @pytest.mark.parametrize("env_class", [Environment, SandboxedEnvironment])
+    def test_strict_undefined(self, env_class):
+        env = env_class(undefined=StrictUndefined)
         with raises_cause_chain(UndefinedError):
             env.from_string("{{ missing }}").render()
         with raises_cause_chain(UndefinedError):
@@ -417,6 +419,30 @@ class TestUndefined:
             == "default"
         )
         assert env.from_string('{{ "foo" if false }}').render() == ""
+
+    def test_strict_undefined_native_env(self):
+        # Like test_strict_undefined, but with additional str() calls to raise errors
+        env = NativeEnvironment(undefined=StrictUndefined)
+        with raises_cause_chain(UndefinedError):
+            str(env.from_string("{{ missing }}").render())
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing.attribute }}").render()
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ missing|list }}").render()
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ 'foo' in missing }}").render()
+        assert str(env.from_string("{{ missing is not defined }}").render()) == "True"
+        with raises_cause_chain(UndefinedError, TypeError, AttributeError):
+            str(env.from_string("{{ foo.missing }}").render(foo=42))
+        with raises_cause_chain(UndefinedError, AttributeError, TypeError):
+            str(env.from_string("{{ foo['missing'] }}").render(foo=42))
+        with raises_cause_chain(UndefinedError):
+            env.from_string("{{ not missing }}").render()
+        assert (
+            env.from_string('{{ missing|default("default", true) }}').render()
+            == "default"
+        )
+        assert str(env.from_string('{{ "foo" if false }}').render()) == ""
 
     def test_indexing_gives_undefined(self):
         t = Template("{{ var[42].foo }}")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -123,3 +123,27 @@ def test_undefined_pickle(undefined_type):
     assert copied._undefined_name is not undef._undefined_name
     assert copied._undefined_name == undef._undefined_name
     assert copied._undefined_exception is undef._undefined_exception
+
+
+@pytest.mark.parametrize("undefined_type", _undefined_types)
+def test_undefined_cause(undefined_type):
+    exception = ValueError("foo")
+    try:
+        raise exception
+    except ValueError:
+        undef = undefined_type()
+    assert undef._undefined_context is exception
+    try:
+        undef._fail_with_undefined_error()
+    except TemplateRuntimeError as exc:
+        assert exc.__context__ is exception
+
+
+@pytest.mark.parametrize("undefined_type", _undefined_types)
+def test_undefined_no_cause(undefined_type):
+    undef = undefined_type()
+    assert undef._undefined_context is None
+    try:
+        undef._fail_with_undefined_error()
+    except TemplateRuntimeError as exc:
+        assert exc.__context__ is None


### PR DESCRIPTION
*At this point, please treat this PR as a “feasibility study” for issue #2103. There are other ways to fix this.*

---

Add ``Undefined._undefined_cause`` attribute, which is used as the default ``__context__`` for exceptions raised by that ``Undefined``.
When an ``Undefined`` is created, automatically set this attribute to the currently handled exception (or ``None``). This mirrors Python's own exception chaining.

Also, restructure `Environment.getitem` and `Environment.getattr` to use exception chaning to preserve the exceptions they encounter.

Fixes: #2103

- [x] TODO: add appropriate `.. versionadded::`
<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
