### PR TITLE
Fix slice filter appending fill_with when items divide evenly

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,7 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
             tmp.append(fill_with)
 
         yield tmp

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
+        if (
+            fill_with is not None
+            and slices_with_extra
+            and slice_number >= slices_with_extra
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,12 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_fill_with_even_divisible(self, env):
+        """fill_with should not be appended when items divide evenly."""
+        tmpl = env.from_string("{{ foo|slice(4, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
Fixes #2118.

When `len(seq) % slices == 0`, `slices_with_extra` is 0, so the guard
`slice_number >= slices_with_extra` is always true. Every slice gets a
spurious `fill_with` value appended even though no padding is needed.

Fix: add a truthiness check — `slices_with_extra and slice_number >= slices_with_extra`.