### PR TITLE
Add type annotation for FILTERS dict

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1809,7 +1809,7 @@ async def async_select_or_reject(
                 yield item
 
 
-FILTERS = {
+FILTERS: dict[str, F] = {
     "abs": abs,
     "attr": do_attr,
     "batch": do_batch,


### PR DESCRIPTION
Fixes #2120

## Problem
The `FILTERS` dict in `src/jinja2/filters.py` was missing a type annotation, causing Pylance to report partially unknown types for `Environment.filters`.

## Solution
Added the type annotation `dict[str, F]` using the existing `F` TypeVar defined at line 44 of the same file.

## Change
```diff
-FILTERS = {
+FILTERS: dict[str, F] = {
```