### PR TITLE
Fix slice filter adding fill_with when items divide evenly

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slices_with_extra != 0 and slice_number >= slices_with_extra:
+        if (
+            fill_with is not None
+            and slices_with_extra != 0
+            and slice_number >= slices_with_extra
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,7 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if fill_with is not None and slices_with_extra != 0 and slice_number >= slices_with_extra:
             tmp.append(fill_with)
 
         yield tmp


### PR DESCRIPTION
## Summary
- Fixes #2118
- When the iterable length is evenly divisible by the slice count, the `slice` filter incorrectly appends `fill_with` to every slice. For example, `[1,2,3,4]|slice(4, 'foo')` produces `[[1, 'foo'], [2, 'foo'], [3, 'foo'], [4, 'foo']]` instead of the expected `[[1], [2], [3], [4]]`.
- The root cause is that `slices_with_extra` (i.e., `length % slices`) is `0` when items divide evenly, making the condition `slice_number >= slices_with_extra` true for all slices. The fix adds a guard `slices_with_extra != 0` so that `fill_with` is only appended when there are actually shorter slices that need filling.

## Test plan
- [x] Verified the fix with the exact example from the issue: `[1,2,3,4]|slice(4, 'foo')` now correctly returns `[[1], [2], [3], [4]]`
- [x] Verified that non-evenly-divisible cases still work: `[1,2,3,4,5]|slice(3, 'foo')` returns `[[1, 2], [3, 4], [5, 'foo']]`
- [x] Verified no-fill_with cases still work: `[1,2,3,4,5]|slice(3)` returns `[[1, 2], [3, 4], [5]]`
- [x] All 181 existing tests in `test_filters.py` and `test_async_filters.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)