### PR TITLE
Add handling logic for none to jinja-filters.default

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -547,6 +547,7 @@ def do_default(
     value: V,
     default_value: V = "",  # type: ignore
     boolean: bool = False,
+    include_none: bool = False,
 ) -> V:
     """If the value is undefined it will return the passed default value,
     otherwise the value of the variable:
@@ -564,13 +565,24 @@ def do_default(
 
         {{ ''|default('the string was empty', true) }}
 
+    If you also want to consider `None` as a value that should be replaced
+    with the default value, you can set the `include_none` parameter to `true`:
+
+    .. sourcecode:: jinja
+
+        {{ ''|default('the string was empty', include_none=true) }}
+
     .. versionchanged:: 2.11
        It's now possible to configure the :class:`~jinja2.Environment` with
        :class:`~jinja2.ChainableUndefined` to make the `default` filter work
        on nested elements and attributes that may contain undefined values
        in the chain without getting an :exc:`~jinja2.UndefinedError`.
     """
-    if isinstance(value, Undefined) or (boolean and not value):
+    if (
+        isinstance(value, Undefined)
+        or (boolean and not value)
+        or (include_none and value is None)
+    ):
         return default_value
 
     return value

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -44,9 +44,10 @@ class TestFilter:
     def test_default(self, env):
         tmpl = env.from_string(
             "{{ missing|default('no') }}|{{ false|default('no') }}|"
-            "{{ false|default('no', true) }}|{{ given|default('no') }}"
+            "{{ false|default('no', true) }}|{{ given|default('no') }}|"
+            "{{ none|default('no') }}|{{ none|default('no', include_none=true) }}"
         )
-        assert tmpl.render(given="yes") == "no|False|no|yes"
+        assert tmpl.render(given="yes") == "no|False|no|yes|None|no"
 
     @pytest.mark.parametrize(
         "args,expect",


### PR DESCRIPTION
Add handling logic for `None` to `jinja-filters.default`. Add a parameter for the `None` type to control whether this rule applies when the value is `None`.