### PR TITLE
Add type annotation for filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: jinja2
 
+Version 3.1.7
+-------------
+
+Unreleased
+
+-   Add type annotation to ``FILTERS`` and ``TESTS``
+    :issue:`2120`, :pr:`2141`
+
+
 Version 3.1.6
 -------------
 

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -35,4 +35,4 @@ from .utils import pass_environment as pass_environment
 from .utils import pass_eval_context as pass_eval_context
 from .utils import select_autoescape as select_autoescape
 
-__version__ = "3.1.6"
+__version__ = "3.1.7"

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -41,7 +41,7 @@ if t.TYPE_CHECKING:
             pass
 
 
-F = t.TypeVar("F", bound=t.Callable[..., t.Any])
+FilterFunction = t.Callable[..., t.Any]
 K = t.TypeVar("K")
 V = t.TypeVar("V")
 
@@ -1815,7 +1815,7 @@ async def async_select_or_reject(
                 yield item
 
 
-FILTERS: t.Dict[str, F] = {
+FILTERS: t.Dict[str, FilterFunction] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1815,7 +1815,7 @@ async def async_select_or_reject(
                 yield item
 
 
-FILTERS = {
+FILTERS: t.Dict[str, F] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -41,7 +41,7 @@ if t.TYPE_CHECKING:
             pass
 
 
-F = t.TypeVar("F", bound=t.Callable[..., t.Any])
+FilterFunction = t.Callable[..., t.Any]
 K = t.TypeVar("K")
 V = t.TypeVar("V")
 
@@ -1815,7 +1815,7 @@ async def async_select_or_reject(
                 yield item
 
 
-FILTERS = {
+FILTERS: t.Dict[str, FilterFunction] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -12,6 +12,9 @@ if t.TYPE_CHECKING:
     from .environment import Environment
 
 
+TestFunction = t.Callable[..., t.Any]
+
+
 def test_odd(value: int) -> bool:
     """Return true if the variable is odd."""
     return value % 2 == 1
@@ -213,7 +216,7 @@ def test_in(value: t.Any, seq: t.Container[t.Any]) -> bool:
     return value in seq
 
 
-TESTS = {
+TESTS: t.Dict[str, TestFunction] = {
     "odd": test_odd,
     "even": test_even,
     "divisibleby": test_divisibleby,


### PR DESCRIPTION
A minimal PR adding a type annotation to `FILTERS` as discussed in #2120

The change was tested in my venv and fixed my project's issues.
You should be aware that it causes the following Pylance warning in the jinja codebase:

> Type variable "F" has no meaning in this context Pylance([reportGeneralTypeIssues](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportGeneralTypeIssues.md))

Looking into this a little more, my understanding is that `TypeVar`s should really only be used for generic `function` and `class` declarations. https://github.com/microsoft/pyright/discussions/9826#discussioncomment-12077223

A type alias may be more appropriate in line 44. https://github.com/pallets/jinja/blob/5ef70112a1ff19c05324ff889dd30405b1002044/src/jinja2/filters.py#L44

```python
FilterFunction = t.Callable[..., t.Any]
```

Additionally, I was unable to find any use of `F` from line 44 and ran `pytest` with the line commented out. I am fairly certain that it was dead code until now.

---

#2135
#2139

The above PRs tried to address #2120 in a different way.

fixes #2120

> Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.

I don't think I can test this without adding a Pylance action, which would fail anyways since jinja is not written with type checkers in mind.

> Add or update relevant docs, in the docs folder and in code.

We could be more explicit about the requirements in [Custom Filters](https://jinja.palletsprojects.com/en/stable/api/#custom-filters) but this doesn't really change anything about them. Python type annotations _usually_ serve as documentation only.

## Other considerations

Aside from annotating `FILTERS`, this same annotation could be applied to https://github.com/pallets/jinja/blob/5ef70112a1ff19c05324ff889dd30405b1002044/src/jinja2/environment.py#L352

During my search for use of line 44, I noticed that the same definition of `F` is declared five times. There may be a semantic difference between the otherwise identical declarations.