### PR TITLE
Allow copy and deepcopy on Template objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Allow ``copy`` and ``deepcopy`` on :class:`Template` objects. Since
+    templates are considered immutable, both return the same object.
+    :issue:`758`
 
 
 Version 3.1.6

--- a/src/jinja2/environment.py
+++ b/src/jinja2/environment.py
@@ -1500,6 +1500,13 @@ class Template:
 
         return []
 
+    def __copy__(self) -> "te.Self":
+        return self
+
+    def __deepcopy__(self, memo: dict[int, t.Any]) -> "te.Self":
+        memo[id(self)] = self
+        return self
+
     def __repr__(self) -> str:
         if self.name is None:
             name = f"memory:{id(self):x}"

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,6 +1,43 @@
 import pickle
+from copy import copy
+from copy import deepcopy
+
+from jinja2 import Environment
+from jinja2 import Template
 
 
 def test_environment(env):
     env = pickle.loads(pickle.dumps(env))
     assert env.from_string("x={{ x }}").render(x=42) == "x=42"
+
+
+def test_template_copy():
+    t = Template("{{ foo }}")
+    t_copy = copy(t)
+    assert t_copy is t
+    assert t_copy.render(foo="bar") == "bar"
+
+
+def test_template_deepcopy():
+    t = Template("{{ foo }}")
+    t_copy = deepcopy(t)
+    assert t_copy is t
+    assert t_copy.render(foo="bar") == "bar"
+
+
+def test_template_deepcopy_in_container():
+    """Deepcopy of an object containing a template should not raise."""
+    t = Template("{{ foo }}")
+    container = {"template": t, "data": [1, 2, 3]}
+    container_copy = deepcopy(container)
+    assert container_copy["template"] is t
+    assert container_copy["data"] is not container["data"]
+    assert container_copy["template"].render(foo="bar") == "bar"
+
+
+def test_environment_template_copy():
+    env = Environment()
+    t = env.from_string("{{ x }}")
+    assert copy(t) is t
+    assert deepcopy(t) is t
+    assert t.render(x=42) == "42"


### PR DESCRIPTION
## Summary

Fixes #758.

`copy.copy()` and `copy.deepcopy()` on a `Template` object raised `TypeError` because `Template.__new__()` requires a `source` argument, but the copy machinery calls `__new__` without arguments.

Since `Template` is documented as immutable ("A template object should be considered immutable. Modifications on the object are not supported."), this adds `__copy__` and `__deepcopy__` methods that return the same object, consistent with how other immutable types like `frozenset` behave.

This is the most practical solution because:

- Templates contain compiled render functions (`root_render_func`) whose `__globals__` hold hard-coded references to their environment, making a true independent deep copy infeasible without full recompilation.
- Returning `self` is semantically correct for immutable objects and satisfies the common use case of templates embedded in larger data structures that get deepcopied (as described in the issue).

## Changes

- **`src/jinja2/environment.py`**: Added `__copy__` and `__deepcopy__` methods to `Template` that return `self`.
- **`tests/test_pickle.py`**: Added 4 tests covering `copy()`, `deepcopy()`, deepcopy within a container, and copy of environment-created templates.
- **`CHANGES.rst`**: Added changelog entry under 3.2.0.

## Test plan

- All 915 tests pass (911 existing + 4 new).
- Verified `copy(template)` and `deepcopy(template)` no longer raise.
- Verified templates in containers can be deepcopied without error.
- Verified copied templates still render correctly.

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*