### PR TITLE
fix: prevent code injection via unsafe __repr__ in Const and TemplateData nodes

### DIFF
--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1444,7 +1444,7 @@ class CodeGenerator(NodeVisitor):
         child nodes, produce a string to write to the template module
         source.
         """
-        return repr(concat(group))
+        return self.safe_repr(concat(group))
 
     def _output_child_to_const(
         self, node: nodes.Expr, frame: Frame, finalize: _FinalizeInfo

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1666,11 +1666,27 @@ class CodeGenerator(NodeVisitor):
         if isinstance(val, float):
             self.write(str(val))
         else:
-            self.write(repr(val))
+            self.write(self.safe_repr(val))
+
+    def safe_repr(self, val) -> str:
+        """repr() that sanitizes output to prevent code injection in generated code.
+
+        Uses repr() for most types, but for objects with custom __repr__ that
+        could return unsafe Python code, falls back to a safe representation.
+        """
+        try:
+            r = repr(val)
+            # Validate repr output is a valid Python literal
+            import ast
+            ast.literal_eval(r)
+            return r
+        except (ValueError, SyntaxError):
+            # If repr() isn't a valid literal, use type name + hex id
+            return f"<{type(val).__name__} object at {hex(id(val))}>"
 
     def visit_TemplateData(self, node: nodes.TemplateData, frame: Frame) -> None:
         try:
-            self.write(repr(node.as_const(frame.eval_ctx)))
+            self.write(self.safe_repr(node.as_const(frame.eval_ctx)))
         except nodes.Impossible:
             self.write(
                 f"(Markup if context.eval_ctx.autoescape else identity)({node.data!r})"

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1699,9 +1699,9 @@ class CodeGenerator(NodeVisitor):
                 f"{self.safe_repr(k)}: {self.safe_repr(v)}" for k, v in val.items()
             ]
             return "{" + ", ".join(items) + "}"
-        # For arbitrary objects: emit a safe placeholder
-        # In production, this value would already be validated upstream
-        return repr(val)
+        # For arbitrary objects: emit a safe placeholder instead of
+        # trusting their __repr__, which could inject arbitrary code
+        return f"<{type(val).__name__} object>"
 
     def visit_TemplateData(self, node: nodes.TemplateData, frame: Frame) -> None:
         try:

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1678,6 +1678,7 @@ class CodeGenerator(NodeVisitor):
             r = repr(val)
             # Validate repr output is a valid Python literal
             import ast
+
             ast.literal_eval(r)
             return r
         except (ValueError, SyntaxError):

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1669,21 +1669,37 @@ class CodeGenerator(NodeVisitor):
             self.write(self.safe_repr(val))
 
     def safe_repr(self, val) -> str:
-        """repr() that sanitizes output to prevent code injection in generated code.
+        """repr() that prevents code injection via malicious __repr__.
 
-        Uses repr() for most types, but for objects with custom __repr__ that
-        could return unsafe Python code, falls back to a safe representation.
+        Only emits repr() for basic Python literal types whose repr output
+        is guaranteed to produce a valid Python literal. For arbitrary objects
+        with custom __repr__, emits a safe placeholder instead of trusting
+        their repr output, which could inject arbitrary code into generated
+        source.
         """
-        try:
-            r = repr(val)
-            # Validate repr output is a valid Python literal
-            import ast
-
-            ast.literal_eval(r)
-            return r
-        except (ValueError, SyntaxError):
-            # If repr() isn't a valid literal, use type name + hex id
-            return f"<{type(val).__name__} object at {hex(id(val))}>"
+        # Only use repr() for types where repr() is guaranteed safe
+        # (produces a valid Python literal that can't escape the expression)
+        if isinstance(val, (str, int, float, bool, type(None))):
+            return repr(val)
+        if isinstance(val, (tuple, list, set)):
+            # Recurse to validate elements
+            items = [self.safe_repr(item) for item in val]
+            if isinstance(val, set):
+                return "{" + ", ".join(items) + "}"
+            elif isinstance(val, tuple):
+                if len(items) == 0:
+                    return "()"
+                if len(items) == 1:
+                    return "(" + items[0] + ",)"
+                return "(" + ", ".join(items) + ")"
+            else:
+                return "[" + ", ".join(items) + "]"
+        if isinstance(val, dict):
+            items = [f"{self.safe_repr(k)}: {self.safe_repr(v)}" for k, v in val.items()]
+            return "{" + ", ".join(items) + "}"
+        # For arbitrary objects: emit a safe placeholder
+        # In production, this value would already be validated upstream
+        return repr(val)
 
     def visit_TemplateData(self, node: nodes.TemplateData, frame: Frame) -> None:
         try:

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1668,7 +1668,7 @@ class CodeGenerator(NodeVisitor):
         else:
             self.write(self.safe_repr(val))
 
-    def safe_repr(self, val) -> str:
+    def safe_repr(self, val: t.Any) -> str:
         """repr() that prevents code injection via malicious __repr__.
 
         Only emits repr() for basic Python literal types whose repr output

--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -1695,7 +1695,9 @@ class CodeGenerator(NodeVisitor):
             else:
                 return "[" + ", ".join(items) + "]"
         if isinstance(val, dict):
-            items = [f"{self.safe_repr(k)}: {self.safe_repr(v)}" for k, v in val.items()]
+            items = [
+                f"{self.safe_repr(k)}: {self.safe_repr(v)}" for k, v in val.items()
+            ]
             return "{" + ", ".join(items) + "}"
         # For arbitrary objects: emit a safe placeholder
         # In production, this value would already be validated upstream


### PR DESCRIPTION
Fix code injection vulnerability in compiler.py where unsafe repr() output was injected into generated Python code without validation.