### PR TITLE
Changed the static annotation of default_for_string and default parameter of the select_autoescape method in utils.py file

### DIFF
--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -581,8 +581,8 @@ class LRUCache:
 def select_autoescape(
     enabled_extensions: t.Collection[str] = ("html", "htm", "xml"),
     disabled_extensions: t.Collection[str] = (),
-    default_for_string: bool = True,
-    default: bool = False,
+    default_for_string: bool | str = True,
+    default: bool | str = False,
 ) -> t.Callable[[str | None], bool]:
     """Intelligently sets the initial value of autoescaping based on the
     filename of the template.  This is the recommended way to configure


### PR DESCRIPTION
Changed the static type annotations of the default_for_string and default parameters of the select_autoescape method of the utils.py file. The static type annotation for default_for_string parameter has been changed from `bool = True` to `bool | str = True` and for the default parameter has been changed from `bool = False` to `bool | str = False`. The change has been made because string values has been passed to both the parameters in test cases file i.e. test_utils.py. The references for the codes has been given below:

https://github.com/pallets/jinja/blob/5ef70112a1ff19c05324ff889dd30405b1002044/src/jinja2/utils.py#L581
https://github.com/pallets/jinja/blob/5ef70112a1ff19c05324ff889dd30405b1002044/tests/test_utils.py#L119