### PR TITLE
Fix #2118: Slice filter no longer adds extra fill_with items

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,7 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if fill_with is not None and slice_number >= slices_with_extra and slices_with_extra != 0:
             tmp.append(fill_with)
 
         yield tmp

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra and slices_with_extra != 0:
+        if (
+            fill_with is not None
+            and slice_number >= slices_with_extra
+            and slices_with_extra != 0
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,28 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_even_division_with_fill(self, env):
+        """Regression test for #2118: fill_with should not add items when
+        the slice count evenly divides the iterable length."""
+        tmpl = env.from_string("{{ foo|slice(4, 'foo')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
+    def test_slice_even_division_no_fill(self, env):
+        tmpl = env.from_string("{{ foo|slice(2)|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1, 2], [3, 4]]"
+
+    def test_slice_uneven_with_fill(self, env):
+        tmpl = env.from_string("{{ foo|slice(2, 'x')|list }}")
+        out = tmpl.render(foo=[1, 2, 3])
+        assert out == "[[1, 2], [3, 'x']]"
+
+    def test_slice_uneven_five_items(self, env):
+        tmpl = env.from_string("{{ foo|slice(3, 'x')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4, 5])
+        assert out == "[[1, 2], [3, 4], [5, 'x']]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
## Summary

Fixes #2118 — The `slice` filter added `fill_with` items even when the slice count evenly divided the iterable length, producing incorrect results.

E.g., `[1,2,3,4]|slice(4, 'foo')` returned `[[1,'foo'],[2,'foo'],[3,'foo'],[4,'foo']]` instead of `[[1],[2],[3],[4]]`.

## Changes

One-line fix in `src/jinja2/filters.py:1092`:
- Added `and slices_with_extra != 0` to the fill condition so `fill_with` is only appended when there are shorter slices that need padding.

## Tests

Added 4 test cases in `tests/test_filters.py`:
- Even division with fill_with (no fill should happen)
- Even division without fill_with
- Uneven division with fill
- 5 items / 3 slices

All existing tests pass.

## Context

This issue has been open for 6 months. Off-by-one bug. Resolved with assistance from [OwlMind](https://owlmind.dev) — an autonomous AI coding agent.