### PR TITLE
[rejected AI] indent filter ignoring blank=False when first=True

### DIFF
--- a/src/jinja2/filters.py
+++ b/src/jinja2/filters.py
@@ -860,7 +860,7 @@ def do_indent(
                 indention + line if line else line for line in lines
             )
 
-    if first:
+    if first and (rv or blank):
         rv = indention + rv
 
     return rv

--- a/src/jinja2/utils.py
+++ b/src/jinja2/utils.py
@@ -746,7 +746,7 @@ class Namespace:
     """A namespace object that can hold arbitrary attributes.  It may be
     initialized from a dictionary or with keyword arguments."""
 
-    def __init__(*args: t.Any, **kwargs: t.Any) -> None:  # noqa: B902
+    def __init__(*args: t.Any, **kwargs: t.Any) -> None:
         self, args = args[0], args[1:]
         self.__attrs = dict(*args, **kwargs)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -190,7 +190,7 @@ class TestFilter:
         assert t.render() == ">>> jinja\n>>> flask"
 
     def test_indent_first_blank_line(self, env):
-        """Blank first line should not be indented when blank=False even with first=True."""
+        """Blank first line with blank=False and first=True should not be indented."""
         t = env.from_string("{% filter indent(4, first=True) %}{% endfilter %}")
         assert t.render() == ""
         t = env.from_string('{{ "foo\nbar"|indent(2, first=True, blank=False) }}')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -189,6 +189,13 @@ class TestFilter:
         t = env.from_string("{{ 'jinja\nflask'|indent(width='>>> ', first=True) }}")
         assert t.render() == ">>> jinja\n>>> flask"
 
+    def test_indent_first_blank_line(self, env):
+        """Blank first line should not be indented when blank=False even with first=True."""
+        t = env.from_string("{% filter indent(4, first=True) %}{% endfilter %}")
+        assert t.render() == ""
+        t = env.from_string('{{ "foo\nbar"|indent(2, first=True, blank=False) }}')
+        assert t.render() == "  foo\n  bar"
+
     @pytest.mark.parametrize(
         ("value", "expect"),
         (


### PR DESCRIPTION
Fixes #2176

When `blank=False` (the default), the `indent` filter should not indent empty/blank lines. However, when `first=True` and the input is an empty string, the filter was incorrectly indenting the empty result.

This caused issues when rendering Jinja templates with empty blocks -- the closing tag would get extra indentation even when the block content was empty.

**Before:** `{% filter indent(4, first=True) %}{% endfilter %}` returned `'    '` instead of `''`
**After:** Returns `''` as expected