### PR TITLE
Fix slice filter appending fill_with when items divide evenly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Fix ``slice`` filter incorrectly appending ``fill_with`` value when the
+    iterable length is evenly divisible by the slice count. :issue:`2118`
 
 
 Version 3.1.6

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,7 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
             tmp.append(fill_with)
 
         yield tmp

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
+        if (
+            fill_with is not None
+            and slices_with_extra
+            and slice_number >= slices_with_extra
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,16 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_evenly_divisible(self, env):
+        """fill_with should not be appended when items divide evenly."""
+        tmpl = env.from_string("{{ foo|slice(4, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
+        tmpl = env.from_string("{{ foo|slice(2, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4, 5, 6])
+        assert out == "[[1, 2, 3], [4, 5, 6]]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
## Summary
- Fixes the `slice` filter incorrectly appending `fill_with` to every slice when the iterable length is evenly divisible by the slice count.
- **Root cause:** When `length % slices == 0`, `slices_with_extra` is `0`, making the condition `slice_number >= slices_with_extra` always `True`. This causes `fill_with` to be appended to every slice even though no padding is needed.
- **Fix:** Add a truthiness check for `slices_with_extra` before the comparison, so `fill_with` is only appended when there are actually shorter slices that need padding.

**Before (broken):**
```
>>> [1,2,3,4]|slice(4, 'foo')|list
[[1, 'foo'], [2, 'foo'], [3, 'foo'], [4, 'foo']]
```

**After (fixed):**
```
>>> [1,2,3,4]|slice(4, 'foo')|list
[[1], [2], [3], [4]]
```

Fixes #2118

## Test plan
- Added `test_slice_evenly_divisible` covering evenly divisible cases (4 items / 4 slices, 6 items / 2 slices)
- Verified existing `test_slice` still passes (non-evenly-divisible case with fill_with works correctly)
- All 133 sync filter tests and 2 async slice tests pass