### PR TITLE
Fix slice fill behavior when iterable divides evenly

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if (
+            fill_with is not None
+            and slices_with_extra > 0
+            and slice_number >= slices_with_extra
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/tests/test_async_filters.py
+++ b/tests/test_async_filters.py
@@ -266,6 +266,12 @@ def test_slice(env_async, items):
     )
 
 
+@mark_dualiter("items", lambda: [1, 2, 3, 4])
+def test_slice_fill_with_even_division(env_async, items):
+    tmpl = env_async.from_string("{{ items()|slice(4, 'X')|list }}")
+    assert tmpl.render(items=items) == "[[1], [2], [3], [4]]"
+
+
 def test_unique_with_async_gen(env_async):
     items = ["a", "b", "c", "c", "a", "d", "z"]
     tmpl = env_async.from_string("{{ items|reject('==', 'z')|unique|list }}")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,11 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_fill_with_even_division(self, env):
+        tmpl = env.from_string("{{ foo|slice(4, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
## Summary
- avoid appending `fill_with` when the iterable length divides evenly by the requested slice count
- add sync and async regression tests for the even-division case

## Testing
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/test_filters.py -k 'slice'`\n- `PYTHONPATH=src ./.venv/bin/pytest -q tests/test_async_filters.py -k 'slice'`\n- `./.venv/bin/uv run --group tests pytest -q tests/test_filters.py -k 'slice'`\n- `./.venv/bin/uv run --group tests pytest -q tests/test_async_filters.py -k 'slice'`