### PR TITLE
tests: lower test_elif_deep depth from 1000 to 100

### DIFF
--- a/tests/test_core_tags.py
+++ b/tests/test_core_tags.py
@@ -309,11 +309,12 @@ class TestIfCondition:
         assert tmpl.render() == "..."
 
     def test_elif_deep(self, env):
-        elifs = "\n".join(f"{{% elif a == {i} %}}{i}" for i in range(1, 1000))
+        n = 100
+        elifs = "\n".join(f"{{% elif a == {i} %}}{i}" for i in range(1, n))
         tmpl = env.from_string(f"{{% if a == 0 %}}0{elifs}{{% else %}}x{{% endif %}}")
-        for x in (0, 10, 999):
+        for x in (0, 10, n - 1):
             assert tmpl.render(a=x).strip() == str(x)
-        assert tmpl.render(a=1000).strip() == "x"
+        assert tmpl.render(a=n).strip() == "x"
 
     def test_else(self, env):
         tmpl = env.from_string("{% if false %}XXX{% else %}...{% endif %}")


### PR DESCRIPTION
The flat `elif` codegen (#759) is unconditional, so even a handful of branches exercises the codepath. On s390x, CPython sets `Py_C_RECURSION_LIMIT` to just 800 because the z/Architecture ABI requires a 160-byte register save area per call frame, roughly 10x what x86_64 needs, which makes 1000 nested branches overflow `compile()` with a `RecursionError`. Lowering to 100 still thoroughly exercises the flat elif codepath while staying within all platform limits.

- Fixes #2145