### PR TITLE
Speed up template parsing and compilation by ~14%

### DIFF
--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -50,7 +50,7 @@ def optimizeconst(f: F) -> F:
         if self.optimizer is not None and not frame.eval_ctx.volatile:
             new_node = self.optimizer.visit(node, frame.eval_ctx)
 
-            if new_node != node:
+            if new_node is not node and new_node != node:
                 return self.visit(new_node, frame)
 
         return f(self, node, frame, **kwargs)

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -204,6 +204,7 @@ class Node(metaclass=NodeType):
     def __init__(self, *fields: t.Any, **attributes: t.Any) -> None:
         if self.abstract:
             raise TypeError("abstract nodes are not instantiable")
+        d = self.__dict__
         if fields:
             if len(fields) != len(self.fields):
                 if not self.fields:
@@ -213,11 +214,15 @@ class Node(metaclass=NodeType):
                     f" argument{'s' if len(self.fields) != 1 else ''}"
                 )
             for name, arg in zip(self.fields, fields, strict=False):
-                setattr(self, name, arg)
-        for attr in self.attributes:
-            setattr(self, attr, attributes.pop(attr, None))
+                d[name] = arg
         if attributes:
-            raise TypeError(f"unknown attribute {next(iter(attributes))!r}")
+            for attr in self.attributes:
+                d[attr] = attributes.pop(attr, None)
+            if attributes:
+                raise TypeError(f"unknown attribute {next(iter(attributes))!r}")
+        else:
+            for attr in self.attributes:
+                d[attr] = None
 
     def iter_fields(
         self,

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -97,11 +97,7 @@ class NodeType(type):
             if args:
                 origin = t.get_origin(hint)
                 if origin is t.Union or isinstance(hint, _types.UnionType):
-                    return any(
-                        _is_node_type(a)
-                        for a in args
-                        if a is not type(None)
-                    )
+                    return any(_is_node_type(a) for a in args if a is not type(None))
             return False
 
         # Collect annotations from the MRO.

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -335,7 +335,12 @@ class Node(metaclass=NodeType):
         if type(self) is not type(other):
             return NotImplemented
 
-        return tuple(self.iter_fields()) == tuple(other.iter_fields())
+        sd = self.__dict__
+        od = other.__dict__
+        for name in self.fields:
+            if sd.get(name) != od.get(name):
+                return False
+        return True
 
     __hash__ = object.__hash__
 

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -67,6 +67,74 @@ class NodeType(type):
         d.setdefault("abstract", False)
         return type.__new__(mcs, name, bases, d)
 
+    def _classify_fields(cls, ns: dict[str, t.Any]) -> None:
+        """Pre-classify fields into node, node-list, and scalar categories
+        by resolving type annotations.  Called once after all node classes
+        are defined.  Results are stored as ``_node_fields`` and
+        ``_node_list_fields`` tuples on the class.
+        """
+        import types as _types
+
+        def _resolve(tp: t.Any) -> t.Any:
+            """Resolve strings and ForwardRef to actual types."""
+            if isinstance(tp, str):
+                return ns.get(tp, tp)
+            if isinstance(tp, t.ForwardRef):
+                return ns.get(tp.__forward_arg__, tp)
+            return tp
+
+        def _is_node_type(tp: t.Any) -> bool:
+            tp = _resolve(tp)
+            return isinstance(tp, type) and issubclass(tp, Node)
+
+        def _hint_is_node(hint: t.Any) -> bool:
+            """Check if a type hint refers to a Node (possibly optional)."""
+            if _is_node_type(hint):
+                return True
+            # Handle X | Y (types.UnionType) and typing.Optional/Union.
+            args = t.get_args(hint)
+            if args:
+                origin = t.get_origin(hint)
+                if origin is t.Union or isinstance(hint, _types.UnionType):
+                    return any(
+                        _is_node_type(a)
+                        for a in args
+                        if a is not type(None)
+                    )
+            return False
+
+        # Collect annotations from the MRO.
+        annotations: dict[str, t.Any] = {}
+        for klass in reversed(cls.__mro__):
+            annotations.update(getattr(klass, "__annotations__", {}))
+
+        node_fields: list[str] = []
+        node_list_fields: list[str] = []
+
+        for field_name in cls.fields:  # type: ignore[attr-defined]
+            hint = annotations.get(field_name)
+            if hint is None:
+                continue
+
+            # Bare string annotation (e.g. 'Expr').
+            if isinstance(hint, str):
+                resolved = ns.get(hint)
+                if resolved is not None and _is_node_type(resolved):
+                    node_fields.append(field_name)
+                continue
+
+            origin = t.get_origin(hint)
+
+            if origin is list:
+                args = t.get_args(hint)
+                if args and _hint_is_node(args[0]):
+                    node_list_fields.append(field_name)
+            elif _hint_is_node(hint):
+                node_fields.append(field_name)
+
+        cls._node_fields = tuple(node_fields)
+        cls._node_list_fields = tuple(node_list_fields)
+
 
 class EvalContext:
     """Holds evaluation time information.  Custom attributes can be attached
@@ -123,6 +191,10 @@ class Node(metaclass=NodeType):
     attributes: tuple[str, ...] = ("lineno", "environment")
     abstract = True
 
+    #: Pre-classified field tuples, set by _init_field_classifications().
+    _node_fields: t.ClassVar[tuple[str, ...]]
+    _node_list_fields: t.ClassVar[tuple[str, ...]]
+
     lineno: int
     environment: t.Optional["Environment"]
 
@@ -175,13 +247,27 @@ class Node(metaclass=NodeType):
         over all fields and yields the values of they are nodes.  If the value
         of a field is a list all the nodes in that list are returned.
         """
-        for _, item in self.iter_fields(exclude, only):
-            if isinstance(item, list):
-                for n in item:
-                    if isinstance(n, Node):
-                        yield n
-            elif isinstance(item, Node):
+        if exclude is not None or only is not None:
+            for _, item in self.iter_fields(exclude, only):
+                if isinstance(item, list):
+                    for n in item:
+                        if isinstance(n, Node):
+                            yield n
+                elif isinstance(item, Node):
+                    yield item
+            return
+
+        # Fast path: use pre-classified field lists to avoid
+        # isinstance checks and iter_fields overhead.
+        d = self.__dict__
+        for name in type(self)._node_fields:
+            item = d.get(name)
+            if item is not None:
                 yield item
+        for name in type(self)._node_list_fields:
+            item = d.get(name)
+            if item:
+                yield from item
 
     def find(self, node_type: type[_NodeBound]) -> _NodeBound | None:
         """Find the first node of a given type.  If no such node exists the
@@ -209,32 +295,32 @@ class Node(metaclass=NodeType):
         most common one.  This method is used in the parser to set assignment
         targets and other nodes to a store context.
         """
-        todo = deque([self])
-        while todo:
-            node = todo.popleft()
+        stack = [self]
+        while stack:
+            node = stack.pop()
             if "ctx" in node.fields:
                 node.ctx = ctx  # type: ignore
-            todo.extend(node.iter_child_nodes())
+            _collect_children(node, stack)
         return self
 
     def set_lineno(self, lineno: int, override: bool = False) -> "Node":
         """Set the line numbers of the node and children."""
-        todo = deque([self])
-        while todo:
-            node = todo.popleft()
+        stack = [self]
+        while stack:
+            node = stack.pop()
             if "lineno" in node.attributes:
                 if node.lineno is None or override:
                     node.lineno = lineno
-            todo.extend(node.iter_child_nodes())
+            _collect_children(node, stack)
         return self
 
     def set_environment(self, environment: "Environment") -> "Node":
         """Set the environment for all nodes."""
-        todo = deque([self])
-        while todo:
-            node = todo.popleft()
-            node.environment = environment
-            todo.extend(node.iter_child_nodes())
+        stack = [self]
+        while stack:
+            node = stack.pop()
+            node.__dict__["environment"] = environment
+            _collect_children(node, stack)
         return self
 
     def __eq__(self, other: t.Any) -> bool:
@@ -1189,6 +1275,36 @@ class ScopedEvalContextModifier(EvalContextModifier):
 
     fields = ("body",)
     body: list[Node]
+
+
+def _collect_children(node: Node, out: list[Node] | deque[Node]) -> None:
+    """Collect all direct child nodes of *node* into *out* (appended)."""
+    d = node.__dict__
+    node_type = type(node)
+    for name in node_type._node_fields:
+        child = d.get(name)
+        if child is not None:
+            out.append(child)
+    for name in node_type._node_list_fields:
+        children = d.get(name)
+        if children:
+            out.extend(children)
+
+
+# Pre-classify fields on all node classes for fast iter_child_nodes.
+def _init_field_classifications() -> None:
+    import sys
+
+    ns = vars(sys.modules[__name__])
+    todo = [Node]
+    while todo:
+        cls = todo.pop()
+        cls._classify_fields(ns)
+        todo.extend(cls.__subclasses__())
+
+
+_init_field_classifications()
+del _init_field_classifications
 
 
 # make sure nobody creates custom nodes

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -65,6 +65,7 @@ class NodeType(type):
             assert len(storage) == len(set(storage)), "layout conflict"
             d[attr] = tuple(storage)
         d.setdefault("abstract", False)
+        d["_visit_name"] = f"visit_{name}"
         return type.__new__(mcs, name, bases, d)
 
     def _classify_fields(cls, ns: dict[str, t.Any]) -> None:
@@ -191,7 +192,9 @@ class Node(metaclass=NodeType):
     attributes: tuple[str, ...] = ("lineno", "environment")
     abstract = True
 
-    #: Pre-classified field tuples, set by _init_field_classifications().
+    #: Pre-computed visitor method name and field tuples, set at class
+    #: definition time by the metaclass and _init_field_classifications().
+    _visit_name: t.ClassVar[str]
     _node_fields: t.ClassVar[tuple[str, ...]]
     _node_list_fields: t.ClassVar[tuple[str, ...]]
 

--- a/src/jinja2/nodes.py
+++ b/src/jinja2/nodes.py
@@ -284,10 +284,15 @@ class Node(metaclass=NodeType):
         """Find all the nodes of a given type.  If the type is a tuple,
         the check is performed for any of the tuple items.
         """
-        for child in self.iter_child_nodes():
-            if isinstance(child, node_type):
-                yield child  # type: ignore
-            yield from child.find_all(node_type)
+        # Iterative BFS avoids the overhead of recursive generators
+        # (yield from) on large ASTs.
+        todo: deque[Node] = deque()
+        _collect_children(self, todo)
+        while todo:
+            node = todo.popleft()
+            if isinstance(node, node_type):
+                yield node  # type: ignore
+            _collect_children(node, todo)
 
     def set_ctx(self, ctx: str) -> "Node":
         """Reset the context of a node and all child nodes.  Per default the

--- a/src/jinja2/visitor.py
+++ b/src/jinja2/visitor.py
@@ -43,8 +43,18 @@ class NodeVisitor:
 
     def generic_visit(self, node: Node, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Called if no explicit visitor function exists for a node."""
-        for child_node in node.iter_child_nodes():
-            self.visit(child_node, *args, **kwargs)
+        d = node.__dict__
+        node_type = type(node)
+        visit = self.visit
+        for name in node_type._node_fields:
+            child = d.get(name)
+            if child is not None:
+                visit(child, *args, **kwargs)
+        for name in node_type._node_list_fields:
+            children = d.get(name)
+            if children:
+                for child in children:
+                    visit(child, *args, **kwargs)
 
 
 class NodeTransformer(NodeVisitor):
@@ -59,25 +69,36 @@ class NodeTransformer(NodeVisitor):
     """
 
     def generic_visit(self, node: Node, *args: t.Any, **kwargs: t.Any) -> Node:
-        for field, old_value in node.iter_fields():
-            if isinstance(old_value, list):
-                new_values = []
-                for value in old_value:
-                    if isinstance(value, Node):
-                        value = self.visit(value, *args, **kwargs)
-                        if value is None:
-                            continue
-                        elif not isinstance(value, Node):
-                            new_values.extend(value)
-                            continue
-                    new_values.append(value)
-                old_value[:] = new_values
-            elif isinstance(old_value, Node):
-                new_node = self.visit(old_value, *args, **kwargs)
-                if new_node is None:
-                    delattr(node, field)
-                else:
-                    setattr(node, field, new_node)
+        d = node.__dict__
+        node_type = type(node)
+        visit = self.visit
+
+        for field in node_type._node_fields:
+            old_value = d.get(field)
+            if old_value is None:
+                continue
+            new_node = visit(old_value, *args, **kwargs)
+            if new_node is None:
+                d.pop(field, None)
+            elif new_node is not old_value:
+                d[field] = new_node
+
+        for field in node_type._node_list_fields:
+            old_value = d.get(field)
+            if not old_value:
+                continue
+            new_values: list[t.Any] = []
+            for value in old_value:
+                if isinstance(value, Node):
+                    value = visit(value, *args, **kwargs)
+                    if value is None:
+                        continue
+                    elif not isinstance(value, Node):
+                        new_values.extend(value)
+                        continue
+                new_values.append(value)
+            old_value[:] = new_values
+
         return node
 
     def visit_list(self, node: Node, *args: t.Any, **kwargs: t.Any) -> list[Node]:

--- a/src/jinja2/visitor.py
+++ b/src/jinja2/visitor.py
@@ -30,7 +30,7 @@ class NodeVisitor:
         exists for this node.  In that case the generic visit function is
         used instead.
         """
-        return getattr(self, f"visit_{type(node).__name__}", None)
+        return getattr(self, type(node)._visit_name, None)
 
     def visit(self, node: Node, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Visit a node."""


### PR DESCRIPTION
## Summary

Optimize the AST node infrastructure and visitor dispatch to reduce
template parse+compile time by ~14% on a large benchmark template
(894KB, 200 macros, 1000 SQL blocks).

## Benchmark results

Measured with [`bench_jinja_compile.py`](https://gist.github.com/tobymao/70fcf637f407acaec3d1b3834d965029)
(894KB template, `env.from_string()`, best of 5 runs). Each optimization
was benchmarked in isolation against its required baseline — not
cumulatively — to show its individual contribution.

| # | Optimization | Baseline | Result | Change |
|---|---|---|---|---|
| 1 | Pre-classify node fields for fast child iteration | 4102 ms | 3832 ms | **-6.6%** |
| 2 | Iterative `find_all` (vs recursive generators) | 3817 ms¹ | 3807 ms¹ | -0.3% |
| 3 | Use pre-classified fields in `generic_visit` | 3925 ms¹ | 3785 ms¹ | **-3.6%** |
| 4 | Pre-compute `_visit_name` on node classes | 4102 ms | 3970 ms | **-3.2%** |
| 5 | Identity check in `optimizeconst` + fast `__eq__` | 4102 ms | 4032 ms | **-1.7%** |
| 6 | Use `__dict__` in `Node.__init__` | 4102 ms | 4150 ms | ~0% |
| | **All combined** | **4102 ms** | **3519 ms** | **-14.2%** |

¹ Measured on top of commit 1 (required dependency).

## What changed

- **nodes.py**: At class definition time, type annotations are inspected
  to pre-classify each field as a node field, node-list field, or scalar.
  `iter_child_nodes`, `set_ctx`, `set_lineno`, `set_environment`,
  `find_all`, `__eq__`, and `__init__` all use these classifications to
  skip isinstance checks and avoid generator/iter_fields overhead.

- **visitor.py**: `NodeVisitor.generic_visit` and
  `NodeTransformer.generic_visit` iterate pre-classified fields directly.
  `get_visitor` uses a pre-computed `_visit_name` attribute instead of
  formatting an f-string on each of ~500K dispatch calls.

- **compiler.py**: `optimizeconst` uses `is not` before `!=` to
  short-circuit the expensive `__eq__` when the optimizer returns the
  same node object (the common case).

## Test plan

- [x] All 911 existing tests pass
- [x] Each commit independently passes the full test suite