### PR TITLE
AI spam

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,7 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slice_number >= slices_with_extra:
+        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
             tmp.append(fill_with)
 
         yield tmp

--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -1089,7 +1089,11 @@ def sync_do_slice(
         end = offset + (slice_number + 1) * items_per_slice
         tmp = seq[start:end]
 
-        if fill_with is not None and slices_with_extra and slice_number >= slices_with_extra:
+        if (
+            fill_with is not None
+            and slices_with_extra
+            and slice_number >= slices_with_extra
+        ):
             tmp.append(fill_with)
 
         yield tmp

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -78,6 +78,11 @@ class TestFilter:
             "[[0, 1, 2, 3], [4, 5, 6, 'X'], [7, 8, 9, 'X']]"
         )
 
+    def test_slice_even_division_does_not_pad(self, env):
+        tmpl = env.from_string("{{ foo|slice(4, 'X')|list }}")
+        out = tmpl.render(foo=[1, 2, 3, 4])
+        assert out == "[[1], [2], [3], [4]]"
+
     def test_escape(self, env):
         tmpl = env.from_string("""{{ '<">&'|escape }}""")
         out = tmpl.render()


### PR DESCRIPTION
## Summary

Fixes #2118

When the iterable length is evenly divisible by the slice count, the `slice` filter incorrectly appended `fill_with` to every slice. Padding should only happen for the trailing partial slice when length does not divide evenly.

## Test plan

- Added `test_slice_even_division_does_not_pad` covering `[1,2,3,4]|slice(4,'X')`
- Existing `test_slice` still passes