### PR TITLE
Fix ZeroDivisionError in slice, batch, and divisibleby with 0 args

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1074,6 +1074,11 @@ def sync_do_slice(
     If you pass it a second argument it's used to fill missing
     values on the last iteration.
     """
+    if slices <= 0:
+        raise FilterArgumentError(
+            f"slice: 'slices' must be greater than 0, got {slices}"
+        )
+
     seq = list(value)
     length = len(seq)
     items_per_slice = length // slices
@@ -1125,6 +1130,11 @@ def do_batch(
         {%- endfor %}
         </table>
     """
+    if linecount <= 0:
+        raise FilterArgumentError(
+            f"batch: 'linecount' must be greater than 0, got {linecount}"
+        )
+
     tmp: list[V] = []
 
     for item in value:

--- a/src/jinja2/tests.py
+++ b/src/jinja2/tests.py
@@ -24,6 +24,8 @@ def test_even(value: int) -> bool:
 
 def test_divisibleby(value: int, num: int) -> bool:
     """Check if a variable is divisible by a number."""
+    if num == 0:
+        return False
     return value % num == 0
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -70,6 +70,13 @@ class TestFilter:
             "[[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 'X', 'X']]"
         )
 
+    def test_batch_zero(self, env):
+        from jinja2.exceptions import FilterArgumentError
+
+        tmpl = env.from_string("{{ foo|batch(0)|list }}")
+        with pytest.raises(FilterArgumentError):
+            tmpl.render(foo=list(range(10)))
+
     def test_slice(self, env):
         tmpl = env.from_string("{{ foo|slice(3)|list }}|{{ foo|slice(3, 'X')|list }}")
         out = tmpl.render(foo=list(range(10)))
@@ -77,6 +84,13 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6], [7, 8, 9]]|"
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
+
+    def test_slice_zero(self, env):
+        from jinja2.exceptions import FilterArgumentError
+
+        tmpl = env.from_string("{{ foo|slice(0)|list }}")
+        with pytest.raises(FilterArgumentError):
+            tmpl.render(foo=list(range(10)))
 
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -27,6 +27,10 @@ class TestTestsCase:
         tmpl = env.from_string("""{{ "foo" is lower }}|{{ "FOO" is lower }}""")
         assert tmpl.render() == "True|False"
 
+    def test_divisibleby_zero(self, env):
+        tmpl = env.from_string("{{ 5 is divisibleby(0) }}")
+        assert tmpl.render() == "False"
+
     # Test type checks
     @pytest.mark.parametrize(
         "op,expect",


### PR DESCRIPTION
This PR adds algebra/bounds-check protections to the [slice](cci:1://file:///c:/Users/lahya/Desktop/pyspectre_release/pysymex_v0.1.0%20alpha/pysymex_release/jinja/src/jinja2/filters.py:1102:0-1108:70) and [batch](cci:1://file:///c:/Users/lahya/Desktop/pyspectre_release/pysymex_v0.1.0%20alpha/pysymex_release/jinja/src/jinja2/filters.py:1111:0-1150:17) filters, as well as the [divisibleby](cci:1://file:///c:/Users/lahya/Desktop/pyspectre_release/pysymex_v0.1.0%20alpha/pysymex_release/jinja/src/jinja2/tests.py:24:0-28:27) test, to prevent them from throwing unhandled native `ZeroDivisionError`s when passed an argument of `0` in a template.

Currently, passing an un-sanitized parameter of `0` to these filters automatically hard-crashes the underlying Python rendering process, bypassing the intended `TemplateRuntimeError` sandbox entirely.

**Changes:**
1. [sync_do_slice](cci:1://file:///c:/Users/lahya/Desktop/pyspectre_release/pysymex_v0.1.0%20alpha/pysymex_release/jinja/src/jinja2/filters.py:1054:0-1099:17): Raises `FilterArgumentError` if `slices <= 0`.
2. [do_batch](cci:1://file:///c:/Users/lahya/Desktop/pyspectre_release/pysymex_v0.1.0%20alpha/pysymex_release/jinja/src/jinja2/filters.py:1111:0-1150:17): Raises `FilterArgumentError` if `linecount <= 0`.
3. [test_divisibleby](cci:1://file:///c:/Users/lahya/Desktop/pyspectre_release/pysymex_v0.1.0%20alpha/pysymex_release/jinja/src/jinja2/tests.py:24:0-28:27): Safely returns `False` if `num == 0`.

