### PR TITLE
Fix slice filter appending fill_with when items divide evenly

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,7 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
             tmp.append(fill_with)
 
         yield tmp

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,11 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_evenly_divisible(self, env):
+        tmpl = env.from_string("{{ foo|slice(4, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
## Summary
- When the iterable length is evenly divisible by the slice count, `fill_with` was incorrectly appended to every slice
- Root cause: `slices_with_extra` is `0` when items divide evenly, making `slice_number >= slices_with_extra` always true
- Fix: add `slices_with_extra` truthiness check before appending `fill_with`

Example: `[1,2,3,4]|slice(4, 'foo')` now correctly returns `[[1], [2], [3], [4]]` instead of `[[1, 'foo'], [2, 'foo'], [3, 'foo'], [4, 'foo']]`

Fixes #2118

## Test plan
- [x] Added `test_slice_evenly_divisible` covering the reported case
- [x] All 182 filter tests pass (sync + async)