### PR TITLE
Fix indent filter ignoring blank=False for empty first line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`1793`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Fix ``indent`` filter not respecting ``blank=False`` for the first line
+    when ``first=True`` is set. :issue:`2176`
 
 
 Version 3.1.6

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -860,7 +860,7 @@ def do_indent(
                 indention + line if line else line for line in lines
             )
 
-    if first:
+    if first and (blank or rv.split("\n", 1)[0]):
         rv = indention + rv
 
     return rv

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -189,7 +189,9 @@ class TestFilter:
         t = env.from_string('{{ "\nhello"|indent(4, first=true) }}')
         assert t.render() == "\n    hello"
         # blank=True still indents the first line even when it is empty.
-        t = env.from_string("{% filter indent(4, first=true, blank=true) %}{% endfilter %}")
+        t = env.from_string(
+            "{% filter indent(4, first=true, blank=true) %}{% endfilter %}"
+        )
         assert t.render() == "    "
 
     def test_indent_markup_input(self, env):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -166,7 +166,7 @@ class TestFilter:
         t = env.from_string("{{ foo|indent(2, false, true) }}")
         assert t.render(foo=text) == '\n  foo bar\n  "baz"\n  '
         t = env.from_string("{{ foo|indent(2, true, false) }}")
-        assert t.render(foo=text) == '  \n  foo bar\n  "baz"\n'
+        assert t.render(foo=text) == '\n  foo bar\n  "baz"\n'
         t = env.from_string("{{ foo|indent(2, true, true) }}")
         assert t.render(foo=text) == '  \n  foo bar\n  "baz"\n  '
 
@@ -178,6 +178,19 @@ class TestFilter:
         assert t.render() == "    jinja"
         t = env.from_string('{{ "jinja"|indent(blank=true) }}')
         assert t.render() == "jinja"
+
+    def test_indent_first_blank(self, env):
+        # ``blank=False`` (the default) must suppress indentation of the first
+        # line when it is empty, even when ``first=True``.  Regression for
+        # https://github.com/pallets/jinja/issues/2176
+        t = env.from_string("{% filter indent(4, first=true) %}{% endfilter %}")
+        assert t.render() == ""
+        # A leading blank line is not indented when blank=False.
+        t = env.from_string('{{ "\nhello"|indent(4, first=true) }}')
+        assert t.render() == "\n    hello"
+        # blank=True still indents the first line even when it is empty.
+        t = env.from_string("{% filter indent(4, first=true, blank=true) %}{% endfilter %}")
+        assert t.render() == "    "
 
     def test_indent_markup_input(self, env):
         """


### PR DESCRIPTION
Fixes #2176.

When `first=True` is passed to the `indent` filter, the code was
unconditionally prepending the indentation string to the output, without
checking whether `blank=False` should suppress it when the first line is
empty.

**Before:**

```python
>>> env.from_string('{% filter indent(4, first=true) %}{% endfilter %}').render()
'    '  # four spaces added to an empty string
```

**After:**

```python
>>> env.from_string('{% filter indent(4, first=true) %}{% endfilter %}').render()
''  # blank=False (default) suppresses indentation of the empty first line
```

The fix is a one-liner in `do_indent`: instead of `if first:`, check
`if first and (blank or rv.split("\n", 1)[0]):` so that an empty first
line is only indented when `blank=True` is explicitly requested.

A new test (`test_indent_first_blank`) covers the three cases:
1. Empty string with `first=True` → no indentation
2. Leading blank line with `first=True` → blank line left alone, rest indented
3. Empty string with `first=True, blank=True` → indentation applied