### PR TITLE
Add type annotation for FILTERS dictionary

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1,4 +1,4 @@
-"""Built-in template filters used with the ``|`` operator."""
+﻿"""Built-in template filters used with the ``|`` operator."""
 
 import math
 import random
@@ -1808,8 +1808,7 @@ async def async_select_or_reject(
             if func(item):
                 yield item
 
-
-FILTERS = {
+FILTERS: t.Dict[str, t.Callable[..., t.Any]] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1,4 +1,4 @@
-﻿"""Built-in template filters used with the ``|`` operator."""
+"""Built-in template filters used with the ``|`` operator."""
 
 import math
 import random
@@ -1808,7 +1808,8 @@ async def async_select_or_reject(
             if func(item):
                 yield item
 
-FILTERS: t.Dict[str, t.Callable[..., t.Any]] = {
+
+FILTERS: dict[str, t.Callable[..., t.Any]] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,


### PR DESCRIPTION
This PR adds an explicit type annotation t.Dict[str, t.Callable[..., t.Any]] to the FILTERS dictionary to improve type checking and IDE support.

Fixes #2120