### PR TITLE
fix: prevent slice filter from appending fill_with when items divide evenly

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1809,7 +1809,7 @@ async def async_select_or_reject(
                 yield item
 
 
-FILTERS = {
+FILTERS: dict[str, t.Callable[..., t.Any]] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if (
+            fill_with is not None
+            and slices_with_extra
+            and slice_number >= slices_with_extra
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -213,7 +213,7 @@ def test_in(value: t.Any, seq: t.Container[t.Any]) -> bool:
     return value in seq
 
 
-TESTS = {
+TESTS: dict[str, t.Callable[..., t.Any]] = {
     "odd": test_odd,
     "even": test_even,
     "divisibleby": test_divisibleby,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,11 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_evenly_divisible_with_fill(self, env):
+        tmpl = env.from_string("{{ foo|slice(4, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
Closes #2118

## Summary

When the number of items is evenly divisible by the slice count, `slices_with_extra` is 0. This causes the condition `slice_number >= slices_with_extra` to always be `True`, so `fill_with` is incorrectly appended to every slice.

**Before:**
```
>>> env.from_string("{{ [1,2,3,4]|slice(4, 'X')|list }}").render()
"[[1, 'X'], [2, 'X'], [3, 'X'], [4, 'X']]"
```

**After:**
```
>>> env.from_string("{{ [1,2,3,4]|slice(4, 'X')|list }}").render()
"[[1], [2], [3], [4]]"
```

## Changes

- `src/jinja2/filters.py`: Add `slices_with_extra` truthiness check before appending `fill_with`
- `tests/test_filters.py`: Add test for evenly divisible slice with fill_with

## Tests

- `mypy`: Success, no issues found
- `ruff`: All checks passed
- `pytest`: 912 passed