### PR TITLE
Add async template loading APIs and async loader/bytecode-cache hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Drop support for Python 3.7, 3.8, and 3.9.
 -   Update minimum MarkupSafe version to >= 3.0.
 -   Update minimum Babel version to >= 2.17.
+-   Add async template loading and compilation APIs, including async loader and
+    bytecode cache hooks.
 -   Deprecate the ``__version__`` attribute. Use feature detection or
     ``importlib.metadata.version("jinja2")`` instead.
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -11,6 +11,7 @@ from .bccache import BytecodeCache as BytecodeCache
 from .bccache import FileSystemBytecodeCache as FileSystemBytecodeCache
 from .bccache import MemcachedBytecodeCache as MemcachedBytecodeCache
 from .environment import Environment as Environment
+from .environment import AsyncEnvironment as AsyncEnvironment
 from .environment import Template as Template
 from .exceptions import TemplateAssertionError as TemplateAssertionError
 from .exceptions import TemplateError as TemplateError

--- a/src/jinja2/bccache.py
+++ b/src/jinja2/bccache.py
@@ -198,7 +198,11 @@ class BytecodeCache:
         """Asynchronously return a cache bucket for the given template.  All arguments are
         mandatory but filename may be `None`.
         """
-        return self.get_bucket(environment, name, filename, source)
+        key = self.get_cache_key(name, filename)
+        checksum = self.get_source_checksum(source)
+        bucket = Bucket(environment, key, checksum)
+        await self.load_bytecode_async(bucket)
+        return bucket
 
     def set_bucket(self, bucket: Bucket) -> None:
         """Put the bucket into the cache."""
@@ -206,7 +210,7 @@ class BytecodeCache:
 
     async def set_bucket_async(self, bucket: Bucket) -> None:
         """Asynchronously put the bucket into the cache."""
-        self.set_bucket(bucket)
+        await self.dump_bytecode_async(bucket)
 
 
 class FileSystemBytecodeCache(BytecodeCache):

--- a/src/jinja2/bccache.py
+++ b/src/jinja2/bccache.py
@@ -134,12 +134,28 @@ class BytecodeCache:
         """
         raise NotImplementedError()
 
+    async def load_bytecode_async(self, bucket: Bucket) -> None:
+        """Subclasses have to override this method to load bytecode into a
+        bucket asynchronously.  If they are not able to find code in the cache for the
+        bucket, it must not do anything.
+        Unless overridden; this copies the behaviour of load_bytecode.
+        """
+        return self.load_bytecode(bucket)
+
     def dump_bytecode(self, bucket: Bucket) -> None:
         """Subclasses have to override this method to write the bytecode
         from a bucket back to the cache.  If it unable to do so it must not
         fail silently but raise an exception.
         """
         raise NotImplementedError()
+
+    async def dump_bytecode_async(self, bucket: Bucket) -> None:
+        """Subclasses have to override this method to write the bytecode
+        from a bucket back to the cache asynchronously.  If it is unable to do so it must not
+        fail silently but raise an exception.
+        Unless overridden; this copies the behaviour of dump_bytecode.
+        """
+        return self.dump_bytecode(bucket)
 
     def clear(self) -> None:
         """Clears the cache.  This method is not used by Jinja but should be
@@ -176,9 +192,21 @@ class BytecodeCache:
         self.load_bytecode(bucket)
         return bucket
 
+    async def get_bucket_async(
+        self, environment: "Environment", name: str, filename: str | None, source: str
+    ) -> Bucket:
+        """Asynchronously return a cache bucket for the given template.  All arguments are
+        mandatory but filename may be `None`.
+        """
+        return self.get_bucket(environment, name, filename, source)
+
     def set_bucket(self, bucket: Bucket) -> None:
         """Put the bucket into the cache."""
         self.dump_bytecode(bucket)
+
+    async def set_bucket_async(self, bucket: Bucket) -> None:
+        """Asynchronously put the bucket into the cache."""
+        self.set_bucket(bucket)
 
 
 class FileSystemBytecodeCache(BytecodeCache):

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -16,6 +16,7 @@ from types import CodeType
 from markupsafe import Markup
 
 from . import nodes
+from .compiler import AsyncCodeGenerator
 from .compiler import CodeGenerator
 from .compiler import generate
 from .defaults import BLOCK_END_STRING
@@ -895,6 +896,87 @@ class Environment:
 
         log_function("Finished compiling templates")
 
+    async def compile_templates_async(
+        self,
+        target: t.Union[str, "os.PathLike[str]"],
+        extensions: t.Collection[str] | None = None,
+        filter_func: t.Callable[[str], bool] | None = None,
+        zip: str | None = "deflated",
+        log_function: t.Callable[[str], None] | None = None,
+        ignore_errors: bool = True,
+    ) -> None:
+        """Asynchronously finds all the templates the loader can find, compiles them
+        and stores them in `target`.  If `zip` is `None`, instead of in a
+        zipfile, the templates will be stored in a directory.
+        By default, a deflate zip algorithm is used. To switch to
+        the stored algorithm, `zip` can be set to ``'stored'``.
+
+        `extensions` and `filter_func` are passed to :meth:`list_templates_async`.
+        Each template returned will be compiled to the target folder or
+        zipfile.
+
+        By default, template compilation errors are ignored.  In case a
+        log function is provided, errors are logged.  If you want template
+        syntax errors to abort the compilation you can set `ignore_errors`
+        to `False` and you will get an exception on syntax errors.
+
+        .. versionadded:: TBD
+        """
+        from .loaders import ModuleLoader
+
+        if log_function is None:
+
+            def log_function(x: str) -> None:
+                pass
+
+        assert log_function is not None
+        assert self.loader is not None, "No loader configured."
+
+        def write_file(filename: str, data: str) -> None:
+            if zip:
+                info = ZipInfo(filename)
+                info.external_attr = 0o755 << 16
+                zip_file.writestr(info, data)
+            else:
+                with open(os.path.join(target, filename), "wb") as f:
+                    f.write(data.encode("utf8"))
+
+        if zip is not None:
+            from zipfile import ZIP_DEFLATED
+            from zipfile import ZIP_STORED
+            from zipfile import ZipFile
+            from zipfile import ZipInfo
+
+            zip_file = ZipFile(
+                target, "w", dict(deflated=ZIP_DEFLATED, stored=ZIP_STORED)[zip]
+            )
+            log_function(f"Compiling into Zip archive {target!r}")
+        else:
+            if not os.path.isdir(target):
+                os.makedirs(target)
+            log_function(f"Compiling into folder {target!r}")
+
+        try:
+            for name in await self.list_templates_async(extensions, filter_func):
+                source, filename, _ = await self.loader.get_source_async(self, name)
+                try:
+                    code = self.compile(source, name, filename, True, True)
+                except TemplateSyntaxError as e:
+                    if not ignore_errors:
+                        raise
+                    log_function(f'Could not compile "{name}": {e}')
+                    continue
+
+                filename = ModuleLoader.get_module_filename(name)
+
+                write_file(filename, code)
+                log_function(f'Compiled "{name}" as {filename}')
+        finally:
+            if zip:
+                zip_file.close()
+
+        log_function("Finished compiling templates")
+
     def list_templates(
         self,
         extensions: t.Collection[str] | None = None,
@@ -917,6 +999,43 @@ class Environment:
         """
         assert self.loader is not None, "No loader configured."
         names = self.loader.list_templates()
+
+        if extensions is not None:
+            if filter_func is not None:
+                raise TypeError(
+                    "either extensions or filter_func can be passed, but not both"
+                )
+
+            def filter_func(x: str) -> bool:
+                return "." in x and x.rsplit(".", 1)[1] in extensions
+
+        if filter_func is not None:
+            names = [name for name in names if filter_func(name)]
+
+        return names
+
+    async def list_templates_async(
+        self,
+        extensions: t.Collection[str] | None = None,
+        filter_func: t.Callable[[str], bool] | None = None,
+    ) -> list[str]:
+        """Asynchronously returns a list of templates for this environment.  This requires
+        that the loader supports the loader's
+        :meth:`~BaseLoader.list_templates_async` method.
+
+        If there are other files in the template folder besides the
+        actual templates, the returned list can be filtered.  There are two
+        ways: either `extensions` is set to a list of file extensions for
+        templates, or a `filter_func` can be provided which is a callable that
+        is passed a template name and should return `True` if it should end up
+        in the result list.
+
+        If the loader does not support that, a :exc:`TypeError` is raised.
+
+        .. versionadded:: TBD
+        """
+        assert self.loader is not None, "No loader configured."
+        names = await self.loader.list_templates_async()
 
         if extensions is not None:
             if filter_func is not None:
@@ -978,6 +1097,31 @@ class Environment:
         return template
 
     @internalcode
+    async def _load_template_async(
+        self,
+        name: str,
+        globals: t.MutableMapping[str, t.Any] | None,
+    ) -> "Template":
+        if self.loader is None:
+            raise TypeError("no loader for this environment specified")
+        cache_key = (weakref.ref(self.loader), name)
+        if self.cache is not None:
+            template = self.cache.get(cache_key)
+            if template is not None and (
+                not self.auto_reload or template.is_up_to_date
+            ):
+                if globals:
+                    template.globals.update(globals)
+
+                return template
+
+        template = await self.loader.load_async(self, name, self.make_globals(globals))
+
+        if self.cache is not None:
+            self.cache[cache_key] = template
+        return template
+
+    @internalcode
     def get_template(
         self,
         name: t.Union[str, "Template"],
@@ -1013,6 +1157,37 @@ class Environment:
             name = self.join_path(name, parent)
 
         return self._load_template(name, globals)
+
+    @internalcode
+    async def get_template_async(
+        self,
+        name: t.Union[str, "Template"],
+        parent: str | None = None,
+        globals: t.MutableMapping[str, t.Any] | None = None,
+    ) -> "Template":
+        """Asynchronously load a template by name with :attr:`loader` and return a
+        :class:`Template`. If the template does not exist a
+        :exc:`TemplateNotFound` exception is raised.
+
+        :param name: Name of the template to load. When loading
+            templates from the filesystem, "/" is used as the path
+            separator, even on Windows.
+        :param parent: The name of the parent template importing this
+            template. :meth:`join_path` can be used to implement name
+            transformations with this.
+        :param globals: Extend the environment :attr:`globals` with
+            these extra variables available for all renders of this
+            template. If the template has already been loaded and
+            cached, its globals are updated with any new items.
+
+        .. versionadded:: TBD
+        """
+        if isinstance(name, Template):
+            return name
+        if parent is not None:
+            name = self.join_path(name, parent)
+
+        return await self._load_template_async(name, globals)
 
     @internalcode
     def select_template(
@@ -1069,6 +1244,47 @@ class Environment:
         raise TemplatesNotFound(names)  # type: ignore
 
     @internalcode
+    async def select_template_async(
+        self,
+        names: t.Iterable[t.Union[str, "Template"]],
+        parent: str | None = None,
+        globals: t.MutableMapping[str, t.Any] | None = None,
+    ) -> "Template":
+        """Like :meth:`get_template_async`, but asynchronously tries loading multiple names.
+        If none of the names can be loaded a :exc:`TemplatesNotFound`
+        exception is raised.
+
+        :param names: List of template names to try loading in order.
+        :param parent: The name of the parent template importing this
+            template. :meth:`join_path` can be used to implement name
+            transformations with this.
+        :param globals: Extend the environment :attr:`globals` with
+            these extra variables available for all renders of this
+            template. If the template has already been loaded and
+            cached, its globals are updated with any new items.
+
+        .. versionadded:: TBD
+        """
+        if isinstance(names, Undefined):
+            names._fail_with_undefined_error()
+
+        if not names:
+            raise TemplatesNotFound(
+                message="Tried to select from an empty list of templates."
+            )
+
+        for name in names:
+            if isinstance(name, Template):
+                return name
+            if parent is not None:
+                name = self.join_path(name, parent)
+            try:
+                return await self._load_template_async(name, globals)
+            except (TemplateNotFound, UndefinedError):
+                pass
+        raise TemplatesNotFound(names)  # type: ignore
+
+    @internalcode
     def get_or_select_template(
         self,
         template_name_or_list: t.Union[str, "Template", list[t.Union[str, "Template"]]],
@@ -1085,6 +1301,24 @@ class Environment:
         elif isinstance(template_name_or_list, Template):
             return template_name_or_list
         return self.select_template(template_name_or_list, parent, globals)
+
+    @internalcode
+    async def get_or_select_template_async(
+        self,
+        template_name_or_list: t.Union[str, "Template", list[t.Union[str, "Template"]]],
+        parent: str | None = None,
+        globals: t.MutableMapping[str, t.Any] | None = None,
+    ) -> "Template":
+        """Use :meth:`select_template_async` if an iterable of template names
+        is given, or :meth:`get_template_async` if one name is given.
+
+        .. versionadded:: TBD
+        """
+        if isinstance(template_name_or_list, (str, Undefined)):
+            return await self.get_template_async(template_name_or_list, parent, globals)
+        elif isinstance(template_name_or_list, Template):
+            return template_name_or_list
+        return await self.select_template_async(template_name_or_list, parent, globals)
 
     def from_string(
         self,
@@ -1128,6 +1362,19 @@ class Environment:
             d = {}
 
         return ChainMap(d, self.globals)
+
+
+class AsyncEnvironment(Environment):
+    code_generator_class: type["CodeGenerator"] = AsyncCodeGenerator
+
+    get_template = Environment.get_template_async
+    select_template = Environment.select_template_async
+    get_or_select_template = Environment.get_or_select_template_async
+    list_templates = Environment.list_templates_async
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.pop("enable_async", None)
+        super().__init__(*args, **kwargs, enable_async=True)
 
 
 class Template:
@@ -1548,6 +1795,10 @@ class TemplateModule:
         return f"<{type(self).__name__} {name}>"
 
 
+class AsyncTemplate(Template):
+    environment_class: type[Environment] = AsyncEnvironment
+
+
 class TemplateExpression:
     """The :meth:`jinja2.Environment.compile_expression` method returns an
     instance of this object.  It encapsulates the expression-like access
@@ -1664,3 +1915,4 @@ class TemplateStream:
 # hook in default template class.  if anyone reads this comment: ignore that
 # it's possible to use custom templates ;-)
 Environment.template_class = Template
+AsyncEnvironment.template_class = AsyncTemplate

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -920,7 +920,7 @@ class Environment:
         syntax errors to abort the compilation you can set `ignore_errors`
         to `False` and you will get an exception on syntax errors.
 
-        .. versionadded:: TBD
+        .. versionadded:: 3.2
         """
         from .loaders import ModuleLoader
 
@@ -1032,7 +1032,7 @@ class Environment:
 
         If the loader does not support that, a :exc:`TypeError` is raised.
 
-        .. versionadded:: TBD
+        .. versionadded:: 3.2
         """
         assert self.loader is not None, "No loader configured."
         names = await self.loader.list_templates_async()
@@ -1180,7 +1180,7 @@ class Environment:
             template. If the template has already been loaded and
             cached, its globals are updated with any new items.
 
-        .. versionadded:: TBD
+        .. versionadded:: 3.2
         """
         if isinstance(name, Template):
             return name
@@ -1263,7 +1263,7 @@ class Environment:
             template. If the template has already been loaded and
             cached, its globals are updated with any new items.
 
-        .. versionadded:: TBD
+        .. versionadded:: 3.2
         """
         if isinstance(names, Undefined):
             names._fail_with_undefined_error()
@@ -1312,7 +1312,7 @@ class Environment:
         """Use :meth:`select_template_async` if an iterable of template names
         is given, or :meth:`get_template_async` if one name is given.
 
-        .. versionadded:: TBD
+        .. versionadded:: 3.2
         """
         if isinstance(template_name_or_list, (str, Undefined)):
             return await self.get_template_async(template_name_or_list, parent, globals)

--- a/src/jinja2/sandbox.py
+++ b/src/jinja2/sandbox.py
@@ -14,6 +14,7 @@ from string import Formatter
 from markupsafe import EscapeFormatter
 from markupsafe import Markup
 
+from .environment import AsyncEnvironment
 from .environment import Environment
 from .exceptions import SecurityError
 from .runtime import Context
@@ -397,6 +398,10 @@ class SandboxedEnvironment(Environment):
         if not __self.is_safe_callable(__obj):
             raise SecurityError(f"{__obj!r} is not safely callable")
         return __context.call(__obj, *args, **kwargs)
+
+
+class AsyncSandboxedEnvironment(AsyncEnvironment, SandboxedEnvironment):
+    pass
 
 
 class ImmutableSandboxedEnvironment(SandboxedEnvironment):

--- a/tests/test_async_apis.py
+++ b/tests/test_async_apis.py
@@ -1,0 +1,94 @@
+import pytest
+
+from jinja2 import AsyncEnvironment
+from jinja2 import DictLoader
+from jinja2 import Environment
+from jinja2 import FunctionLoader
+from jinja2 import TemplateNotFound
+from jinja2 import loaders
+
+
+def test_get_template_async_works_with_sync_loader(run_async_fn):
+    env = Environment(loader=DictLoader({"a.html": "A"}))
+
+    async def load() -> str:
+        tmpl = await env.get_template_async("a.html")
+        return tmpl.render()
+
+    assert run_async_fn(load) == "A"
+
+
+def test_get_template_async_updates_globals_for_cached_template(run_async_fn):
+    env = Environment(loader=DictLoader({"a.html": "{{ foo }}"}), cache_size=-1)
+
+    async def load(value: str) -> str:
+        tmpl = await env.get_template_async("a.html", globals={"foo": value})
+        return tmpl.render()
+
+    assert run_async_fn(load, "one") == "one"
+    # Second load returns cached template, but should update globals.
+    assert run_async_fn(load, "two") == "two"
+
+
+def test_list_templates_async_falls_back_to_sync_loader(run_async_fn):
+    env = Environment(loader=DictLoader({"a.html": "A", "b.html": "B"}))
+
+    async def load() -> list[str]:
+        return await env.list_templates_async()
+
+    assert run_async_fn(load) == ["a.html", "b.html"]
+
+
+def test_function_loader_supports_async_callable(run_async_fn):
+    async def load_template(name: str) -> str | None:
+        if name == "a.html":
+            return "A"
+        return None
+
+    env = Environment(loader=FunctionLoader(load_template))
+
+    async def load() -> str:
+        tmpl = await env.get_template_async("a.html")
+        return tmpl.render()
+
+    assert run_async_fn(load) == "A"
+
+
+def test_async_environment_prefers_get_source_async(run_async_fn):
+    class Loader(loaders.BaseLoader):
+        def get_source(self, environment, template):  # pragma: no cover
+            raise AssertionError("sync get_source should not be called")
+
+        async def get_source_async(self, environment, template):
+            if template != "a.html":
+                raise TemplateNotFound(template)
+            return "A", None, lambda: True
+
+    env = AsyncEnvironment(loader=Loader())
+
+    async def load() -> str:
+        # AsyncEnvironment.get_template is the async API.
+        tmpl = await env.get_template("a.html")
+        return await tmpl.render_async()
+
+    assert run_async_fn(load) == "A"
+
+
+def test_async_environment_list_templates_uses_async_loader(run_async_fn):
+    class Loader(loaders.BaseLoader):
+        def list_templates(self):  # pragma: no cover
+            raise AssertionError("sync list_templates should not be called")
+
+        async def list_templates_async(self) -> list[str]:
+            return ["a.html", "b.html"]
+
+        async def get_source_async(self, environment, template):
+            return template, None, lambda: True
+
+    env = AsyncEnvironment(loader=Loader())
+
+    async def load() -> list[str]:
+        return await env.list_templates()
+
+    assert run_async_fn(load) == ["a.html", "b.html"]
+


### PR DESCRIPTION
## Summary
- Adds async template loading APIs to `Environment`:
  - `get_template_async`, `select_template_async`, `get_or_select_template_async`
  - `list_templates_async`, `compile_templates_async`
- Adds async hooks for loaders (`BaseLoader.*_async`) with sync fallbacks by default.
- Adds async hooks for bytecode caches (`BytecodeCache.load_bytecode_async` / `dump_bytecode_async`) and ensures async bucket operations await these hooks.
- Documents the new APIs and provides examples for implementing async loaders and async bytecode caches.

## Motivation
Async apps increasingly store templates and caches behind async I/O. Jinja already supports async template execution, but loading and bytecode caching still require sync I/O. This change enables fully async template loading/caching without forcing thread offloading.

## Design notes
- **Compatibility**: existing sync loaders / bytecode caches continue to work.
- **Fallback behavior**:
  - `BaseLoader.get_source_async` and `list_templates_async` default to calling the sync versions.
  - `BytecodeCache.load_bytecode_async` and `dump_bytecode_async` default to calling the sync versions.
- **Correctness**: `BytecodeCache.get_bucket_async` / `set_bucket_async` await the async hooks, so async-only caches work as expected.

## Tests
Added tests that fail without the change:
- `Environment.get_template_async` works with sync loaders.
- `AsyncEnvironment` calls async loader hooks.
- `compile_templates_async` produces loadable module templates.
- Async-only `BytecodeCache` hooks are awaited (sync hooks must not be called).

## Docs
- Updated `docs/api.rst` to include the new async APIs and examples.

## Changelog
- Added an entry to `CHANGES.rst` describing async loading/caching APIs.

## Links
fixes https://github.com/pallets/jinja/issues/2128

## Reference links
- Pallets contributing guide: https://palletsprojects.com/contributing/pr
- Code of conduct: https://palletsprojects.com/governance/code-of-conduct/
