### PR TITLE
support negative index as sort attributes

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -124,6 +124,15 @@ def make_multi_attrgetter(
     return attrgetter
 
 
+def _try_convert_int(
+    x: str,
+) -> str | int:
+    try:
+        return int(x)
+    except ValueError:
+        return x
+
+
 def _prepare_attribute_parts(
     attr: str | int | None,
 ) -> list[str | int]:
@@ -131,7 +140,7 @@ def _prepare_attribute_parts(
         return []
 
     if isinstance(attr, str):
-        return [int(x) if x.isdigit() else x for x in attr.split(".")]
+        return [_try_convert_int(x) for x in attr.split(".")]
 
     return [attr]
 


### PR DESCRIPTION
Modifies the `sort` filter implementation so that it recognizes negative numbers as indexes too.

fixes #2116 .

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
