### PR TITLE
Fix include without context in macros

### DIFF
--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1085,7 +1085,7 @@ class CodeGenerator(NodeVisitor):
             self.writeline(
                 f"finally: {self.choose_async('await gen.aclose()', 'gen.close()')}"
             )
-            elif self.environment.is_async:
+        elif self.environment.is_async:
             self.writeline(
                 "for event in (await template._get_default_module_async())"
                 "._body_stream:"
@@ -1093,7 +1093,7 @@ class CodeGenerator(NodeVisitor):
             loop_body()
         else:
             if frame.buffer is None:
-                self.writeline("yield from template._get_default_module()._body_stream")
+                self.writeline("yeld from template._get_default_module()._body_stream")
             else:
                 self.writeline("for event in template._get_default_module()._body_stream:")
                 loop_body()

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1085,16 +1085,16 @@ class CodeGenerator(NodeVisitor):
             self.writeline(
                 f"finally: {self.choose_async('await gen.aclose()', 'gen.close()')}"
             )
-        elif self.environment.is_async:
+            elif self.environment.is_async:
             self.writeline(
                 "for event in (await template._get_default_module_async())"
                 "._body_stream:"
             )
             loop_body()
         else:
-        if frame.buffer is None:
+            if frame.buffer is None:
                 self.writeline("yield from template._get_default_module()._body_stream")
-        else:
+            else:
                 self.writeline("for event in template._get_default_module()._body_stream:")
                 loop_body()
 

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1092,7 +1092,11 @@ class CodeGenerator(NodeVisitor):
             )
             loop_body()
         else:
-            self.writeline("yield from template._get_default_module()._body_stream")
+        if frame.buffer is None:
+                self.writeline("yield from template._get_default_module()._body_stream")
+        else:
+                self.writeline("for event in template._get_default_module()._body_stream:")
+                loop_body()
 
         if node.ignore_missing:
             self.outdent()

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1095,7 +1095,7 @@ class CodeGenerator(NodeVisitor):
             if frame.buffer is None:
                 self.writeline("yield from template._get_default_module()._body_stream")
             else:
-                self.writeline("for event in template._get_default_module()._body_stream:")
+                self.writeline ("for event in template._get_default_module()._body_stream:")
                 loop_body()
 
         if node.ignore_missing:

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1095,7 +1095,7 @@ class CodeGenerator(NodeVisitor):
             if frame.buffer is None:
                 self.writeline("yield from template._get_default_module()._body_stream")
             else:
-                self.writeline ("for event in template._get_default_module()._body_stream:")
+                self.writeline("for event in template._get_default_module()._body_stream:")
                 loop_body()
 
         if node.ignore_missing:

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1093,7 +1093,7 @@ class CodeGenerator(NodeVisitor):
             loop_body()
         else:
             if frame.buffer is None:
-                self.writeline("yeld from template._get_default_module()._body_stream")
+                self.writeline("yield from template._get_default_module()._body_stream")
             else:
                 self.writeline("for event in template._get_default_module()._body_stream:")
                 loop_body()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -195,6 +195,18 @@ class TestIncludes:
         )
         assert t.render().strip() == "(FOO)"
 
+    def test_include_without_context_inside_macro(self, test_env):
+        test_env.loader.mapping["included"] = "foo"
+        t = test_env.from_string(
+            """
+            {%- macro foo() %}
+                {%- include "included" without context %}
+            {%- endmacro %}
+            {{- foo() -}}
+            """
+        )
+        assert t.render() == "foo"
+    
     def test_import_from_with_context(self):
         env = Environment(
             loader=DictLoader({"a": "{% macro x() %}{{ foobar }}{% endmacro %}"})


### PR DESCRIPTION
Fixes #2108

`visit_Include` currently uses `yield from template._get_default_module()._body_stream`
in the sync `without context` branch unconditionally.

That is fine for unbuffered output, but inside buffered frames such as macros it turns
the generated macro into a generator function, so rendering returns the generator repr
instead of the included template output.

This keeps the existing `yield from` path for unbuffered frames and switches buffered
frames to explicit iteration so included output is appended to the frame buffer instead.

Adds a regression test for `{% include "included" without context %}` inside a macro.