### PR TITLE
fix: add type annotation for FILTERS and TESTS dictionaries

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1809,7 +1809,7 @@ async def async_select_or_reject(
                 yield item
 
 
-FILTERS = {
+FILTERS: dict[str, t.Callable[..., t.Any]] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -213,7 +213,7 @@ def test_in(value: t.Any, seq: t.Container[t.Any]) -> bool:
     return value in seq
 
 
-TESTS = {
+TESTS: dict[str, t.Callable[..., t.Any]] = {
     "odd": test_odd,
     "even": test_even,
     "divisibleby": test_divisibleby,


### PR DESCRIPTION
Closes #2120

## Summary

Add explicit `dict[str, t.Callable[..., t.Any]]` type annotations to the module-level `FILTERS` dict in `filters.py` and `TESTS` dict in `tests.py`.

This allows type checkers (Pylance/Pyright/mypy) to properly infer the type of `Environment.filters` and `Environment.tests`, which are copied from these module-level dicts.

## Changes

- `src/jinja2/filters.py`: Add type annotation to `FILTERS`
- `src/jinja2/tests.py`: Add type annotation to `TESTS`

## Tests

- `mypy`: Success, no issues found
- `ruff`: All checks passed
- `pytest`: 911 passed in 1.32s